### PR TITLE
Sidebar Style Fixes

### DIFF
--- a/src/icp/js/src/draw/templates/splash.html
+++ b/src/icp/js/src/draw/templates/splash.html
@@ -2,4 +2,6 @@
 <h2>Learn about how you can impact things to increase bees being there</h2>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis ac pharetra nibh. Nullam gravida massa non egestas pellentesque. Nam vitae fermentum ex. Maecenas accumsan velit sit amet justo lobortis maximus. Quisque a ullamcorper est, sit amet imperdiet nunc. Suspendisse rhoncus consequat laoreet. Nam malesuada purus et blandit dictum.</p>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis ac pharetra nibh. Nullam gravida massa non egestas pellentesque. Nam vitae fermentum ex. Maecenas accumsan velit sit amet justo lobortis maximus. Quisque a ullamcorper est, sit amet imperdiet nunc. Suspendisse rhoncus consequat laoreet. Nam malesuada purus et blandit dictum.</p>
-<button id="get-started" class="btn btn-active btn-lg btn-block" type="button">Get started <i class="fa fa-arrow-right"></i></button>
+<div id="splash-button">
+    <button id="get-started" class="btn btn-active btn-lg btn-block" type="button">Get started <i class="fa fa-arrow-right"></i></button>
+</div>

--- a/src/icp/sass/base/_header.scss
+++ b/src/icp/sass/base/_header.scss
@@ -9,7 +9,7 @@ header {
 //Standard Header
 #app-header {
   background-color: $ui-primary;
-  height: $height-lg;
+  height: $app-header-height;
   box-shadow: 0 0 4px $black-54;
   padding: 0 1rem;
 

--- a/src/icp/sass/base/_map.scss
+++ b/src/icp/sass/base/_map.scss
@@ -40,7 +40,7 @@
     top: $height-lg * 2 + $toolbar-height;
     right: $sidebar-width;
     @media(min-width: 1040px) {
-      right: 485px !important;
+      right: $sidebar-width-lg !important;
     }
   }
   // Sets map to correct container size for sidebar
@@ -49,7 +49,7 @@
     top: $height-lg;
     right: $sidebar-width;
     @media(min-width: 1040px) {
-      right: 485px !important;
+      right: $sidebar-width-lg !important;
     }
   }
   // Sets map to correct container size for sidebar.

--- a/src/icp/sass/components/_tabs.scss
+++ b/src/icp/sass/components/_tabs.scss
@@ -48,7 +48,7 @@
 .output-tabs-wrapper {
   position: absolute;
   left: 0;
-  top: $sidebar-tab-subheader-height;
+  top: 0;
   right: 0;
   bottom: 0;
 

--- a/src/icp/sass/pages/_draw.scss
+++ b/src/icp/sass/pages/_draw.scss
@@ -1,5 +1,8 @@
 #splash-window, #draw-window {
-  width: 485px;
+  width: $sidebar-width;
+  @media(min-width: 1040px) {
+    width: $sidebar-width-lg;
+  }
   height: 100%;
   padding: 15px;
   padding-bottom: $app-header-height + 15;

--- a/src/icp/sass/pages/_draw.scss
+++ b/src/icp/sass/pages/_draw.scss
@@ -1,9 +1,12 @@
 #splash-window, #draw-window {
   width: 485px;
+  height: 100%;
   padding: 15px;
+  padding-bottom: $app-header-height + 15;
   position: absolute;
   right: 0;
   transition: all 200ms;
+  overflow: scroll;
 
   .hidden-sidebar & {
     transform: translateX(100%);

--- a/src/icp/sass/pages/_draw.scss
+++ b/src/icp/sass/pages/_draw.scss
@@ -23,3 +23,14 @@
       width: 100%;
   }
 }
+
+#splash-button {
+  position: fixed;
+  bottom: 0;
+  width: $sidebar-width - (15px * 2);
+  @media(min-width: 1040px) {
+    width: $sidebar-width-lg - (15px * 2);
+  }
+  padding: 15px 0;
+  background: white;
+}

--- a/src/icp/sass/pages/_model.scss
+++ b/src/icp/sass/pages/_model.scss
@@ -6,7 +6,7 @@
   bottom: 0;
   width: $sidebar-width !important;
   @media(min-width: 1040px) {
-    width: 485px !important;
+    width: $sidebar-width-lg !important;
   }
   min-height: 300px;
   height: auto !important;

--- a/src/icp/sass/utils/_variables.scss
+++ b/src/icp/sass/utils/_variables.scss
@@ -41,6 +41,7 @@ $height-md: 36px;
 $height-sm: 28px;
 $height-xs: 18px;
 $sidebar-width: 460px;
+$sidebar-width-lg: 485px;
 $sidebar-header-height: 40px;
 $sidebar-tab-subheader-height: 60px;
 $app-header-height: $height-lg;

--- a/src/icp/sass/utils/_variables.scss
+++ b/src/icp/sass/utils/_variables.scss
@@ -43,6 +43,7 @@ $height-xs: 18px;
 $sidebar-width: 460px;
 $sidebar-header-height: 40px;
 $sidebar-tab-subheader-height: 60px;
+$app-header-height: $height-lg;
 
 //Border-radius
 $radius-sm: 2px;


### PR DESCRIPTION
## Overview

Makes the app more accessible on smaller screens by allowing scrolling of the sidebar when content overflows. Also removes extra whitespace in the Modeling view.

Connects #61 
Connects #133 

### Demo

Scrolling:

![2017-02-02 16 22 29](https://cloud.githubusercontent.com/assets/1430060/22569027/0f954c88-e964-11e6-9679-261587bbac07.gif)

With scrollbar on Windows:

![image](https://cloud.githubusercontent.com/assets/1430060/22569181/867919ce-e964-11e6-85a0-16375050efc0.png)

Removed whitespace:

![image](https://cloud.githubusercontent.com/assets/1430060/22569048/1ed31aea-e964-11e6-8cde-e64b1f6a6f04.png)

## Testing Instructions

 * Check out this branch, and run the bundle script
 * Open the app in a short browser window. Ensure you can scroll the sidebar easily, without interfering with the map
 * Ensure you can proceed to the Modeling stage.
 * Ensure there is no extra whitespace above "Crop Yield" in the Modeling view.