### PR TITLE
Remove tooltip when chart is removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ $ aws configure --profile icp-stg
 ```
 
 Next, ensure you have the CDL raster data available to the worker machine.  This can be done, on your host:
-* Create the file at `/opt/icp-crop-data/cdl_5070.tif`, or
-* Add the `cdl_5070.tif` file at a directory of your choosing, and set an environment variable `ICP_DATA_DIR` to it. 
+* Get the file `cdl_reclass_lzw_5070.tif` off of a USB stick
+* Copy the file to `/opt/icp-crop-data/cdl_reclass_lzw_5070.tif`, or
+* Add the `cdl_reclass_lzw_5070.tif` file at a directory of your choosing, and set an environment variable `ICP_DATA_DIR` to it.
 
 Then, use the following command to bring up a local development environment:
 
@@ -49,10 +50,10 @@ $ ./scripts/manage.sh migrate
 $ ./scripts/bundle.sh
 ```
 
-To load or reload data, from an `app` server, run (`scripts` is not mounted by default to the VM, you may need to copy the file over):
+To load or reload data, from an `app` server, run
 
 ```bash
-$ ./scripts/setupdb.sh
+$ /vagrant/scripts/aws/setupdb.sh
 ```
 
 Note that if you receive out of memory errors while loading the data, you may want to increase the RAM on your `services` VM (1512 MB may be all that is necessary).

--- a/src/icp/js/src/core/chart.js
+++ b/src/icp/js/src/core/chart.js
@@ -7,6 +7,20 @@ var d3 = require('d3'),
 
 var widthCutoff = 400;
 
+// Make jQuery handle destroyed event. This is needed so that
+// removeTooltipOnDestroy will work.
+// http://stackoverflow.com/questions/2200494/
+// jquery-trigger-event-when-an-element-is-removed-from-the-dom
+(function($) {
+    $.event.special.destroyed = {
+        remove: function(o) {
+            if (o.handler) {
+                o.handler();
+            }
+        }
+    };
+})($);
+
 function makeSvg(el) {
     // For some reason, the chart will only render if the style is
     // defined inline, even if it is blank.
@@ -297,6 +311,8 @@ function renderGroupedVerticalBarChart(chartEl, data, options) {
         // The bar-chart:refresh event occurs when switching tabs which requires
         // redrawing the chart.
         $(chartEl).on('bar-chart:refresh', updateChart);
+
+        removeTooltipOnDestroy(chartEl, chart.tooltip);
 
         return chart;
     });


### PR DESCRIPTION
 In the analyze view, when the tooltip is displayed and new results arrived, a second tooltip appears. This PR fixes this problem by removing the tooltip when the chart is removed. This was first fixed in https://github.com/WikiWatershed/model-my-watershed/pull/1574.

#### Testing
* Go to the analyze view. 
* Make a modification.
* Hover over a bar in the bar chart so a tooltip appears.
* When the new results come back the tooltip should disappear. Moving the mouse should make a new tooltip appear.

Connects #109 