### PR TITLE
Display Imperial Units instead of Metric

### DIFF
--- a/src/icp/js/src/core/models.js
+++ b/src/icp/js/src/core/models.js
@@ -225,13 +225,11 @@ var TaskMessageViewModel = Backbone.Model.extend({
 });
 
 var GeoModel = Backbone.Model.extend({
-    M_IN_KM: 1000000,
-
     defaults: {
         name: '',
         shape: null,        // GeoJSON
         area: '0',
-        units: 'm<sup>2</sup>',
+        units: 'acres',
     },
 
     initialize: function() {
@@ -247,14 +245,8 @@ var GeoModel = Backbone.Model.extend({
 
         var areaInMeters = turfArea(this.get(shape));
 
-        // If the area is less than 1 km, use m
-        if (areaInMeters < this.M_IN_KM) {
-            this.set(area, areaInMeters);
-            this.set(units, 'm<sup>2</sup>');
-        } else {
-            this.set(area, areaInMeters / this.M_IN_KM);
-            this.set(units, 'km<sup>2</sup>');
-        }
+        this.set(area, utils.convertToImperial(areaInMeters, 'm2'));
+        this.set(units, 'acres');
     }
 });
 

--- a/src/icp/js/src/core/utils.js
+++ b/src/icp/js/src/core/utils.js
@@ -248,9 +248,17 @@ var utils = {
                 // return feet.
                 return value * 3.28084;
 
+            case 'm2':
+                // return acres.
+                return value * 0.000247105;
+
             case 'km':
                 // return miles.
                 return value * 0.621371;
+
+            case 'km2':
+                // return acres.
+                return value * 247.105;
 
             case 'kg':
                 // return Lbs.

--- a/src/icp/js/src/draw/views.js
+++ b/src/icp/js/src/draw/views.js
@@ -20,7 +20,7 @@ var $ = require('jquery'),
     windowTmpl = require('./templates/window.html'),
     settings = require('../core/settings');
 
-var MAX_AREA = 112700; // About the size of a large state (in km^2)
+var MAX_AREA = 27500000; // About the size of a large state (in acres)
 var codeToLayer = {}; // code to layer mapping
 
 function actOnUI(datum, bool) {
@@ -42,7 +42,7 @@ function actOnLayer(datum) {
 }
 
 function validateShape(polygon) {
-    var area = coreUtils.changeOfAreaUnits(turfArea(polygon), 'm<sup>2</sup>', 'km<sup>2</sup>'),
+    var area = coreUtils.convertToImperial(turfArea(polygon), 'm2'),
         d = new $.Deferred();
     var selfIntersectingShape = turfKinks(polygon).features.length > 0;
 
@@ -54,9 +54,9 @@ function validateShape(polygon) {
         d.reject(errorMsg);
     } else if (area > MAX_AREA) {
         var message = 'Sorry, your Area of Interest is too large.\n\n' +
-                      Math.floor(area).toLocaleString() + ' km² were selected, ' +
+                      Math.floor(area).toLocaleString() + ' acres were selected, ' +
                       'but the maximum supported size is currently ' +
-                      MAX_AREA.toLocaleString() + ' km².';
+                      MAX_AREA.toLocaleString() + ' acres.';
         window.alert(message);
         d.reject(message);
     } else {

--- a/src/icp/js/src/geocode/templates/search.html
+++ b/src/icp/js/src/geocode/templates/search.html
@@ -1,4 +1,4 @@
-<input class="search-input" id="geocoder-search" type="text" placeholder="Search"/>
+<input class="search-input" id="geocoder-search" type="text" placeholder="Enter address or location"/>
 <i class="search-icon fa fa-search"></i>
 <div id="geocode-search-results-region"></div>
 <div class="message hidden">


### PR DESCRIPTION
## Overview

Switches displayed values to imperial rather than metric. I could not find any examples of length, thus didn't convert meters to feet. More values will come in to play as we flesh out the model side, so we'll have to keep this in mind.

## Testing Instructions

Check out this branch, bundle scripts and hard refresh your browser.

 * Notice the new message in the search bar in the home / draw views.
 * Draw a very large area of interest (like half the country). The error message admonishing you should be in acres, not km².
 * Draw a regular area of interest and move to the model view. Draw a modification for New Scenario. Click the modification. Its area should be displayed in acres.
 * Click the modification dropdown in the top right of the model view. It should display the area of all drawn modifications in acres.

Are there any other places that may have metric units? If so, please let me know and I will update them.

Connects #72 
Connects #73 