### PR TITLE
Use Current Condition Results In Scenarios Without Modifications

### DIFF
--- a/src/icp/apps/modeling/tasks.py
+++ b/src/icp/apps/modeling/tasks.py
@@ -44,4 +44,8 @@ def calculate_yield(model_input):
 
     yields = crop_yield.calculate(bee_shed_geom, field_geom,
                                   modifications, managed_hives)
-    return json.dumps(yields)
+
+    return {
+        'inputmod_hash': model_input['inputmod_hash'],
+        'yield': yields,
+    }

--- a/src/icp/js/src/modeling/tr55/runoff/views.js
+++ b/src/icp/js/src/modeling/tr55/runoff/views.js
@@ -34,7 +34,6 @@ var ResultView = Marionette.LayoutView.extend({
     onShow: function() {
         this.tableRegion.reset();
         this.chartRegion.reset();
-
         if (this.model.get('result')) {
             var aoiVolumeModel = new AoiVolumeModel({
                 areaOfInterest: this.aoi
@@ -175,6 +174,7 @@ var TableView = Marionette.CompositeView.extend({
     },
 
     makeRowsForScenario: function(runoffKey) {
+        return;
         var self = this,
             runoffPartition = this.tr55Results[runoffKey];
 


### PR DESCRIPTION
## Overview
Unlike MMW, land cover changes on the Current Conditions tab will carry over to the scenario tabs. Instead of running the model job for every open scenario, this PR sets up the model job to only kick off if: 
1) The scenario is current conditions (and it has no results/no resolved promise yet)
2) The scenario isn't current conditions, is active, and the current conditions job hasn't returned any results
3) There are new modifications

Otherwise we copy the current conditions results over to the initial "New Scenario", and don't rerun the model

## Demo
Below you can see we're on a scenario tab with scenario results, but only the current condition tab has called the model (there's only one set of polling calls)
<img width="1280" alt="screen shot 2016-12-27 at 12 52 34 pm" src="https://cloud.githubusercontent.com/assets/7633670/21505266/a773096c-cc33-11e6-8ba0-0a49a8adf419.png">

## Testing Instructions
- Pull this branch and `./scripts/bundle.sh --debug`
- Open the Dev tools console
- Draw an AOI and stay on the current conditions tab
   - Check that there is only one call to `/yield`
- When there are results, switch to the New Scenario tab
   - There should be no new polling, and the logged "Scenario Result" should be the same as Current Conditions' result
- Add some modifications in the new scenario and confirm the model re-runs
- Repeat the process, but while the Current Conditions tab is polling, switch to the New Scenario
   - The new scenario should start polling itself

Connects #84

