### PR TITLE
Fixup - Remove Console Logs From Tests + Mounts Config From Deployment Setup

### DIFF
--- a/deployment/cfn/worker.py
+++ b/deployment/cfn/worker.py
@@ -341,9 +341,6 @@ class Worker(StackNode):
     def get_cloud_config(self):
         return ['#cloud-config\n',
                 '\n',
-                'mounts:\n',
-                '  - [xvdf, ext4, "defaults,nofail,discard", 0, 2]\n'  # NOQA
-                '\n',
                 'write_files:\n',
                 '  - path: /etc/mmw.d/env/MMW_STACK_COLOR\n',
                 '    permissions: 0750\n',

--- a/src/mmw/js/src/analyze/tests.js
+++ b/src/mmw/js/src/analyze/tests.js
@@ -65,11 +65,7 @@ function testAnalysisType(type) {
                 actualTableRows = $('table tbody td').map(function() {
                     return $(this).text().trim();
                 }).toArray();
-            console.log("expected rows => " + expectedTableRows);
-            console.log("actual rows => " + actualTableRows);
-
-            console.log("expected headers => " + expectedTableHeaders);
-            console.log("actual headers => " + actualTableHeaders);
+        
             assert.deepEqual(expectedTableHeaders, actualTableHeaders);
             assert.deepEqual(expectedTableRows, actualTableRows);
 


### PR DESCRIPTION
Connects #2 and #7 

At some point I made changes to the actual mmw repo instead of the bee pollinator and the patch file I made picked up some console log statements I had in for testing. This PR removes those.

Also removes `mounts` config for the deployment setup. Without RWD we don't need it anymore.