### PR TITLE
Install ACL utilities to provision services VM

### DIFF
--- a/deployment/ansible/services.yml
+++ b/deployment/ansible/services.yml
@@ -6,6 +6,9 @@
     - name: Update APT cache
       apt: update_cache=yes cache_valid_time=3600
 
+    - name: Install ACL utilities
+      apt: pkg="acl" state=present
+
   roles:
     - { role: "bee-pollinator.postgresql", when: "['development', 'test'] | some_are_in(group_names)" }
     - { role: "bee-pollinator.pgweb", when: "['development', 'test'] | some_are_in(group_names)" }


### PR DESCRIPTION
The `acl` package includes the setfacl tool, which Ansible 2.1+ uses to set POSIX ACLs to share modules with unprivileged users (`postgres` in this case).

See: http://docs.ansible.com/ansible/become.html

---

**Testing**

Provision the `services` virtual machine and ensure that it completes successfully.