### PR TITLE
Allow corrected land use to be applied to all scenarios

### DIFF
--- a/src/icp/js/src/compare/views.js
+++ b/src/icp/js/src/compare/views.js
@@ -134,7 +134,7 @@ var CompareScenarioView = Marionette.LayoutView.extend({
 
         this.mapView.fitToAoi();
         this.mapView.updateAreaOfInterest();
-        this.mapView.updateModifications(this.model.get('modifications'));
+        this.mapView.updateModifications(this.model);
         this.mapRegion.show(this.mapView);
         this.modelingRegion.show(new CompareModelingView({
             projectModel: this.projectModel,

--- a/src/icp/js/src/core/modificationConfig.json
+++ b/src/icp/js/src/core/modificationConfig.json
@@ -28,21 +28,21 @@
         "strokeColor": "#021655"
     },
     "wildflower_strip": {
-        "value": 5,
+        "value": 21,
         "name": "Wildflower Strip",
         "summary": "Grouping of residential homes on a development site in order to use the extra land as open space, recreation or agriculture.",
         "fillColor": "pink",
         "strokeColor": "#777777"
     },
     "bee_hab_a": {
-        "value": 42,
+        "value": 24,
         "name": "Bee Habitat A",
         "summary": "A roof of a building that is partially or completely covered with vegetation and a growing medium, planted over a waterproofing membrane.",
         "fillColor": "green",
         "strokeColor": "#9ABD52"
     },
     "bee_hab_b": {
-        "value": 43,
+        "value": 25,
         "name": "Bee Habitat B",
         "summary": "A roof of a building that is partially or completely covered with vegetation and a growing medium, planted over a waterproofing membrane.",
         "fillColor": "blue",

--- a/src/icp/js/src/core/templates/modificationPopup.html
+++ b/src/icp/js/src/core/templates/modificationPopup.html
@@ -1,12 +1,13 @@
-<h2>{{ value|modName }}</h2>
-<table class='table'>
-    <tr>
-        <td>Total Area</td>
-        <td class='strong text-right'>{{ area|round(2)|toLocaleString(2) }} {{ units }}</td>
-    </tr>
-</table>
-<span>
-    <button class="btn btn-sm btn-icon dark delete-modification" type="button">
-        <i class="fa fa-trash"></i>
-    </button>
-</span>
+<h3>
+    {{ value|modName }}
+    <small class="text-muted">{{ area|round(2)|toLocaleString(2) }} {{ units }}</small>
+</h3>
+
+{% if isCurrentConditions %}
+    <p>This change corrects the underlying land cover data and will be applied to all scenarios. </p>
+{% else %}
+    <p>This land cover change will only affect this scenario.</p>
+{% endif %}
+<button class="btn btn-sm btn-icon dark delete-modification" type="button" title="Remove">
+    <i class="fa fa-trash"></i>
+</button>

--- a/src/icp/js/src/core/templates/sharedModificationPopup.html
+++ b/src/icp/js/src/core/templates/sharedModificationPopup.html
@@ -5,8 +5,3 @@
         <td class='strong text-right'>{{ area|round(2)|toLocaleString(2) }} {{ units }}</td>
     </tr>
 </table>
-<span>
-    <button class="btn btn-sm btn-icon dark delete-modification" type="button">
-        <i class="fa fa-trash"></i>
-    </button>
-</span>

--- a/src/icp/js/src/core/templates/sharedModificationPopup.html
+++ b/src/icp/js/src/core/templates/sharedModificationPopup.html
@@ -1,7 +1,8 @@
-<h2>{{ value|modName }}</h2>
-<table class='table'>
-    <tr>
-        <td>Total Area</td>
-        <td class='strong text-right'>{{ area|round(2)|toLocaleString(2) }} {{ units }}</td>
-    </tr>
-</table>
+<h3>
+    {{ value|modName }}
+    <small class="text-muted">{{ area|round(2)|toLocaleString(2) }} {{ units }}</small>
+</h3>
+
+<p>
+    This area was created in Current Conditions to correct land cover data and is applied to all scenarios.
+</p>

--- a/src/icp/js/src/core/utils.js
+++ b/src/icp/js/src/core/utils.js
@@ -155,8 +155,8 @@ var utils = {
         return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
     },
 
-    // Convert a backbone collection into a canonical MD5 hash
-    getCollectionHash: function(collection) {
+    // Converts up to two backbone collections into a canonical MD5 hash
+    getCollectionHash: function(collection1, collection2) {
         // JSON objects are not guaranteed consistent order in string
         // representation, so we convert to sorted array which can be
         // stringified reliably.
@@ -181,9 +181,17 @@ var utils = {
                 return sorted;
             },
             // Convert each model to a sorted array
-            sortedCollection = collection.map(function(model) {
+            sortedCollection = collection1.map(function(model) {
                 return objectToSortedArray(model.toJSON());
             });
+
+            if (collection2) {
+                sortedCollection = sortedCollection.concat(
+                    collection2.map(function(model) {
+                        return objectToSortedArray(model.toJSON());
+                    })
+                );
+            }
 
         return md5(JSON.stringify(sortedCollection));
     },

--- a/src/icp/js/src/core/views.js
+++ b/src/icp/js/src/core/views.js
@@ -586,8 +586,9 @@ var MapView = Marionette.ItemView.extend({
     // shared and specific modification collections.
     updateModifications: function(scenario) {
         var self = this,
+            isCurrentConditions = scenario.get('is_current_conditions'),
             sharedMods = self._modificationToLayer(scenario.get('shared_modifications'), true),
-            mods = self._modificationToLayer(scenario.get('modifications'));
+            mods = self._modificationToLayer(scenario.get('modifications'), false, isCurrentConditions);
 
         self.clearModifications();
 
@@ -596,13 +597,15 @@ var MapView = Marionette.ItemView.extend({
         });
     },
 
-    _modificationToLayer: function(modificationsColl, shared) {
+    _modificationToLayer: function(modificationsColl, shared, isCurrentConditions) {
         var self = this;
         return modificationsColl.reduce(function(acc, model) {
             try {
                 var popupView = shared ? SharedModificationPopupView : ModificationPopupView,
                     modType = model.get('value'),
                     style = modificationConfigUtils.getDrawOpts(modType, shared);
+
+                model.set('isCurrentConditions', isCurrentConditions);
 
                 return acc.concat(new L.GeoJSON(model.get('shape'), {
                         style: style,

--- a/src/icp/js/src/modeling/controllers.js
+++ b/src/icp/js/src/modeling/controllers.js
@@ -187,7 +187,8 @@ function updateUrl() {
 }
 
 function updateScenario(scenario) {
-    App.getMapView().updateModifications(scenario.get('modifications'));
+    // Render both shared and scenario specific modifications
+    App.getMapView().updateModifications(scenario);
     updateUrl();
 }
 

--- a/src/icp/js/src/modeling/controls.js
+++ b/src/icp/js/src/modeling/controls.js
@@ -97,6 +97,7 @@ var ThumbSelectView = Marionette.ItemView.extend({
                 name: controlName,
                 value: controlValue,
                 cdlId: modificationConfigUtils.getCdlId(controlValue),
+                summary: modificationConfigUtils.getHumanReadableSummary(controlValue),
                 shape: geojson
             }));
         });

--- a/src/icp/js/src/modeling/models.js
+++ b/src/icp/js/src/modeling/models.js
@@ -127,13 +127,13 @@ var ProjectModel = Backbone.Model.extend({
         this.set('is_activity', settings.get('activityMode'));
 
         this.listenTo(this.get('scenarios'), 'add', this.addIdsToScenarios, this);
-        this.get('scenarios').on('change:modification_hash', this.shareGlobalModifications);
+        this.get('scenarios').on('change:modification_hash', this.shareGlobalModifications, this);
     },
 
     shareGlobalModifications: function(changedScenario) {
         // When modifications are made to current conditions, add them
         // to all other scenarios as well
-        var scenarios = this;
+        var scenarios = this.get('scenarios');
         if (changedScenario.get('is_current_conditions')) {
             var sharedMods = changedScenario.get('modifications').toJSON();
             scenarios.each(function(scenario) {
@@ -267,6 +267,11 @@ var ProjectModel = Backbone.Model.extend({
                 });
 
             scenariosCollection.reset(scenarios);
+
+            // Apply current condition's modifications to all other scenarios
+            var currentConditions = scenariosCollection.findWhere({is_current_conditions: true});
+            this.shareGlobalModifications(currentConditions);
+
             // Set the user_id to ensure controls are properly set.
             response.user_id = user_id;
 

--- a/src/icp/js/src/modeling/models.js
+++ b/src/icp/js/src/modeling/models.js
@@ -319,6 +319,7 @@ var ModificationModel = coreModels.GeoModel.extend({
     defaults: _.extend({
             name: '',
             type: '',
+            summary: '',
             effectiveArea: null, // Area after being clip by AoI
             effectiveUnits: null, // Units of effective area
             effectiveShape: null, // GeoJSON after being clip by AoI,

--- a/src/icp/js/src/modeling/models.js
+++ b/src/icp/js/src/modeling/models.js
@@ -629,16 +629,18 @@ var ScenarioModel = Backbone.Model.extend({
 
         switch(App.currentProject.get('model_package')) {
             case YIELD_PACKAGE:
-                var activeModifications = self.get('modifications')
-                    .map(function(mod) {
-                        var attr = mod.attributes;
-                        return {
-                            shape: attr.shape,
-                            area: attr.effectiveArea,
-                            category: attr.name,
-                            value: attr.cdlId
-                        };
-                    });
+                var scenarioMods = self.get('modifications').models,
+                    sharedMods = self.get('shared_modifications').models,
+                    activeModifications = sharedMods.concat(scenarioMods)
+                        .map(function(mod) {
+                            var attr = mod.attributes;
+                            return {
+                                shape: attr.shape,
+                                area: attr.effectiveArea,
+                                category: attr.name,
+                                value: attr.cdlId
+                            };
+                        });
 
                 return {
                     model_input: JSON.stringify({

--- a/src/icp/js/src/modeling/modificationConfigUtils.js
+++ b/src/icp/js/src/modeling/modificationConfigUtils.js
@@ -1,4 +1,5 @@
 "use strict";
+var $ = require('jquery');
 
 var modificationConfig = require('../core/modificationConfig.json');
 
@@ -50,28 +51,35 @@ function getCdlId(modKey) {
     return unknownModKey(modKey);
 }
 
-var getDrawOpts = function(modKey) {
-    var defaultStyle = {
-        color: '#888',
-        opacity: 1,
-        weight: 3,
-        strokeWidth: 1,
-        fillColor: '#888',
-        fillOpacity: 0.74
-    };
+/*
+ * Retrieve configuration for vector drawing of modification types,
+ * both Land Cover and Enhancements.
+ * Args:
+ *   modKey (string): The key for the modification entry in modificationConfig
+ *   shared (bool): Will augment the returned rendering options to include
+ *      changes appropriate for shared vectors drawn across scenarios.
+ */
+var getDrawOpts = function(modKey, shared) {
+    var defaultOpacity = shared ? 0.4 : 0.75,
+        defaultStrokeWidth = shared ? 1 : 3,
+        defaultStyle = {
+            weight: defaultStrokeWidth,
+            color: '#888',
+            opacity: defaultOpacity,
+            strokeWidth: defaultStrokeWidth,
+            fillColor: '#888',
+            fillOpacity: defaultOpacity
+        };
 
     if (modKey && modificationConfig[modKey]) {
         var config = modificationConfig[modKey];
         if (config.copyStyle) {
             return getDrawOpts(config.copyStyle);
         } else if (config.strokeColor){
-            return {
+            return $.extend(defaultStyle, {
                 color: config.strokeColor,
-                opacity: 1,
-                weight: 3,
                 fillColor: config.fillColor,
-                fillOpacity: 0.74
-            };
+            });
         } else {
             return defaultStyle;
         }

--- a/src/icp/js/src/modeling/views.js
+++ b/src/icp/js/src/modeling/views.js
@@ -548,8 +548,7 @@ var ToolbarTabContentView = Marionette.CompositeView.extend({
 
     updateMap: function() {
         if (this.model.get('active')) {
-            var modificationsColl = this.model.get('modifications');
-            App.getMapView().updateModifications(modificationsColl);
+            App.getMapView().updateModifications(this.model);
         }
     },
 


### PR DESCRIPTION
#### Overview
All modifications made or removed from the current conditions scenario are propagated across all other scenarios, including new and duplicated scenarios.  This facilitates using current conditions as a rectified base layer for constant model data. Both shared and scenario-specific modifications are submitted to the model endpoint. See detailed description in #87.

Additionally, the modification popups were altered to allow different behaviors for each type and the enhancement modifications were changed to types which have attributes more likely to affect the model output.

Connects #87 

![screenshot from 2016-12-30 14 16 19](https://cloud.githubusercontent.com/assets/1014341/21571175/90f07468-ce9a-11e6-902e-b39c197dd3da.png)

#### Known issues
There is a bug present on develop as well as this branch that cancels jobs too eagerly when switching between tabs if one is currently polling.  This can result in too many requests being generated for the number of scenarios there are.  Rather than try and fix it here, I'm going to investigate that in another issue, along with the aspects of the connected issue dealing with managing requests when modifications are shared.

#### Testing
* Update your local bundle `./scripts/bundle.sh --debug`
* Draw an area of interest and move to the modelling screen.
* To avoid the bug listed above, wait until polling completes before switching tabs, although all the intended behavior in this PR is not specifically affected - just the model results polling.
* Draw some land use changes on CC
    * Popup should be "normal", ie, let you delete
* Switch to new scenario, CC modification should be present
    * Has muted symbology
    * Popup won't let you delete, tells you where it's from
* Make new scenario, should behave like scenario above with CC changes already applied
* Duplicate a scenario, changes should be applied
* Delete a change on CC
    * Feature should be removed from all scenarios
* Scenario specific modifications should stay only available on that scenario, except when duplicated