### PR TITLE
Report output as average of relative crop yield

### DIFF
--- a/src/icp/js/src/core/chart.js
+++ b/src/icp/js/src/core/chart.js
@@ -267,6 +267,7 @@ function renderGroupedVerticalBarChart(chartEl, data, options) {
             .disableToggle(options.disableToggle)
             .reverse(options.reverseLegend)
             .rightAlign(false);
+        chart.yAxis.ticks(5);
         chart.tooltip.enabled(true);
         handleCommonOptions(chart, options);
 
@@ -274,6 +275,10 @@ function renderGroupedVerticalBarChart(chartEl, data, options) {
             chart.tooltip.valueFormatter(function(d) {
                 return chart.yAxis.tickFormat()(d) + ' ' + options.yAxisUnit;
             });
+        }
+
+        if (options.yAxisDomain) {
+            chart.yDomain(options.yAxisDomain);
         }
 
         if (options.seriesColors) {

--- a/src/icp/js/src/modeling/yield/templates/table.html
+++ b/src/icp/js/src/modeling/yield/templates/table.html
@@ -2,10 +2,10 @@
     <thead>
         <tr>
             <th data-sortable="true">Crop</th>
-            <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Yield Per Acre</th>
             {% if not isCurrentConditions %}
-                <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Yield Per Acre Under Current Conditions</th>
+                <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Baseline Yield</th>
             {% endif %}
+            <th class="text-left" data-sortable="true" data-sorter="window.numericSort">Scenario Yield</th>
         </tr>
     </thead>
     <tbody>

--- a/src/icp/js/src/modeling/yield/templates/tableRow.html
+++ b/src/icp/js/src/modeling/yield/templates/tableRow.html
@@ -1,5 +1,5 @@
 <td>{{ cropType }}</td>
-<td class="strong text-right">{{ scenarioYield|round(3)|toLocaleString(3) }}</td>
 {% if not isCurrentConditions %}
     <td class="strong text-right">{{ currentConditionsYield|round(3)|toLocaleString(3) }}</td>
 {% endif %}
+<td class="strong text-right">{{ scenarioYield|round(3)|toLocaleString(3) }}</td>

--- a/src/icp/js/src/modeling/yield/views.js
+++ b/src/icp/js/src/modeling/yield/views.js
@@ -154,9 +154,11 @@ var ChartView = Marionette.ItemView.extend({
             data = formatData(this.options.currentConditionsResults,
                 this.options.scenarioResults, this.options.isCurrentConditions),
             chartOptions = {
-                yAxisLabel: 'Yield Per Acre',
+                yAxisLabel: 'Relative Yield',
+                yAxisUnit: 'Relative Yield',
                 showLegend: false,
-                barClasses: _.pluck(_.flatten(_.pluck(data, 'values')), 'class')
+                barClasses: _.pluck(_.flatten(_.pluck(data, 'values')), 'class'),
+                yAxisDomain: [0,100]
             };
 
         chart.renderGroupedVerticalBarChart(chartEl, data, chartOptions);
@@ -164,7 +166,6 @@ var ChartView = Marionette.ItemView.extend({
 });
 
 var CompareChartView = Marionette.ItemView.extend({
-    // TODO Render yield chart, filterable by crop
     template: barChartTmpl,
 
     className: 'chart-container yield-chart-container',
@@ -199,9 +200,9 @@ var CompareChartView = Marionette.ItemView.extend({
         if (result) {
             data = getData(result),
             chartOptions = {
-                yAxisLabel: 'Yield Per Acre',
+                yAxisLabel: 'Relative Yield',
                 barClasses: _.pluck(data, 'class'),
-                yAxisUnit: 'bu / A',
+                yAxisUnit: 'Relative Yield',
                 margin: {top: 20, right: 0, bottom: 40, left: 60},
                 showLegend: false,
                 disableToggle: true,
@@ -213,7 +214,7 @@ var CompareChartView = Marionette.ItemView.extend({
     }
 });
 
-var formatResultsFromModel = function(results, seriesName, isCurrentConditionsData) {
+var formatResultsFromModel = function(results, seriesName, useCurrentConditionsClass) {
     return {
         key: seriesName,
         values: _.map(results, function(value, key) {
@@ -221,7 +222,7 @@ var formatResultsFromModel = function(results, seriesName, isCurrentConditionsDa
                 x: cropTypes[key],
                 y: value,
                 class: 'crop-' + key +
-                        (isCurrentConditionsData ? ' current-conditions' : ' scenario'),
+                        (useCurrentConditionsClass ? ' current-conditions' : ' scenario'),
             };
         })
     };
@@ -230,14 +231,14 @@ var formatResultsFromModel = function(results, seriesName, isCurrentConditionsDa
 var formatData = function(currentConditionsResults, scenarioResults, isCurrentConditions) {
     var data = [
         formatResultsFromModel(currentConditionsResults, "Current Conditions",
-            true),
+            isCurrentConditions ? false : true),
     ];
     if (!isCurrentConditions) {
-        data.push(formatResultsFromModel(scenarioResults, "Scenario",
+        data.push(formatResultsFromModel(scenarioResults, "This Scenario",
             false));
     }
     // Make the scenario be the leftmost bar
-    return data.reverse();
+    return data;
 };
 
 

--- a/src/icp/pollinator/src/pollinator/crop_yield.py
+++ b/src/icp/pollinator/src/pollinator/crop_yield.py
@@ -17,7 +17,6 @@ RASTER_PATH = '/opt/icp-crop-data/cdl_reclass_lzw_5070.tif'
 
 SETTINGS = {}
 ABUNDANCE_IDX = 0.1  # A constant for managing wild bee yield
-ACRES_PER_SQM = 0.000247105
 CELL_SIZE = 30
 FORAGE_DIST = 670
 AG_CLASSES = [12, 16, 17, 18, 20, 27, 33, 46, 47]
@@ -151,11 +150,10 @@ def yield_calc(crop_id, abundance, managed_hives, config):
 
 def aggregate_crops(yield_field, cdl_field, crops=AG_CLASSES):
     """
-    Within the unmasked field portion of the provided yield_field, sum the
+    Within the unmasked field portion of the provided yield_field, avg the
     yield quantities per ag type, resulting in a total yield increase per
-    relavent crop type on the field and report the yield in terms of yield
-    per acre, to create a uniform unit for comparisons.
-
+    relavent crop type on the field and report the yield in terms of average
+    crop yield on a scale of 0-100
     Args:
         yield_field (masked ndarray): The bee shed area of computed yield with
             a mask of the field applied.
@@ -165,42 +163,26 @@ def aggregate_crops(yield_field, cdl_field, crops=AG_CLASSES):
             defaults to system specified list
 
     Returns:
-        dict<cld_id, yield_sum>: A mapping of bee pollinated agricultural
-            CDL crop types with the sum of their yield across the field
-            portion of the yield data, reported in per acre units
+        dict<cld_id, yield_avg>: A mapping of bee pollinated agricultural
+            CDL crop types with the avg of their yield across the field
+            portion of the yield data, reported on 0-100 scale
     """
-
-    # Get a count of the number of cells of each crop type in the field
-    values, counts = np.unique(cdl_field.compressed(), return_counts=True)
-    crop_counts = dict(zip(values, counts))
 
     crop_yields = {}
     field_mask = yield_field.mask.copy()
 
-    # Sum the yield for each each crop type cell, by crop
+    # Average the yield for each each crop type cell, by crop
     for crop in crops:
-        num_cells = crop_counts.get(crop, 0)
+        # Create a mask for values that are not this crop type and include
+        # the mask which is already applied to non-field areas of AoI
+        cdl_mask = np.ma.masked_where(cdl_field != crop, cdl_field).mask
+        crop_mask = np.ma.mask_or(field_mask, cdl_mask)
 
-        # If there are no cells of this crop type, skip the work of finding
-        # that out again
-        if num_cells:
-            # Create a mask for values that are not this crop type and include
-            # the mask which is already applied to non-field areas of AoI
-            cdl_mask = np.ma.masked_where(cdl_field != crop, cdl_field).mask
-            crop_mask = np.ma.mask_or(field_mask, cdl_mask)
+        # Average the yield from this one crop only over the field
+        yield_field.mask = crop_mask
+        crop_yield = np.ma.mean(yield_field).item() * 100 or 0
 
-            # Sum the yield from this one crop only over the field
-            yield_field.mask = crop_mask
-            crop_yield = np.ma.sum(yield_field).item()
-
-            # Determine the approximate area in acres which this crop covers
-            # in the field, and calculate the per acre yield
-            crop_acres = CELL_SIZE * ACRES_PER_SQM * num_cells
-            yield_per_acre = crop_yield / crop_acres
-            crop_yields[str(crop)] = yield_per_acre
-
-        else:
-            crop_yields[str(crop)] = 0
+        crop_yields[str(crop)] = crop_yield
 
     # Restore the original mask of just the field
     yield_field.mask = field_mask

--- a/src/icp/pollinator/tests/tests.py
+++ b/src/icp/pollinator/tests/tests.py
@@ -7,8 +7,7 @@ import numpy as np
 from shapely.geometry import Polygon
 
 from pollinator import raster_ops
-from pollinator.crop_yield import aggregate_crops, yield_calc, \
-    ACRES_PER_SQM, CELL_SIZE
+from pollinator.crop_yield import aggregate_crops, yield_calc
 
 
 class ReadTests(unittest.TestCase):
@@ -82,8 +81,8 @@ class ReadTests(unittest.TestCase):
 class ModelTests(unittest.TestCase):
     def setUp(self):
         # Simulate an area with a sub section unmasked
-        shed = np.array([1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4])
-        field_mask =    [1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1]  # noqa
+        shed = np.array([.1, .1, .1, .2, .2, .2, .3, .3, .3, .4, .4, .4])
+        field_mask =    [ 1,  1,  1,  1,  0,  0,  0,  0,  0,  1,  1,  1]  # noqa
         shed.shape = (3, 4)
         self.yield_field = np.ma.masked_array(shed, mask=field_mask)
 
@@ -93,17 +92,16 @@ class ModelTests(unittest.TestCase):
         self.cdl = np.ma.masked_array(cdl, mask=field_mask)
 
     def test_aggregation(self):
-        # Crop types 100 and 400 are completely outside of unmasked field area,
-        # and types 200 & 300 each have one pixel outside the area
+        # Crop types 100 and 400 are completely outside of unmasked field area
         crops = [100, 200, 300, 400]
         yield_by_crop = aggregate_crops(self.yield_field, self.cdl, crops)
 
-        # Expect the values to be the sum / cell count * 30m * acres per m
+        # Expect the values to be the mean yield value per crop
         # Crops that were masked out should be 0
         expected = {
             '100': 0,
-            '200': 4 / (2 * CELL_SIZE * ACRES_PER_SQM),
-            '300': 9 / (3 * CELL_SIZE * ACRES_PER_SQM),
+            '200': .4 / 2 * 100,
+            '300': .9 / 3 * 100,
             '400': 0
         }
 

--- a/src/icp/sass/components/_charts.scss
+++ b/src/icp/sass/components/_charts.scss
@@ -27,8 +27,8 @@
     }
   }
 
-  .scenario { fill-opacity: 0.4; }
-  .current-conditions { fill-opacity: 0.8; }
+  .scenario { fill-opacity: 0.8; }
+  .current-conditions { fill-opacity: 0.4; }
 
   svg {
     width: 450px;


### PR DESCRIPTION
#### Overview
Replace per acre yield with mean relative yield. Summing the yield values across a crop was a misuse of the yield value. It is more appropriate to simply average the crop yield cells and report that as the final crop yield value.  Reports out values on a 0-100 scale instead of 0-1.

Additionally updates charts to use 0-100 fixed scale and makes some small changes to
order and opacity between current conditions and the current scenario.

Connects #101 
Connects #102 

![screenshot from 2017-01-13 22 42 46](https://cloud.githubusercontent.com/assets/1014341/21952120/18268ccc-d9e2-11e6-9926-236bed0f1fee.png)
![screenshot from 2017-01-13 22 27 00](https://cloud.githubusercontent.com/assets/1014341/21952121/18274a0e-d9e2-11e6-97f5-56a8ca2fd531.png)
![screenshot from 2017-01-13 22 29 10](https://cloud.githubusercontent.com/assets/1014341/21952119/18264852-d9e2-11e6-99d5-c17786b2c6ac.png)

#### Testing
* Reprovision worker to install new model
* Check model tests pass
* Model results are returned as 0-100, and cannot be larger, even with high managed hive/acre counts
* Charts & Table are updated:
    * Style is similar between compare and scenario
    * CC comes first and is the lighter shade
    * CC is darker shade on CC tab
    * Output is labeled Relative Yield and not Yield Per Acre