### PR TITLE
Increase opacity slider click area + IE11 fix

### DIFF
--- a/src/icp/sass/components/_slider.scss
+++ b/src/icp/sass/components/_slider.scss
@@ -13,6 +13,12 @@
     &.slider-leaflet {
         background-color: transparent;
         cursor: pointer;
+        @media screen and (-webkit-min-device-pixel-ratio:0) {
+        /* Webkit only http://phrappe.com/css/conditional-css-for-webkit-based-browsers/ */
+            border-top: 11px solid transparent;
+            border-bottom: 11px solid transparent;
+        }
+        padding: 0;
 
         &::-webkit-slider-thumb {
             background: $black;
@@ -36,7 +42,8 @@
         }
 
         &::-moz-range-track {
-            background: $ui-primary;
+            background-color: $ui-primary;
+            height: 2px;
         }
         &::-moz-range-thumb {
             background: $black;
@@ -47,19 +54,24 @@
         }
 
         &::-ms-track {
+            color: transparent;
             background: transparent;
             border-color: transparent;
-            color: transparent;
+            width: 100%;
+            height: 2px;
+            cursor: pointer;
+            border-top: 11px solid transparent;
+            border-bottom: 11px solid transparent;
         }
         &::-ms-thumb {
             background: $black;
-            width: 14px;
-            height: 14px;
+            width: 12px;
+            height: 12px;
             border: 1px solid $black;
             border-radius: 50px;
         }
         &::-ms-fill-lower {
-            background:$ui-primary;
+            background: $ui-primary;
             border: $ui-primary;
         }
         &::-ms-fill-upper {


### PR DESCRIPTION
### Overview
Connects #123 

This PR adds a transparent border to the opacity slider to make it easier to click. It also fixes the styling on IE11 which previously looked like this (it's missing entirely):

![screen shot 2017-01-26 at 5 43 39 pm](https://cloud.githubusercontent.com/assets/7633670/22376957/22e55d2c-e47e-11e6-9274-ad6cae37360d.png)

### Demo

![opacityslider](https://cloud.githubusercontent.com/assets/7633670/22377073/79e9c2e8-e47e-11e6-9de9-195b57a742ee.gif)

### Testing instructions
Pull and bundle
- Test that the opacity slider looks okay and is easy to click (ie has a large hit target) on Chrome, Firefox, IE11 and Safari



