### PR TITLE
Use same project for Compare view as Modeling

### DIFF
--- a/src/icp/js/src/compare/controllers.js
+++ b/src/icp/js/src/compare/controllers.js
@@ -1,38 +1,24 @@
 "use strict";
 
-var _ = require('lodash'),
-    App = require('../app'),
+var App = require('../app'),
     router = require('../router').router,
     views = require('./views'),
     modelingModels = require('../modeling/models.js');
 
 var CompareController = {
     compare: function(projectId) {
-        var first = null,
-            aoi_census = null;
-
         if (App.currentProject) {
-            first = App.currentProject.get('scenarios').first();
-            if (first) {
-                aoi_census = first.get('aoi_census');
-            }
-
-            setupProjectCopy(aoi_census);
+            setupProject();
             showCompareWindow();
         } else if (projectId) {
             App.currentProject = new modelingModels.ProjectModel({
                 id: projectId
             });
 
-            first = App.currentProject.get('scenarios').first();
-            if (first) {
-                aoi_census = first.get('aoi_census');
-            }
-
             App.currentProject
                 .fetch()
                 .done(function() {
-                    setupProjectCopy(aoi_census);
+                    setupProject();
                     showCompareWindow();
                 });
         }
@@ -42,11 +28,8 @@ var CompareController = {
 
     compareCleanUp: function() {
         App.user.off('change:guest', saveAfterLogin);
-        App.origProject.off('change:id', updateUrl);
+        App.currentProject.off('change:id', updateUrl);
 
-        // Switch back to the origProject so any changes are discarded.
-        App.currentProject.off();
-        App.currentProject = App.origProject;
         if (!App.map.get('areaOfInterest')) {
             App.map.set('areaOfInterest', App.currentProject.get('area_of_interest'));
         }
@@ -55,77 +38,26 @@ var CompareController = {
     }
 };
 
-function setupProjectCopy(aoi_census) {
-    /*
-    Create a copy of the project so that:
-      -Changes to the results and inputs are not saved to the server
-      -Changes to the results and inputs are not present after hitting the back button (and project is unsaved).
-       When the user is logged in as a guest, the only copy of the original inputs and results
-       are in App.currentProject, and modifying these values in the compare views will result in those new
-       values being back in the modeling views, which is not what we want.
-      -The original project (without changes) is saved when logging in. If the user is a guest,
-       goes into the compare views, and then logs in, the project should be saved with the inputs
-       and results that were present before going to the compare views. This is to enforce the
-       constraint that inputs and results entered in the compare views should never be saved.
-       Without holding onto the original copies of these values, it's not possible to do this.
-     */
-    App.origProject = App.currentProject;
-    App.currentProject = copyProject(App.origProject, aoi_census);
-
+function setupProject() {
     App.user.on('change:guest', saveAfterLogin);
-    App.origProject.on('change:id', updateUrl);
-}
-
-// Creates a special-purpose copy of the project
-// for the compare views, since creating a true deep
-// clone is more difficult and unnecessary.
-function copyProject(project, aoi_census) {
-    var scenariosCopy = new modelingModels.ScenariosCollection();
-    project.get('scenarios').forEach(function(scenario) {
-        var scenarioCopy = new modelingModels.ScenarioModel({});
-        scenarioCopy.set({
-            name: scenario.get('name'),
-            is_current_conditions: scenario.get('is_current_conditions'),
-            modifications: scenario.get('modifications'),
-            shared_modifications: scenario.get('shared_modifications'),
-            modification_hash: scenario.get('modification_hash'),
-            modification_censuses: scenario.get('modification_censuses'),
-            results: new modelingModels.ResultCollection(scenario.get('results').toJSON()),
-            inputs: new modelingModels.ModificationsCollection(scenario.get('inputs').toJSON()),
-            inputmod_hash: scenario.get('inputmod_hash'),
-            allow_save: false
-        });
-        if (aoi_census) {
-            scenarioCopy.set('aoi_census', aoi_census);
-        }
-        scenarioCopy.get('inputs').on('add', _.debounce(_.bind(scenarioCopy.fetchResults, scenarioCopy), 500));
-        scenariosCopy.add(scenarioCopy);
-    });
-    return new modelingModels.ProjectModel({
-        name: App.origProject.get('name'),
-        area_of_interest: App.origProject.get('area_of_interest'),
-        model_package: App.origProject.get('model_package'),
-        scenarios: scenariosCopy,
-        allow_save: false
-    });
+    App.currentProject.on('change:id', updateUrl);
 }
 
 function saveAfterLogin(user, guest) {
-    if (!guest && App.origProject.isNew()) {
+    if (!guest && App.currentProject.isNew()) {
         var user_id = user.get('id');
-        App.origProject.set('user_id', user_id);
-        App.origProject.get('scenarios').each(function(scenario) {
+        App.currentProject.set('user_id', user_id);
+        App.currentProject.get('scenarios').each(function(scenario) {
             scenario.set('user_id', user_id);
         });
-        // Save the origProject (as opposed to the currentProject)
-        // to not include changes to inputs and results.
-        App.origProject.saveProjectAndScenarios();
+
+        App.currentProject.saveProjectAndScenarios();
     }
 }
 
 function updateUrl() {
     // Use replace: true, so that the back button will work as expected.
-    router.navigate(App.origProject.getCompareUrl(), { replace: true });
+    router.navigate(App.currentProject.getCompareUrl(), { replace: true });
 }
 
 function showCompareWindow() {


### PR DESCRIPTION
## Overview

Previously, we would create a sandboxed copy of the main project for the Compare view. This was done in order to preserve the state of the main project from any changes made in the Compare view, which could trigger model runs and modify input values.

This led to bugs such as spinners continuing to spin if that's how Compare view was initialized, even after any polling finishes. The original project's results would be updated, but not of the sandboxed copy, causing the user to see stale results.

Since we don't expect the Pollinator App to be able to trigger model runs from the Compare view, it is safe to remove the sandboxed copy of the project and just use the original one. This simplifies the code, making it easier to reason about, as well as removing any bugs like the one mentioned above.

This functionality was originally added in Model My Watershed in https://github.com/WikiWatershed/model-my-watershed/pull/673

Connects #115 

### Notes

I found a number of quirks with the Compare view, which I've recorded in #141. Please read that issue before reporting the same quirks here.

## Testing Instructions

 * Check out this branch and update bundle scripts
 * Create a new project. Wait for Current Conditions and New Scenario to process in the Modeling view.
 * Make a change in New Scenario and switch to Compare view before processing finishes. Ensure that the Compare view's chart updates with the new values, and the spinner stops accurately.
 * Ensure you are logged out. Draw a shape and proceed to the Compare view. Log in from the Compare view. Ensure that your project is saved correctly.