### PR TITLE
Remove 100% Forest Cover From Compare View

### DIFF
--- a/src/icp/js/src/compare/controllers.js
+++ b/src/icp/js/src/compare/controllers.js
@@ -19,7 +19,6 @@ var CompareController = {
             }
 
             setupProjectCopy(aoi_census);
-            addForestCoverScenario(aoi_census);
             showCompareWindow();
         } else if (projectId) {
             App.currentProject = new modelingModels.ProjectModel({
@@ -35,7 +34,6 @@ var CompareController = {
                 .fetch()
                 .done(function() {
                     setupProjectCopy(aoi_census);
-                    addForestCoverScenario(aoi_census);
                     showCompareWindow();
                 });
         }
@@ -110,30 +108,6 @@ function copyProject(project, aoi_census) {
         scenarios: scenariosCopy,
         allow_save: false
     });
-}
-
-// Adds special 100% Forest Cover Scenario for the Compare View
-function addForestCoverScenario(aoi_census) {
-    var project = App.currentProject,
-        forestCoverScenario = new modelingModels.ScenarioModel({}),
-        currentConditions = project.get('scenarios').findWhere({ is_current_conditions: true });
-
-    forestCoverScenario.set({
-        name: '100% Forest Cover',
-        is_current_conditions: false,
-        is_pre_columbian: true,
-        modifications: currentConditions.get('modifications'),
-        modification_hash: currentConditions.get('modification_hash'),
-        results: new modelingModels.ResultCollection(currentConditions.get('results').toJSON()),
-        inputs: new modelingModels.ModificationsCollection(currentConditions.get('inputs').toJSON()),
-        inputmod_hash: currentConditions.get('inputmod_hash'),
-        allow_save: false
-    });
-    if (aoi_census) {
-        forestCoverScenario.set('aoi_census', aoi_census);
-    }
-    forestCoverScenario.get('inputs').on('add', _.debounce(_.bind(forestCoverScenario.fetchResults, forestCoverScenario), 500));
-    project.get('scenarios').add(forestCoverScenario, { at: 0 });
 }
 
 function saveAfterLogin(user, guest) {

--- a/src/icp/sass/pages/_compare.scss
+++ b/src/icp/sass/pages/_compare.scss
@@ -46,15 +46,15 @@
             border-right: solid 1px $black-12;
 
             @media(min-width: 768px) {
-              width: 32.5vw;
+              width: 35vw;
             }
 
             @media(min-width: 1024px) {
-              width: 24.5vw;
+              width: 30vw;
             }
 
             @media(min-width: 1280px) {
-              width: 19.5vw;
+              width: 25vw;
             }
           }
 


### PR DESCRIPTION
We don't need to add the 100% Forest Cover scenario to the compare view, so now we only show the Current Conditions and whatever scenarios you've created.

## Screenshot
![screen shot 2016-11-21 at 5 35 16 pm](https://cloud.githubusercontent.com/assets/7633670/20503703/f1801254-b011-11e6-9e18-aa5f67a6c691.png)

## Notes
It looked like each column should take up about half the screen if there were only 2 initial scenarios. Such wide columns made it hard to compare more than two scenarios at a time though, so I decided to only increase the column width a little. I think it'd be cool if they resized dynamically.

_Half viewport column widths_
![screen shot 2016-11-21 at 5 34 48 pm](https://cloud.githubusercontent.com/assets/7633670/20503820/6d83b2a2-b012-11e6-88d6-a1c89207c392.png)

## Testing instructions
- Pull this branch
- `./scripts/bundle.sh`

- Draw a shape and go to the compare view
- Confirm there are only 2 columns and no errors in the console
- Go back to Model, and add some more scenarios
- Check that the compare view still looks okay 
