### PR TITLE
Decimal hive inputs

### DIFF
--- a/src/icp/js/src/modeling/controls.js
+++ b/src/icp/js/src/modeling/controls.js
@@ -237,7 +237,7 @@ var NumberOfHivesView = ControlView.extend({
     },
 
     onInputChange: function() {
-        var value = parseInt(this.ui.input.val());
+        var value = parseFloat(this.ui.input.val());
         this.addOrReplaceInput(new models.ModificationModel({
             name: this.getControlName(),
             value: value

--- a/src/icp/js/src/modeling/templates/controls/userInput.html
+++ b/src/icp/js/src/modeling/templates/controls/userInput.html
@@ -6,6 +6,7 @@
         id="{{ userInputName }}"
         value="{{ value }}"
         min="0"
+        step="0.1"
     >
     <div class="info-region"></div>
 </div>

--- a/src/icp/sass/base/_header.scss
+++ b/src/icp/sass/base/_header.scss
@@ -227,7 +227,7 @@ header {
         }
         input {
           display: inline-block;
-          width: 120px;
+          width: 80px;
           margin: 0 0.7rem;
           vertical-align: bottom;
         }


### PR DESCRIPTION
### Overview
Allows input for "number of hives" of single digit decimals, from 0 to 10.

Connects #124 

### Demo
#### @ 1.2 h/a
![screenshot from 2017-01-27 14 55 01](https://cloud.githubusercontent.com/assets/1014341/22385444/ac8e27f8-e4a0-11e6-9988-f3865deb4ba5.png)

#### @ 1.3 h/a
![screenshot from 2017-01-27 14 55 13](https://cloud.githubusercontent.com/assets/1014341/22385448/afebcb4e-e4a0-11e6-8b69-889c0db779da.png)

![screenshot from 2017-01-27 14 58 43](https://cloud.githubusercontent.com/assets/1014341/22385557/204b47ca-e4a1-11e6-91e9-3d7f24b1ce0a.png)

### Testing
* Rebundle the client JS
* Attempt run the model with number of hives expressed as a decimal
* Verify that `/yield` requests include the decimal values
* Verify that the model output for two scenarios which share the same whole number, but different decimals, differ slightly.