### PR TITLE
Fix UI error when transitioning from model view

### DIFF
--- a/src/icp/js/src/core/views.js
+++ b/src/icp/js/src/core/views.js
@@ -181,6 +181,11 @@ var MapView = Marionette.ItemView.extend({
     // Google Maps API library is loaded asynchronously via an inline script tag
     _googleMaps: (window.google ? window.google.maps : null),
 
+    _centeredBounds: [
+        [24.2, -126.4],
+        [49.8, -66.0]
+    ],
+
     initialize: function(options) {
         var defaultLayer = _.findWhere(settings.get('base_layers'), function(layer) {
                 return layer.default === true;
@@ -205,10 +210,7 @@ var MapView = Marionette.ItemView.extend({
             });
 
         // Center the map on the U.S.
-        map.fitBounds([
-            [24.2, -126.4],
-            [49.8, -66.0]
-        ]);
+        map.fitBounds(this._centeredBounds);
 
         this._leafletMap = map;
         this._areaOfInterestLayer = new L.FeatureGroup();
@@ -264,6 +266,15 @@ var MapView = Marionette.ItemView.extend({
         $('.leaflet-bottom.leaflet-right>.leaflet-control-sidebar-toggle, \
           .leaflet-bottom.leaflet-right>.leaflet-control-zoom')
             .wrapAll('<div class="leaflet-bottom-right-controls"></div>');
+    },
+
+    clearMapState: function() {
+        var self = this;
+        self._leafletMap.fitBounds(self._centeredBounds);
+        self.updateModifications(null);
+        self.model.set('areaOfInterest', null);
+        self.model.set('areaOfInterestName', '');
+        self.model.set('previousAreaOfInterest', null);
     },
 
     setupGeoLocation: function(maxAge) {

--- a/src/icp/js/src/modeling/controllers.js
+++ b/src/icp/js/src/modeling/controllers.js
@@ -103,11 +103,11 @@ var ModelingController = {
     },
 
     projectCleanUp: function() {
-        projectCleanUp();
+        projectCleanUp(true);
     },
 
     makeNewProjectCleanUp: function() {
-        projectCleanUp();
+        projectCleanUp(true);
     },
 
     // Redirect the project cloning route back to the server.
@@ -169,7 +169,7 @@ function setPageTitle() {
         modelPackageDisplayName = _.find(modelPackages, {name: modelPackageName}).display_name;
 }
 
-function projectCleanUp() {
+function projectCleanUp(shouldClearMapState) {
     if (App.currentProject) {
         var scenarios = App.currentProject.get('scenarios');
 
@@ -184,9 +184,12 @@ function projectCleanUp() {
         App.projectNumber = scenarios.at(0).get('project');
     }
 
-    App.getMapView().updateModifications(null);
     App.rootView.subHeaderRegion.empty();
     App.rootView.sidebarRegion.empty();
+
+    if (shouldClearMapState) {
+        App.getMapView().clearMapState();
+    }
 }
 
 function updateUrl() {

--- a/src/icp/js/src/modeling/views.js
+++ b/src/icp/js/src/modeling/views.js
@@ -724,7 +724,7 @@ var ResultsView = Marionette.LayoutView.extend({
 
         // Change map to full size first so there isn't empty space when
         // results window animates out
-        App.map.setDoubleHeaderSmallFooterSize(fit);
+        App.map.setNoHeaderSidebarSize(fit);
 
         this.$el.animate({ width: '0px' }, 200, function() {
             self.trigger('animateOut');


### PR DESCRIPTION
This fixes an error that resulted in the UI being put into a bad state when app was backed out of the modelling view.


To test:
* clone this branch and bring up the environment
* navigate to `http://localhost:8000`
* draw an AoI and confirm it to move to the modelling view -->
![download 7](https://cloud.githubusercontent.com/assets/18290666/20432603/f8890e12-ad6d-11e6-873d-cdc68158d1ed.png)
* back out of this using the browser, and you should be returned to the same home view -->
![download 8](https://cloud.githubusercontent.com/assets/18290666/20432643/26c15a5a-ad6e-11e6-8c30-b5a6e535fd73.png)
* check the browser console for any errors; the `Failed to start modeling job.` and associated 500 error are expected

Connects #32
