### PR TITLE
Allow Compare All

### DIFF
--- a/src/icp/js/src/compare/controllers.js
+++ b/src/icp/js/src/compare/controllers.js
@@ -4,8 +4,7 @@ var _ = require('lodash'),
     App = require('../app'),
     router = require('../router').router,
     views = require('./views'),
-    modelingModels = require('../modeling/models.js'),
-    cropTypes = require('../core/cropTypes.json');
+    modelingModels = require('../modeling/models.js');
 
 var CompareController = {
     compare: function(projectId) {
@@ -75,63 +74,6 @@ function setupProjectCopy(aoi_census) {
 
     App.user.on('change:guest', saveAfterLogin);
     App.origProject.on('change:id', updateUrl);
-
-    /* transform the result models for display: each result object with n
-        actual "result data" objects is mapped to n result objects, which are
-        clones with only a single data item; doing so permits the
-        comparison view to invert the aggregation scheme, such that it
-        displays multiple selectable items of the same "type" rather than
-        a group of items of the same (selectable) "type"
-    */
-    var currentScenarios = App.currentProject.get('scenarios').models;
-
-    var displayModels = _.map(currentScenarios, function(scenarioModel) {
-        var resultModels = scenarioModel.get('results').models;
-        var transformedModels = _.map(resultModels, function (r) {
-            var results = r.get('result');
-            var clones = _.map(results, function (value, key) {
-                var clone = r.clone();
-                clone.set('result', { key: key, value: value });
-                clone.set('displayName', cropTypes[key]);
-                return clone;
-            });
-            return clones;
-        });
-
-        // transformedModels is an array type but will always have a single element,
-        // taking the head of the list is a vestigial necessity from the original
-        // MMW implementation
-        return _.head(transformedModels);
-    });
-
-    // filter models for those with nonzero data in any scenario
-    var nonzeroCrops = _.chain(displayModels)
-        .flatten()
-        .map(function(d) { return d.get('result'); })
-        .filter(function(d) { return d.value !== 0; })
-        .pluck('key')
-        .uniq()
-        .value();
-
-    var filteredModels = _.map(displayModels, function(displayModel) {
-        var filteredResults = _.filter(displayModel, function(resultModel) {
-            return _.contains(nonzeroCrops, resultModel.get('result').key);
-        });
-        return filteredResults;
-    });
-    
-    // defaultResults is used for scenario(s) with no modifications
-    var defaultResults = _.head(filteredModels);
-
-    // pair scenarios with their filtered result models and update
-    _.each(_.zip(currentScenarios, filteredModels), function(pair) {
-        var scenarioModel = pair[0];
-        var newResultsModel = pair[1];
-        if (_.size(newResultsModel) === 0) {
-            newResultsModel = defaultResults;
-        }
-        scenarioModel.get('results').models = newResultsModel;
-    });
 }
 
 // Creates a special-purpose copy of the project

--- a/src/icp/js/src/compare/templates/compareModeling.html
+++ b/src/icp/js/src/compare/templates/compareModeling.html
@@ -5,9 +5,10 @@
     {% endif %}
     <div class="pull-right">
         <select class="form-control btn btn-small btn-primary">
-            {% for result in results %}
-                <option value="{{ result.displayName }}" {{ "selected" if result.active }}>
-                    {{ result.displayName }}
+            <option value="all">All Crops</option>
+            {% for crop in chartableCrops %}
+                <option value="{{ crop }}">
+                    {{ cropTypes[crop] }}
                 </option>
             {% endfor %}
         </select>

--- a/src/icp/js/src/core/chart.js
+++ b/src/icp/js/src/core/chart.js
@@ -58,136 +58,6 @@ function removeTooltipOnDestroy(chartEl, tooltip) {
 }
 
 /*
-    Renders a stacked vertical bar chart for multiple series of data
-    with a legend.
-
-    data is of the form
-    [
-        {
-            key: series-name,
-            values: [
-                {
-                    x: ...,
-                    y: ...
-                },
-                ...
-            ]
-        },
-        ...
-   ]
-   where a series corresponds to a group of data that will be
-   displayed with the same color/legend item. Eg. Runoff
-
-   options includes: margin, yAxisLabel, yAxisUnit, seriesColors,
-   isPercentage, maxBarWidth, abbreviateTicks, reverseLegend, and
-   disableToggle
-*/
-function renderVerticalBarChart(chartEl, data, options) {
-    var chart = nv.models.multiBarChart(),
-        svg = makeSvg(chartEl),
-        $svg = $(svg);
-
-    function setChartWidth() {
-        // Set chart width to ensure that bars (and their padding)
-        // are no wider than maxBarWidth.
-        var numBars = getNumBars(data),
-            maxWidth = options.margin.left + options.margin.right +
-                       numBars * options.maxBarWidth,
-            actualWidth = $svg.width();
-
-        if (actualWidth > maxWidth) {
-           chart.width(maxWidth);
-        } else {
-           chart.width(actualWidth);
-        }
-    }
-
-    function addBarClasses() {
-        var bars = $(chartEl).find('.nv-bar'),
-            oldClass,
-            newClass;
-
-        _.each(bars, function(bar, i) {
-            // Can't use addClass on SVG elements.
-            oldClass = $(bar).attr('class');
-            newClass = oldClass + ' ' + options.barClasses[i];
-            $(bar).attr('class', newClass);
-            $(bar).attr('style', '');
-        });
-    }
-
-    function updateChart() {
-        if($svg.is(':visible')) {
-            setChartWidth();
-            chart
-                .staggerLabels($svg.width() < widthCutoff)
-                .update(); // Throws error if updating a hidden svg.
-
-            if (options.barClasses) {
-                addBarClasses();
-            }
-        }
-    }
-
-    options = options || {};
-    _.defaults(options, {
-        margin: {top: 20, right: 30, bottom: 40, left: 60},
-        maxBarWidth: 150
-    });
-
-    nv.addGraph(function() {
-        chart.showLegend(options.showLegend || false)
-             .showControls(false)
-             .stacked(true)
-             .reduceXTicks(false)
-             .staggerLabels($svg.width() < widthCutoff)
-             .duration(0)
-             .margin(options.margin);
-
-        if (options.yAxisDomain) {
-            chart.yDomain(options.yAxisDomain);
-        }
-
-        setChartWidth();
-        // Throws error if this is not set to false for unknown reasons.
-        chart.legend
-            .disableToggle(options.disableToggle)
-            .reverse(options.reverseLegend)
-            .rightAlign(false);
-        chart.tooltip.enabled(true);
-        chart.yAxis.ticks(5);
-        handleCommonOptions(chart, options);
-
-        if (options.yAxisUnit) {
-            chart.tooltip.valueFormatter(function(d) {
-                return chart.yAxis.tickFormat()(d) + ' ' + options.yAxisUnit;
-            });
-        }
-        if (options.seriesColors) {
-            chart.color(options.seriesColors);
-        }
-
-        d3.select(svg)
-            .datum(data)
-            .call(chart);
-
-        if (options.barClasses) {
-            addBarClasses();
-        }
-
-        nv.utils.windowResize(updateChart);
-        // The bar-chart:refresh event occurs when switching tabs which requires
-        // redrawing the chart.
-        $(chartEl).on('bar-chart:refresh', updateChart);
-
-        removeTooltipOnDestroy(chartEl, chart.tooltip);
-
-        return chart;
-    });
-}
-
-
-/*
     Renders a grouped vertical bar chart for multiple series of data
     with a legend.
 
@@ -226,14 +96,21 @@ function renderGroupedVerticalBarChart(chartEl, data, options) {
             newClass;
 
         _.each(bars, function(bar, i) {
-            // Can't use addClass on SVG elements.
-            oldClass = $(bar).attr('class');
-            newClass = oldClass + ' ' + options.barClasses[i];
-            $(bar).attr('class', newClass);
+            var $bar = $(bar),
+                newClass = options.barClasses[i];
+
+            addSvgClass($bar, newClass);
             $(bar).attr('style', '');
         });
     }
 
+    function addSvgClass($el, newClass) {
+        // Can't use $.addClass on SVG elements.
+        var oldClass = $el.attr('class') || '';
+        newClass = oldClass + ' ' + newClass;
+        $el.attr('class', newClass);
+
+    }
     function setChartWidth() {
         // Set chart width to ensure that bars (and their padding)
         // are no wider than maxBarWidth.
@@ -252,8 +129,8 @@ function renderGroupedVerticalBarChart(chartEl, data, options) {
     function updateChart() {
         if($svg.is(':visible')) {
             setChartWidth();
-            chart
-                .update(); // Throws error if updating a hidden svg.
+            chart.update(); // Throws error if updating a hidden svg.
+
             if (options.barClasses) {
                 addBarClasses();
             }
@@ -274,6 +151,10 @@ function renderGroupedVerticalBarChart(chartEl, data, options) {
              .reduceXTicks(false)
              .duration(0)
              .margin(options.margin);
+
+        if (options.compareMode) {
+            addSvgClass($svg, 'compare');
+        }
 
         setChartWidth();
         // Throws error if this is not set to false for unknown reasons.
@@ -320,6 +201,5 @@ function renderGroupedVerticalBarChart(chartEl, data, options) {
 
 
 module.exports = {
-    renderVerticalBarChart: renderVerticalBarChart,
-    renderGroupedVerticalBarChart: renderGroupedVerticalBarChart,
+    renderGroupedVerticalBarChart: renderGroupedVerticalBarChart
 };

--- a/src/icp/js/src/modeling/models.js
+++ b/src/icp/js/src/modeling/models.js
@@ -97,7 +97,7 @@ var ResultCollection = Backbone.Collection.extend({
         return this.findWhere({name: name});
     },
 
-    getResultByAttribute(attribute, value) {
+    getResultByAttribute: function(attribute, value) {
         var d = {};
         d[attribute] = value;
         return this.findWhere(d);

--- a/src/icp/js/src/modeling/models.js
+++ b/src/icp/js/src/modeling/models.js
@@ -97,21 +97,9 @@ var ResultCollection = Backbone.Collection.extend({
         return this.findWhere({name: name});
     },
 
-    getResultByAttribute: function(attribute, value) {
-        var d = {};
-        d[attribute] = value;
-        return this.findWhere(d);
-    },
-
     setActive: function(name) {
         this.invoke('set', 'active', false);
         this.getResult(name).set('active', true);
-        this.trigger('change:active');
-    },
-
-    setActiveByAttribute: function(attribute, value) {
-        this.invoke('set', 'active', false);
-        this.getResultByAttribute(attribute, value).set('active', true);
         this.trigger('change:active');
     },
 

--- a/src/icp/sass/components/_charts.scss
+++ b/src/icp/sass/components/_charts.scss
@@ -33,5 +33,9 @@
   svg {
     width: 450px;
     height: 300px;
+
+    &.compare {
+      width: 300px;
+    }
   }
 }


### PR DESCRIPTION
#### Overview
Adds an "All Crops" option to the compare chart, to view all crops with values in the AoI.  The chart is generally optimized for showing up to 4 crop types, which is the upper end of what actual users might have.  Things tend to get squished above that value, but the client thinks the vast majority will have only two crop types at a time.  Also, tries to simplify the compare chart by reusing the existing chart rendering code and not modifying the format of the `ResultsModel`.

Connects #107 

![screenshot from 2017-01-20 10 53 11](https://cloud.githubusercontent.com/assets/1014341/22155780/b441a3b4-defe-11e6-8be8-aeb706cede6e.png)
![screenshot from 2017-01-20 10 53 27](https://cloud.githubusercontent.com/assets/1014341/22155779/b43cf4b8-defe-11e6-882a-a940dd51fb4a.png)

#### Testing
* Rebundle the front end assets `./scripts/bundle.sh --debug`
* Generate model results for a field that contains multiple crops
* In compare view, verify you can view all (up to 4) crops at once and still have the ability to choose single crop types.