### PR TITLE
Add yield results chart to Compare view

### DIFF
--- a/src/icp/js/src/compare/controllers.js
+++ b/src/icp/js/src/compare/controllers.js
@@ -5,7 +5,6 @@ var _ = require('lodash'),
     router = require('../router').router,
     views = require('./views'),
     modelingModels = require('../modeling/models.js'),
-    modelingControls = require('../modeling/controls'),
     cropTypes = require('../core/cropTypes.json');
 
 var CompareController = {

--- a/src/icp/js/src/compare/templates/compareModeling.html
+++ b/src/icp/js/src/compare/templates/compareModeling.html
@@ -6,7 +6,7 @@
     <div class="pull-right">
         <select class="form-control btn btn-small btn-primary">
             {% for result in results %}
-                <option value="{{ result.name }}" {{ "selected" if result.active }}>
+                <option value="{{ result.displayName }}" {{ "selected" if result.active }}>
                     {{ result.displayName }}
                 </option>
             {% endfor %}

--- a/src/icp/js/src/compare/views.js
+++ b/src/icp/js/src/compare/views.js
@@ -6,15 +6,13 @@ var _ = require('lodash'),
     App = require('../app'),
     coreModels = require('../core/models'),
     coreViews = require('../core/views'),
-    modelingModels = require('../modeling/models'),
     modelingViews = require('../modeling/views'),
     modConfigUtils = require('../modeling/modificationConfigUtils'),
     compareWindowTmpl = require('./templates/compareWindow.html'),
     compareScenariosTmpl = require('./templates/compareScenarios.html'),
     compareScenarioTmpl = require('./templates/compareScenario.html'),
     compareModelingTmpl = require('./templates/compareModeling.html'),
-    compareModificationsTmpl = require('./templates/compareModifications.html'),
-    cropTypes = require('../core/cropTypes.json');
+    compareModificationsTmpl = require('./templates/compareModifications.html');
 
 var CompareWindow = Marionette.LayoutView.extend({
     //model: modelingModels.ProjectModel,

--- a/src/icp/js/src/compare/views.js
+++ b/src/icp/js/src/compare/views.js
@@ -13,7 +13,8 @@ var _ = require('lodash'),
     compareScenariosTmpl = require('./templates/compareScenarios.html'),
     compareScenarioTmpl = require('./templates/compareScenario.html'),
     compareModelingTmpl = require('./templates/compareModeling.html'),
-    compareModificationsTmpl = require('./templates/compareModifications.html');
+    compareModificationsTmpl = require('./templates/compareModifications.html'),
+    cropTypes = require('../core/cropTypes.json');
 
 var CompareWindow = Marionette.LayoutView.extend({
     //model: modelingModels.ProjectModel,
@@ -210,7 +211,7 @@ var CompareModelingView = Marionette.LayoutView.extend({
     updateResult: function() {
         var selection = this.ui.resultSelector.val();
 
-        this.model.get('results').setActive(selection);
+        this.model.get('results').setActiveByAttribute("displayName", selection);
         this.showResult();
 
         _.forEach(this.scenariosView.modelingViews, function(sibling) {
@@ -218,7 +219,7 @@ var CompareModelingView = Marionette.LayoutView.extend({
                 return;
             } else {
                 sibling.ui.resultSelector.val(selection);
-                sibling.model.get('results').setActive(selection);
+                sibling.model.get('results').setActiveByAttribute("displayName", selection);
                 sibling.showResult();
             }
         });
@@ -233,8 +234,9 @@ var CompareModelingView = Marionette.LayoutView.extend({
         this.resultRegion.show(new ResultView({
             areaOfInterest: this.projectModel.get('area_of_interest'),
             model: resultModel,
+            currentConditions: _.head(this.projectModel.get('scenarios').models),
             scenario: this.model,
-            compareMode: true
+            compareMode: true,
         }));
     },
 

--- a/src/icp/js/src/core/chart.js
+++ b/src/icp/js/src/core/chart.js
@@ -88,12 +88,30 @@ function renderVerticalBarChart(chartEl, data, options) {
         }
     }
 
+    function addBarClasses() {
+        var bars = $(chartEl).find('.nv-bar'),
+            oldClass,
+            newClass;
+
+        _.each(bars, function(bar, i) {
+            // Can't use addClass on SVG elements.
+            oldClass = $(bar).attr('class');
+            newClass = oldClass + ' ' + options.barClasses[i];
+            $(bar).attr('class', newClass);
+            $(bar).attr('style', '');
+        });
+    }
+
     function updateChart() {
         if($svg.is(':visible')) {
             setChartWidth();
             chart
                 .staggerLabels($svg.width() < widthCutoff)
                 .update(); // Throws error if updating a hidden svg.
+
+            if (options.barClasses) {
+                addBarClasses();
+            }
         }
     }
 
@@ -111,6 +129,10 @@ function renderVerticalBarChart(chartEl, data, options) {
              .staggerLabels($svg.width() < widthCutoff)
              .duration(0)
              .margin(options.margin);
+
+        if (options.yAxisDomain) {
+            chart.yDomain(options.yAxisDomain);
+        }
 
         setChartWidth();
         // Throws error if this is not set to false for unknown reasons.
@@ -134,6 +156,10 @@ function renderVerticalBarChart(chartEl, data, options) {
         d3.select(svg)
             .datum(data)
             .call(chart);
+
+        if (options.barClasses) {
+            addBarClasses();
+        }
 
         nv.utils.windowResize(updateChart);
         // The bar-chart:refresh event occurs when switching tabs which requires

--- a/src/icp/js/src/modeling/models.js
+++ b/src/icp/js/src/modeling/models.js
@@ -81,9 +81,21 @@ var ResultCollection = Backbone.Collection.extend({
         return this.findWhere({name: name});
     },
 
+    getResultByAttribute(attribute, value) {
+        var d = {};
+        d[attribute] = value;
+        return this.findWhere(d);
+    },
+
     setActive: function(name) {
         this.invoke('set', 'active', false);
         this.getResult(name).set('active', true);
+        this.trigger('change:active');
+    },
+
+    setActiveByAttribute: function(attribute, value) {
+        this.invoke('set', 'active', false);
+        this.getResultByAttribute(attribute, value).set('active', true);
         this.trigger('change:active');
     },
 
@@ -93,7 +105,7 @@ var ResultCollection = Backbone.Collection.extend({
 
     makeFirstActive: function() {
         this.setActive(this.at(0).get('name'));
-    }
+    },
 });
 
 var ProjectModel = Backbone.Model.extend({

--- a/src/icp/js/src/modeling/yield/views.js
+++ b/src/icp/js/src/modeling/yield/views.js
@@ -4,14 +4,12 @@ var $ = require('jquery'),
     _ = require('underscore'),
     Backbone = require('../../../shim/backbone'),
     Marionette = require('../../../shim/backbone.marionette'),
-    AoiVolumeModel = require('../models').AoiVolumeModel,
     chart = require('../../core/chart.js'),
     barChartTmpl = require('../../core/templates/barChart.html'),
     resultTmpl = require('./templates/result.html'),
     tableRowTmpl = require('./templates/tableRow.html'),
     tableTmpl = require('./templates/table.html'),
-    cropTypes = require('../../core/cropTypes.json'),
-    utils = require('../../core/utils.js');
+    cropTypes = require('../../core/cropTypes.json');
 
 var ResultView = Marionette.LayoutView.extend({
     className: 'tab-pane',
@@ -37,7 +35,7 @@ var ResultView = Marionette.LayoutView.extend({
 
     initialize: function(options) {
         this.compareMode = options.compareMode;
-        this.isCurrentConditions = options.scenario.get('is_current_conditions')
+        this.isCurrentConditions = options.scenario.get('is_current_conditions');
         this.currentConditionsModel = options.currentConditions.get('results').models[0];
     },
 
@@ -48,10 +46,10 @@ var ResultView = Marionette.LayoutView.extend({
             var scenarioResults = this.model.get('result'),
                 currentConditionsResults = this.currentConditionsModel.get('result'),
                 filteredScenarioResults = _.pick(scenarioResults, function(value, key) {
-                    return value !== 0 || currentConditionsResults[key] !== 0
+                    return value !== 0 || currentConditionsResults[key] !== 0;
                 }),
                 filteredCurrentConditionsResults = _.pick(currentConditionsResults, function(value, key) {
-                    return value !== 0 || scenarioResults[key] !== 0
+                    return value !== 0 || scenarioResults[key] !== 0;
                 });
             if (this.compareMode) {
                 this.chartRegion.show(new CompareChartView({
@@ -186,7 +184,6 @@ var CompareChartView = Marionette.ItemView.extend({
     addChart: function() {
         var chartEl = this.$el.find('.bar-chart').get(0),
             result = this.model.get('result'),
-            seriesDisplayNames = null,
             data,
             chartOptions;
 

--- a/src/icp/js/src/modeling/yield/views.js
+++ b/src/icp/js/src/modeling/yield/views.js
@@ -185,17 +185,33 @@ var CompareChartView = Marionette.ItemView.extend({
 
     addChart: function() {
         var chartEl = this.$el.find('.bar-chart').get(0),
-            result = null,
+            result = this.model.get('result'),
             seriesDisplayNames = null,
             data,
             chartOptions;
 
+        function getData(result) {
+            return [{
+                key: cropTypes[result.key],
+                values: [{ x: "", y: result.value}],
+                class: 'crop-' + result.key
+            }];
+        }
+
         $(chartEl).empty();
         if (result) {
-            data = null;
-            chartOptions = null;
+            data = getData(result),
+            chartOptions = {
+                yAxisLabel: 'Yield Per Acre',
+                barClasses: _.pluck(data, 'class'),
+                yAxisUnit: 'bu / A',
+                margin: {top: 20, right: 0, bottom: 40, left: 60},
+                showLegend: false,
+                disableToggle: true,
+                yAxisDomain: [0,100]
+            };
 
-            chart.renderGroupedVerticalBarChart(chartEl, data, chartOptions);
+            chart.renderVerticalBarChart(chartEl, data, chartOptions);
         }
     }
 });


### PR DESCRIPTION
This adds stacked bar charts to the Compare view, for the baseline and for each scenario.

For example, if the basic modelling view looks like this:
![download 10](https://cloud.githubusercontent.com/assets/18290666/21655185/f80763a6-d286-11e6-90e1-efbcb5d48240.png)


The Compare view now looks like this:
![download 11](https://cloud.githubusercontent.com/assets/18290666/21655197/00eb6b20-d287-11e6-9ced-ffd5fa045da8.png)

To test:
* clone this branch and open the app
* draw some AoI that has nonzero crop data somewhere within it and create at least one scenario with some set of modifications
* when the model has completed, open the "Compare" view and check that the stacked bar charts have been drawn and look accurate

Connects #94 