### PR TITLE
Consistent polling behavior

### DIFF
--- a/src/icp/js/src/core/models.js
+++ b/src/icp/js/src/core/models.js
@@ -85,7 +85,7 @@ var MapModel = Backbone.Model.extend({
 
 var TaskModel = Backbone.Model.extend({
     defaults: {
-        pollInterval: 500,
+        pollInterval: 1000,
         /* The timeout is set to 45 seconds here, while in the
            src/icp/apps/modeling/tasks.py file it is set to 42
            seconds.  That was done because the countdown starts in the

--- a/src/icp/js/src/core/models.js
+++ b/src/icp/js/src/core/models.js
@@ -107,6 +107,7 @@ var TaskModel = Backbone.Model.extend({
     // by previous calls to pollForResults will be rejected.
     reset: function() {
         this.set({
+            'inputmod_hash': null,
             'job': null,
             'result': null,
             'status': null
@@ -126,6 +127,8 @@ var TaskModel = Backbone.Model.extend({
         });
 
         this.reset();
+        this.set('inputmod_hash', taskHelper.inputmod_hash);
+
         if (taskHelper.onStart) {
             taskHelper.onStart();
         }

--- a/src/icp/js/src/modeling/models.js
+++ b/src/icp/js/src/modeling/models.js
@@ -423,6 +423,7 @@ var ScenarioModel = Backbone.Model.extend({
 
         this.set('taskModel', App.currentProject.createTaskModel());
         this.set('results', App.currentProject.createTaskResultCollection());
+        this.get('results').on('change', this.attemptSave, this);
     },
 
     attemptSave: function() {

--- a/src/icp/js/src/modeling/models.js
+++ b/src/icp/js/src/modeling/models.js
@@ -615,8 +615,12 @@ var ScenarioModel = Backbone.Model.extend({
                     results.setNullResults();
                 },
 
-                pollEnd: function() {
-                    results.setPolling(false);
+                pollEnd: function(endType) {
+                    // Jobs are cancelled by starting a new job with
+                    // updated input, continue to poll in that case.
+                    if (!endType.cancelledJob) {
+                        results.setPolling(false);
+                    }
                     self.attemptSave();
                 },
 


### PR DESCRIPTION
#### Overview
With the changes introduced for editing current conditions (CC), sharing modifications and the workflow that assumes the user will spend some time on CC, there were some inconsistent behavior introduced for when a scenario would poll for results, when that polling would be cancelled and when that polling would be diverted and just use an existing scenario's result. This PR adds additional guards to make sure that scenarios poll for results as expected

Connects #98 

#### Testing
Generally, adding modifications or changing inputs on any scenario should ultimately update that scenario, without interference from work on other scenarios. Some specifics to check:
* Multiple scenarios can be edited sequentially without waiting for polling to complete on any given one
* Switching tabs while scenarios are polling should not alter their in-progress polling
* When a scenario is equivalent to CC, it should quickly just display those pre-computed results
* When modifying CC and there are several scenarios, those scenarios don't poll until they are activated.
* Reloaded a saved project should not reinstate any polling for new results (assuming you let the results complete before reloading)
* Doing sequential modification on a scenario, without letting the polling complete, should cancel the previous polling and start a new one.  The "polling" spinner should also remain visible after the second polling sequence has begun, as appropriate.