### PR TITLE
Replace Precipitation Slider With Number Of Hives Input

### DIFF
--- a/src/icp/apps/modeling/tests.py
+++ b/src/icp/apps/modeling/tests.py
@@ -287,7 +287,7 @@ class TaskRunnerTestCase(TestCase):
         self.model_input = {
             'inputs': [
                 {
-                    'name': 'precipitation',
+                    'name': 'numberofhives',
                     'value': 1.2
                 }
             ],
@@ -407,7 +407,7 @@ class TaskRunnerTestCase(TestCase):
             chain(job_chain).apply_async()
 
         self.assertEqual(str(context.exception),
-                         'No precipitation value defined',
+                         'No number of hives value defined',
                          'Unexpected exception occurred')
 
     def test_tr55_chain_doesnt_generate_censuses_if_they_exist(self):

--- a/src/icp/js/src/compare/controllers.js
+++ b/src/icp/js/src/compare/controllers.js
@@ -5,14 +5,9 @@ var _ = require('lodash'),
     router = require('../router').router,
     views = require('./views'),
     modelingModels = require('../modeling/models.js'),
-    modelingControls = require('../modeling/controls'),
-    synchronizer = modelingControls.PrecipitationSynchronizer;
+    modelingControls = require('../modeling/controls');
 
 var CompareController = {
-    comparePrepare: function() {
-        synchronizer.on();
-    },
-
     compare: function(projectId) {
         var first = null,
             aoi_census = null;
@@ -49,7 +44,6 @@ var CompareController = {
     },
 
     compareCleanUp: function() {
-        synchronizer.off();
         App.user.off('change:guest', saveAfterLogin);
         App.origProject.off('change:id', updateUrl);
 

--- a/src/icp/js/src/compare/views.js
+++ b/src/icp/js/src/compare/views.js
@@ -8,14 +8,12 @@ var _ = require('lodash'),
     coreViews = require('../core/views'),
     modelingModels = require('../modeling/models'),
     modelingViews = require('../modeling/views'),
-    modelingControls = require('../modeling/controls'),
     modConfigUtils = require('../modeling/modificationConfigUtils'),
     compareWindowTmpl = require('./templates/compareWindow.html'),
     compareScenariosTmpl = require('./templates/compareScenarios.html'),
     compareScenarioTmpl = require('./templates/compareScenario.html'),
     compareModelingTmpl = require('./templates/compareModeling.html'),
-    compareModificationsTmpl = require('./templates/compareModifications.html'),
-    synchronizer = modelingControls.PrecipitationSynchronizer;
+    compareModificationsTmpl = require('./templates/compareModifications.html');
 
 var CompareWindow = Marionette.LayoutView.extend({
     //model: modelingModels.ProjectModel,
@@ -89,7 +87,6 @@ var CompareWindow = Marionette.LayoutView.extend({
             model: this.model,
             collection: this.model.get('scenarios')
          }));
-        synchronizer.sync();
     }
 });
 
@@ -181,7 +178,6 @@ var CompareModelingView = Marionette.LayoutView.extend({
 
     regions: {
         resultRegion: '.result-region',
-        controlsRegion: '.controls-region'
     },
 
     ui: {
@@ -241,24 +237,8 @@ var CompareModelingView = Marionette.LayoutView.extend({
         }));
     },
 
-    showControls: function() {
-        var controls = modelingModels.getControlsForModelPackage(
-            this.projectModel.get('model_package'),
-            {compareMode: true}
-        );
-
-        // TODO this needs to be generalized if we want the compare view
-        // to work with GWLF-E
-        this.controlsRegion.show(new modelingViews.Tr55ToolbarTabContentView({
-            model: this.model,
-            collection: controls,
-            compareMode: true
-        }));
-    },
-
     onShow: function() {
         this.showResult();
-        this.showControls();
     }
 });
 

--- a/src/icp/js/src/modeling/controllers.js
+++ b/src/icp/js/src/modeling/controllers.js
@@ -209,11 +209,11 @@ function setupNewProjectScenarios(project) {
         new models.ScenarioModel({
             name: 'Current Conditions',
             is_current_conditions: true,
-            active: true,
             aoi_census: aoiCensus
         }),
         new models.ScenarioModel({
             name: 'New Scenario',
+            active: true,
             aoi_census: aoiCensus
         })
         // Silent is set to true because we don't actually want to save the

--- a/src/icp/js/src/modeling/mocks.js
+++ b/src/icp/js/src/modeling/mocks.js
@@ -37,7 +37,7 @@ var scenarios = {
         "inputs": [
             {
                 "area": "0",
-                "name": "precipitation",
+                "name": "numberofhives",
                 "shape": null,
                 "type": "",
                 "units": "m<sup>2</sup>",

--- a/src/icp/js/src/modeling/models.js
+++ b/src/icp/js/src/modeling/models.js
@@ -36,7 +36,7 @@ var ModelPackageControlModel = Backbone.Model.extend({
     // modification control.
     isInputControl: function() {
         return _.contains([
-            'precipitation'
+            'numberofhives'
         ], this.get('name'));
     }
 });
@@ -616,8 +616,8 @@ var ScenarioModel = Backbone.Model.extend({
             defaultMods = {
                inputs: [
                    {
-                       name: 'precipitation',
-                       value: 0.984252 // equal to 2.5 cm.
+                       name: 'numberofhives',
+                       value: 0.0
                    }
                ]
            };
@@ -1008,13 +1008,13 @@ function getControlsForModelPackage(modelPackageName, options) {
         if (options && (options.compareMode ||
                         options.is_current_conditions)) {
             return new ModelPackageControlsCollection([
-                new ModelPackageControlModel({ name: 'precipitation' })
+                new ModelPackageControlModel({ name: 'landcover' })
             ]);
         } else {
             return new ModelPackageControlsCollection([
                 new ModelPackageControlModel({ name: 'landcover' }),
                 new ModelPackageControlModel({ name: 'conservation_practice' }),
-                new ModelPackageControlModel({ name: 'precipitation' })
+                new ModelPackageControlModel({ name: 'numberofhives' })
             ]);
         }
     }

--- a/src/icp/js/src/modeling/templates/controls/precipitation.html
+++ b/src/icp/js/src/modeling/templates/controls/precipitation.html
@@ -1,6 +1,0 @@
-<div class="btn-sm btn-primary">
-<label>
-    <span class="name">Precipitation</span>
-    <input type="range" min="0" max="25" step="0.25" />
-    <span class="value"></span></label>
-</div>

--- a/src/icp/js/src/modeling/templates/controls/userInput.html
+++ b/src/icp/js/src/modeling/templates/controls/userInput.html
@@ -1,5 +1,5 @@
-<div class="form-group">
-  <label for="{{ userInputName }}">{{ displayNames[userInputName] }}</label>
-  <input type="text" class="form-control" id="{{ userInputName }}">
+<div class="hives">
+  <label for="{{ userInputName }}">{{ displayName }}</label>
+  <input type="number" class="form-control" id="{{ userInputName }}">
   <div class="info-region"></div>
 </div>

--- a/src/icp/js/src/modeling/tests.js
+++ b/src/icp/js/src/modeling/tests.js
@@ -214,8 +214,8 @@ describe('Modeling', function() {
                                'Should have shown landcover control');
                 assert.equal($('#sandbox .controls .conservation_practice').length, 1,
                                'Should have shown conservation practices control');
-                assert.equal($('#sandbox .controls .precipitation').length, 1,
-                               'Should have shown precipitation control');
+                assert.equal($('#sandbox .controls .hives').length, 1,
+                               'Should have shown number of hives control');
             });
 
             it('only shows input tools if user does not own project', function() {
@@ -226,8 +226,8 @@ describe('Modeling', function() {
                                'Should not have shown landcover control');
                 assert.equal($('#sandbox .controls .conservation_practice').length, 0,
                                'Should not have shown conservation practices control');
-                assert.equal($('#sandbox .controls .precipitation').length, 1,
-                               'Should have shown precipitation control');
+                assert.equal($('#sandbox .controls .hives').length, 1,
+                               'Should have shown hives control');
             });
         });
 
@@ -585,8 +585,6 @@ describe('Modeling', function() {
                 it('it sets attributes correctly', function() {
                     assert.equal(this.model.get('user_id'), App.user.get('id'),
                                  'user_id should equal the one in App');
-                    assert.equal(this.model.get('inputs').at(0).get('name'),
-                                 'precipitation', 'First input should be precipitation');
                     assert.deepEqual(this.model.get('modifications').toJSON(),
                                      new models.ModificationsCollection(mocks.scenarios.sample.modifications).toJSON(),
                                      'Should set modifications from argument to initialize');
@@ -596,6 +594,8 @@ describe('Modeling', function() {
                     assert.deepEqual(this.model.get('results').toJSON(),
                                      App.currentProject.createTaskResultCollection().toJSON(),
                                      'Should have set results from App.currentProject');
+                     assert.equal(this.model.get('inputs').pop().get('name'),
+                                  'numberofhives', 'Last input should be number of hives');
                 });
 
                 it('sets hashes', function() {

--- a/src/icp/sass/base/_header.scss
+++ b/src/icp/sass/base/_header.scss
@@ -266,14 +266,19 @@ header {
     }
 
     .controls {
-      // Precipitation slider
-      .precipitation {
+      // Number of hives input
+      .hives {
         // Undo bootstrap input[type="range"] syling
+        label {
+            font-size: 1.0rem;
+            color: $ui-primary;
+            vertical-align: middle;
+            margin-left: 1rem;
+        }
         input {
           display: inline-block;
           width: 120px;
           margin: 0 0.7rem;
-          padding: 0;
           vertical-align: bottom;
         }
       }

--- a/src/icp/sass/components/_buttons.scss
+++ b/src/icp/sass/components/_buttons.scss
@@ -44,6 +44,14 @@
     background-color: $brand-primary;
     border: solid 1px transparent;
   }
+
+  &:disabled {
+      background-color: transparent;
+  }
+
+  &.inverted {
+      color: $active;
+  }
 }
 
 .btn-primary {

--- a/src/icp/sass/pages/_compare.scss
+++ b/src/icp/sass/pages/_compare.scss
@@ -135,36 +135,6 @@
                   }
                 }
               }
-
-              .controls-region {
-                .controls {
-                  .precipitation {
-                    .btn-primary {
-                      z-index: 10;
-                      padding: 0;
-                      margin-top: 10px;
-                      width: 100%;
-
-                      label {
-                        display: table;
-                        width: 100%;
-
-                        span {
-                          display: table-cell;
-                          width: 10%;
-                          white-space: nowrap;
-                          padding: 5px;
-                        }
-                        input {
-                          display: table-cell;
-                          width: 100%;
-                          vertical-align: bottom;
-                        }
-                      }
-                    }
-                  }
-                }
-              }
             }
           }
 


### PR DESCRIPTION
## Overview
Bee pollinator model takes the number of managed hives as a numeric input, so this PR replaces the precipitation slider an number input field.

### Other small fixups
- Match the inverted dropdown button "Modifications" in the model header to the wireframes (ie make it blue)
- Set "New Scenario" as initial active tab


<img width="561" alt="screen shot 2016-11-11 at 3 15 11 pm" src="https://cloud.githubusercontent.com/assets/7633670/20228942/c331908c-a821-11e6-8427-672ac06d2e4c.png">
<img width="563" alt="screen shot 2016-11-11 at 3 15 22 pm" src="https://cloud.githubusercontent.com/assets/7633670/20228958/d188d4f6-a821-11e6-9ca2-48203d9edf00.png">

## Testing Instructions
- Pull this branch
- `./scripts/bundle.sh`
- Draw a shape
- You should only be able to enter numeric values in the input field
- You should be able go to compare still
- There shouldn't be any errors in the console

Connects #30 