### PR TITLE
Friendlier Crop Legend

### DIFF
--- a/src/icp/js/src/core/overlayControl.js
+++ b/src/icp/js/src/core/overlayControl.js
@@ -35,11 +35,16 @@ var OverlayControlView = Marionette.ItemView.extend({
 
     ui: {
         controlToggle: '.eye-button',
+        legendDropdown: '.crop-legend-dropdown > .dropdown-menu',
     },
 
     events: {
         'click @ui.controlToggle': 'toggle',
-        'mousedown input': 'handleMouseDownEvent',
+        'mouseover @ui.legendDropdown': 'disableMapScrollZoom',
+        'mouseout @ui.legendDropdown': 'enableMapScrollZoom',
+        'mousedown @ui.legendDropdown': 'disableMapDragging',
+        'mouseup @ui.legendDropdown': 'enableMapDragging',
+        'mousedown input': 'disableMapDragging',
         'mouseup input': 'handleMouseUpEvent',
     },
 
@@ -53,12 +58,24 @@ var OverlayControlView = Marionette.ItemView.extend({
         this.render();
     },
 
-    handleMouseDownEvent: function(e) {
+    disableMapScrollZoom: function() {
+        this.map.scrollWheelZoom.disable();
+    },
+
+    enableMapScrollZoom: function() {
+        this.map.scrollWheelZoom.enable();
+    },
+
+    disableMapDragging: function(e) {
         this.map.dragging.disable();
     },
 
-    handleMouseUpEvent: function(e) {
+    enableMapDragging: function() {
         this.map.dragging.enable();
+    },
+
+    handleMouseUpEvent: function(e) {
+        this.enableMapDragging();
         var el = $(e.target),
         sliderValue = el.val();
         this.layer.setOpacity(sliderValue / 100);

--- a/src/icp/js/src/core/overlayControl.js
+++ b/src/icp/js/src/core/overlayControl.js
@@ -29,17 +29,20 @@ var OverlayControlView = Marionette.ItemView.extend({
         this.map = options.map;
         this.layer = options.layer;
         this.isDisplayed = false;
+        this.isLegendOpen = false;
         this.initialOpacity = 0.50;
         this.layer.setOpacity(this.initialOpacity);
     },
 
     ui: {
         controlToggle: '.eye-button',
+        legendToggle: '.legend-button',
         legendDropdown: '.crop-legend-dropdown > .dropdown-menu',
     },
 
     events: {
         'click @ui.controlToggle': 'toggle',
+        'click @ui.legendToggle': 'toggleLegend',
         'mouseover @ui.legendDropdown': 'disableMapScrollZoom',
         'mouseout @ui.legendDropdown': 'enableMapScrollZoom',
         'mousedown @ui.legendDropdown': 'disableMapDragging',
@@ -51,10 +54,17 @@ var OverlayControlView = Marionette.ItemView.extend({
     toggle: function() {
         if (this.isDisplayed) {
             this.map.removeLayer(this.layer);
+            this.isLegendOpen = false;
         } else {
             this.map.addLayer(this.layer);
+            this.isLegendOpen = true;
         }
         this.isDisplayed = !this.isDisplayed;
+        this.render();
+    },
+
+    toggleLegend: function() {
+        this.isLegendOpen = !this.isLegendOpen;
         this.render();
     },
 
@@ -84,12 +94,13 @@ var OverlayControlView = Marionette.ItemView.extend({
 
     templateHelpers: function() {
         return {
-            legend: this.isDisplayed ? "open" : "",
+            isDisplayed: this.isDisplayed,
+            legend: this.isLegendOpen ? "open" : "",
             cropTypes: cropTypes,
             iconClass: this.isDisplayed ? "fa fa-eye-slash" : "fa fa-eye",
             inputType: this.isDisplayed ? "range" : "hidden",
             layerName: 'Crop Layer',
-            initialOpacity: this.initialOpacity * 100,
+            initialOpacity: this.layer.options.opacity * 100,
         };
     }
 });

--- a/src/icp/js/src/core/templates/overlayControl.html
+++ b/src/icp/js/src/core/templates/overlayControl.html
@@ -21,5 +21,8 @@
             value="{{ initialOpacity }}"
         >
         <i class="eye-button {{ iconClass }}"></i>
+        {% if isDisplayed %}
+            <i class="legend-button {{ legend }} fa fa-th-list"></i>
+        {% endif %}
     </a>
 </div>

--- a/src/icp/sass/components/_buttons.scss
+++ b/src/icp/sass/components/_buttons.scss
@@ -191,3 +191,12 @@
   background-color: darken($ui-light, 5%);
   border: solid 1px darken($ui-light, 10%);
 }
+
+// Crop Layer Overlay Control
+.leaflet-bar a i.legend-button {
+  color: $black-39;
+
+  &.open {
+    color: $black-74;
+  }
+}

--- a/src/icp/sass/components/_dropdowns.scss
+++ b/src/icp/sass/components/_dropdowns.scss
@@ -177,8 +177,10 @@
     border-radius: 0;
     box-shadow: none;
     padding: 0.5rem;
-    overflow: scroll;
-    column-count: 4;
+    overflow-x: hidden;
+    overflow-y: scroll;
+    max-height: 8.5rem;
+    width: 100%;
   }
 
   .legend-color {


### PR DESCRIPTION
## Overview

Makes the crop layer legend smaller and more manageable for small screens. It is now also toggle-able, thus can be turned off when not needed.

Connects #108 

### Demo

![2017-01-23 15 05 05](https://cloud.githubusercontent.com/assets/1430060/22220662/91ef5c3a-e17d-11e6-8afb-cfb1b970e543.gif)

On Windows (and probably Linux) systems, a vertical scrollbar will also be visible:

![image](https://cloud.githubusercontent.com/assets/1430060/22220696/b709a7aa-e17d-11e6-8289-75545f99bcec.png)

### Notes

The original issue asked for potentially a hover-based solution. I didn't do that since it can lead to mistakes between moving the mouse from the overlay control to the legend, and scrolling within it. Hover based solutions are also inaccessible on touch devices.

Also tagging @jfrankl to get his feedback.

## Testing Instructions

 * Check out this branch, and run `bundle.sh` and go to [:8000/](http://localhost:8000/)
 * Open the crop layer overlay control. Ensure the legend pops up as well, and is only one column instead of the previous four.
 * Try scrolling the single column. Ensure you can scroll to see all values, and that the map does not zoom.
 * Try hiding the legend with the new legend button. Ensure the button dims when legend is hidden, and that the opacity scrollbar's position does not change.
 * Try closing and opening the overlay control. Ensure that the legend is always visible when the control opens, regardless of its state upon closing, and that the legend always closes with the control.
 * Change the opacity value and close the control. Enable it again. Ensure that the overlay scrollbar's position accurately reflects the layer's opacity, and is not set to 50%.
