### PR TITLE
Add Crop Layer Legend

### DIFF
--- a/src/icp/js/src/core/overlayControl.js
+++ b/src/icp/js/src/core/overlayControl.js
@@ -4,7 +4,8 @@ var L = require('leaflet'),
     $ = require('jquery'),
     _ = require('underscore'),
     Marionette = require('../../shim/backbone.marionette'),
-    overlayControlTmpl = require('./templates/overlayControl.html');
+    overlayControlTmpl = require('./templates/overlayControl.html'),
+    cropTypes = require('./cropTypes.json');
 
 module.exports = L.Control.extend({
     options: {
@@ -67,6 +68,7 @@ var OverlayControlView = Marionette.ItemView.extend({
     templateHelpers: function() {
         return {
             legend: this.isDisplayed ? "open" : "",
+            cropTypes: cropTypes,
             iconClass: this.isDisplayed ? "fa fa-eye-slash" : "fa fa-eye",
             inputType: this.isDisplayed ? "range" : "hidden",
             layerName: 'Crop Layer',

--- a/src/icp/js/src/core/overlayControl.js
+++ b/src/icp/js/src/core/overlayControl.js
@@ -66,6 +66,7 @@ var OverlayControlView = Marionette.ItemView.extend({
 
     templateHelpers: function() {
         return {
+            legend: this.isDisplayed ? "open" : "",
             iconClass: this.isDisplayed ? "fa fa-eye-slash" : "fa fa-eye",
             inputType: this.isDisplayed ? "range" : "hidden",
             layerName: 'Crop Layer',

--- a/src/icp/js/src/core/templates/overlayControl.html
+++ b/src/icp/js/src/core/templates/overlayControl.html
@@ -1,9 +1,9 @@
 <div class="crop-legend-dropdown dropup {{ legend }}">
     <div class="dropdown-menu dropdown-menu-left">
-        {% for i in range(1, 48) %}
+        {% for id, name in cropTypes %}
             <div class="legend-item">
-                <span class="legend-color crop-{{ i }}"></span>
-                Crop {{ i }}
+                <span class="legend-color crop-{{ id }}"></span>
+                {{ name }}
             </div>
         {% endfor %}
     </div>

--- a/src/icp/js/src/core/templates/overlayControl.html
+++ b/src/icp/js/src/core/templates/overlayControl.html
@@ -1,3 +1,13 @@
+<div class="crop-legend-dropdown dropup {{ legend }}">
+    <div class="dropdown-menu dropdown-menu-left">
+        {% for i in range(1, 48) %}
+            <div class="legend-item">
+                <span class="legend-color crop-{{ i }}"></span>
+                Crop {{ i }}
+            </div>
+        {% endfor %}
+    </div>
+</div>
 <div class="layer-control-button-container leaflet-bar" style="width:100%;">
     <a class="leaflet-bar leaflet-bar-part leaflet-bar-part-single"
       style="cursor:default;" href="#" title="{{ action }} {{ layerName }}">

--- a/src/icp/sass/components/_dropdowns.scss
+++ b/src/icp/sass/components/_dropdowns.scss
@@ -169,3 +169,35 @@
 .modification-dropdown {
   z-index: 1002;
 }
+
+.crop-legend-dropdown {
+
+  .dropdown-menu {
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+    padding: 0.5rem;
+    overflow: scroll;
+    column-count: 4;
+  }
+
+  .legend-color {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    margin-right: 4px;
+    margin-bottom: -3px;
+    border: 2px solid $black-39;
+
+    // Official CDL legend colors for classes selected for display
+    @for $i from 1 through 47 {
+      &.crop-#{$i} {
+        background: map-get($cropColors, $i)
+      }
+    }
+  }
+
+  .legend-item {
+    white-space: nowrap;
+  }
+}


### PR DESCRIPTION
## Overview

Adds a legend for the crop layer, visible whenever the crop layer is visible. This is an initial stab. We need to replace "Crop n" labels with proper names, and better manage the number of items.

### Demo

![image](https://cloud.githubusercontent.com/assets/1430060/21618687/220744a0-d1ba-11e6-9318-45a805b3ac89.png)

### Notes

This uses placeholder colors. Actual colors are expected in #95 / #96. When the variables are updated, this should update automatically.

## Testing Instructions

Pull down this branch. Run the bundle script. Open the app. Enable the crop layer. You should see a legend right above the crop layer button. It should go away when the crop layer is hidden.

Connects #74 