### PR TITLE
Patch model demand for new group ids

### DIFF
--- a/src/icp/pollinator/src/pollinator/crop_yield.py
+++ b/src/icp/pollinator/src/pollinator/crop_yield.py
@@ -81,7 +81,7 @@ def load_crop_data(data_src=DEFAULT_DATA_PATH):
             id = int(row[id_idx])
             nesting_reclass.append([id, float(row[hn_idx])])
             floral_reclass.append([id, float(row[hf_idx])])
-            yield_config[id]['demand'] = id / 47  # Temporary unique default
+            yield_config[id]['demand'] = id / 65  # Temporary unique default
             yield_config[id]['density'] = 2.5  # Temporary default
 
         return nesting_reclass, floral_reclass, yield_config


### PR DESCRIPTION
### Overview
Updating the temporary demand values was overlooked when adding
additional crop types to the model in #140.  This caused the model to fail.

### Testing
* Reinstall the model by either `vagrant provision worker` or `python setup.py install` on the vm
* Run a model and verify it executes correctly