### PR TITLE
Add Basemap to Compare View

### DIFF
--- a/src/icp/js/src/core/views.js
+++ b/src/icp/js/src/core/views.js
@@ -225,11 +225,13 @@ var MapView = Marionette.ItemView.extend({
             addLocateMeButton(map, maxGeolocationAge);
         }
 
+        var initialLayerName = this.options.initialLayerName || 'satellite',
+            initialLayer = this.baseLayers[initialLayerName];
         if (options.addLayerSelector) {
 
             self.layerControl = new LayerControl({
                 layers: this.baseLayers,
-                initialLayer: this.baseLayers.satellite
+                initialLayer: initialLayer
             });
 
             var overlayInfo = settings.get('overlay_layer'),
@@ -242,6 +244,8 @@ var MapView = Marionette.ItemView.extend({
             });
             self.layerControl.addTo(map);
             self.overlayControl.addTo(map);
+        } else {
+            map.addLayer(initialLayer);
         }
 
         this.setMapEvents();

--- a/src/icp/js/src/core/views.js
+++ b/src/icp/js/src/core/views.js
@@ -255,8 +255,8 @@ var MapView = Marionette.ItemView.extend({
         }
 
         // wrap the zoom & sidebar toggle controls in one div for styling
-        $('.leaflet-bottom.leaflet-right>.leaflet-control-sidebar-toggle, \
-          .leaflet-bottom.leaflet-right>.leaflet-control-zoom')
+        $('.leaflet-bottom.leaflet-right>.leaflet-control-sidebar-toggle,' +
+          '.leaflet-bottom.leaflet-right>.leaflet-control-zoom')
             .wrapAll('<div class="leaflet-bottom-right-controls"></div>');
     },
 


### PR DESCRIPTION
## Overview

Adds currently active  basemap to compare view.

### Demo

![image](https://cloud.githubusercontent.com/assets/1430060/21057310/26a7a8ea-be07-11e6-8f5b-0de340bd5848.png)

## Testing Instructions

Check out the branch, bundle the scripts.

Open the app, draw an area of interest, proceed to the modeling, then the compare view. The maps in the compare view should have a satellite basemap.

Go back to the modeling view, and change the basemap to streets. Go forward to compare view. The maps in the compare view should have a street basemap.

Connects #67 