### PR TITLE
Default to Current Conditions, Bordered AoI

### DIFF
--- a/src/icp/js/src/core/views.js
+++ b/src/icp/js/src/core/views.js
@@ -709,7 +709,10 @@ function applyMask(featureGroup, shapeLayer) {
         outerRing = getLatLngs(worldBounds),
         innerRings = getLatLngs(shapeLayer),
         polygonOptions = {
-            stroke: false,
+            stroke: true,
+            color: '#fff',
+            weight: 1.5,
+            opacity: 1,
             fill: true,
             fillColor: '#000',
             fillOpacity: 0.5,

--- a/src/icp/js/src/modeling/controllers.js
+++ b/src/icp/js/src/modeling/controllers.js
@@ -212,11 +212,11 @@ function setupNewProjectScenarios(project) {
         new models.ScenarioModel({
             name: 'Current Conditions',
             is_current_conditions: true,
+            active: true,
             aoi_census: aoiCensus
         }),
         new models.ScenarioModel({
             name: 'New Scenario',
-            active: true,
             aoi_census: aoiCensus
         })
         // Silent is set to true because we don't actually want to save the


### PR DESCRIPTION
## Overview

"Current Conditions" are now the default scenario when a new project is created.
The area of interest now features a thin white border that makes it easier to differentiate, especially on satellite view.

### Demo

![image](https://cloud.githubusercontent.com/assets/1430060/20500817/07395b6c-b005-11e6-9dee-719eff620d5c.png)

## Testing Instructions

Pull the branch, bundle the scripts.

Draw an area of interest. Switch to Satellite view. Ensure that the AoI is clearly distinguishable.

Proceed to the modeling view. Ensure that "Current Conditions" are active by default.

Connects #49 
Connects #50 