### PR TITLE
Fix Scenario Dropdowns and Compare View Map Sidebar Toggle

### DIFF
--- a/src/icp/icp/settings/base.py
+++ b/src/icp/icp/settings/base.py
@@ -470,6 +470,7 @@ MAP_CONTROLS = [
     'LayerAttribution',
     'LocateMeButton',
     'ZoomControl',
+    'SidebarToggle'
 ]
 
 TR55_PACKAGE = 'tr-55'

--- a/src/icp/icp/settings/production.py
+++ b/src/icp/icp/settings/production.py
@@ -103,6 +103,7 @@ MAP_CONTROLS = [
     'LayerAttribution',
     'LocateMeButton',
     'ZoomControl',
+    'SidebarToggle'
 ]
 
 DISABLED_MODEL_PACKAGES = []

--- a/src/icp/js/src/compare/views.js
+++ b/src/icp/js/src/compare/views.js
@@ -129,6 +129,7 @@ var CompareScenarioView = Marionette.LayoutView.extend({
             addZoomControl: false,
             addLocateMeButton: false,
             addLayerSelector: false,
+            addSidebarToggle: false,
             showLayerAttribution: false,
             initialLayerName: App.getMapView().getActiveBaseLayerName(),
             interactiveMode: false

--- a/src/icp/js/src/core/views.js
+++ b/src/icp/js/src/core/views.js
@@ -185,6 +185,7 @@ var MapView = Marionette.ItemView.extend({
             addZoomControl: _.contains(map_controls, 'ZoomControl'),
             addLocateMeButton: _.contains(map_controls, 'LocateMeButton'),
             showLayerAttribution: _.contains(map_controls, 'LayerAttribution'),
+            addSidebarToggle: _.contains(map_controls, 'SidebarToggle'),
             interactiveMode: true // True if clicking on map does stuff
         });
 
@@ -224,7 +225,9 @@ var MapView = Marionette.ItemView.extend({
         map.addLayer(this._areaOfInterestLayer);
         map.addLayer(this._modificationsLayer);
 
-        map.addControl(new SidebarToggleControl());
+        if (options.addSidebarToggle) {
+            map.addControl(new SidebarToggleControl());
+        }
     },
 
     setupGeoLocation: function(maxAge) {
@@ -565,18 +568,6 @@ var MapView = Marionette.ItemView.extend({
                 });
             }
         });
-    },
-
-    addSidebarToggleControl: function() {
-        this._sidebarToggleControl = new SidebarToggleControl();
-        this._leafletMap.addControl(this._sidebarToggleControl);
-    },
-
-    removeSidebarToggleControl: function() {
-        if (this._sidebarToggleControl) {
-            this._leafletMap.removeControl(this._sidebarToggleControl);
-            delete this._sidebarToggleControl;
-        }
     }
 });
 

--- a/src/icp/js/src/modeling/views.js
+++ b/src/icp/js/src/modeling/views.js
@@ -312,6 +312,15 @@ var ScenarioTabPanelView = Marionette.ItemView.extend({
         'change': 'render'
     },
 
+    templateHelpers: function() {
+        return {
+            csrftoken: csrf.getToken(),
+            cid: this.model.cid,
+            editable: isEditable(this.model),
+            is_new: this.model.isNew()
+        };
+    },
+
     onRender: function() {
         this.$el.toggleClass('active', this.model.get('active'));
     },


### PR DESCRIPTION
### Overview
During #12 we removed the template helpers of `ScenarioTabPanelView` - they set booleans we needed for the dropdowns on that view to appear. This PR adds the necessary template helpers back in.

Because it was such a quick fix and I had noticed what was causing the expand/collapse control to appear in the compare view (#39) I've also included a0feb80.

_Dropdown is back_
![screen shot 2016-11-14 at 10 15 21 am](https://cloud.githubusercontent.com/assets/7633670/20269964/5167fdb8-aa53-11e6-91d4-71cd87a7f0c1.png)
![screen shot 2016-11-14 at 10 15 29 am](https://cloud.githubusercontent.com/assets/7633670/20269962/51669e64-aa53-11e6-9342-206e33cf8d6d.png)

_Sidebar toggle no longer appears on compare maps_
![screen shot 2016-11-14 at 10 05 28 am](https://cloud.githubusercontent.com/assets/7633670/20269963/51664662-aa53-11e6-9c30-c6ac42eb117a.png)

### Testing Instructions
- Pull this branch
- `./scripts/bundle.sh`
- Make sure the sidebar expand/collapse toggle still appears and works in the draw view
- Go to the model view and confirm the scenario dropdowns are there/working (they will not appear for "Current Conditions"
- Go to compare view and confirm there are no sidebar toggles on the little maps

Connects #33, #39 