### PR TITLE
Max draw area size update  + fancy modals

### DIFF
--- a/src/icp/js/src/core/error/handlers.js
+++ b/src/icp/js/src/core/error/handlers.js
@@ -1,11 +1,12 @@
 "use strict";
 
-var router = require('../../router').router;
+var router = require('../../router').router,
+    modalViews = require('../modals/views');
 
 var ErrorHandlers = {
     generic: function(type) {
         router.navigate('');
-        window.alert("We're sorry, but an error occurred in the application.");
+        modalViews.showError("We're sorry, but an error occurred in the application.");
         console.log("[ICP] An unknown error occurred: " + type);
     }
 };

--- a/src/icp/js/src/core/modals/models.js
+++ b/src/icp/js/src/core/modals/models.js
@@ -30,8 +30,36 @@ var ShareModel = Backbone.Model.extend({
     }
 });
 
+var AlertTypes = {
+    info: {
+        alertHeader: 'Information',
+        alertIcon: 'fa-info-circle',
+        dismissLabel: 'Okay'
+    },
+    warn: {
+        alertHeader: 'Warning',
+        alertIcon: 'fa-exclamation-triangle',
+        dismissLabel: 'Okay'
+    },
+    error: {
+        alertHeader: 'Error',
+        alertIcon: 'fa-ban',
+        dismissLabel: 'Okay'
+    }
+};
+
+var AlertModel = Backbone.Model.extend({
+    defaults: {
+        alertMessage: '',
+        alertType: AlertTypes.info,
+    },
+});
+
+
 module.exports = {
     ConfirmModel: ConfirmModel,
     InputModel: InputModel,
-    ShareModel: ShareModel
+    ShareModel: ShareModel,
+    AlertTypes: AlertTypes,
+    AlertModel: AlertModel
 };

--- a/src/icp/js/src/core/modals/templates/alertModal.html
+++ b/src/icp/js/src/core/modals/templates/alertModal.html
@@ -1,0 +1,16 @@
+<div class="modal-dialog modal-dialog-sm modal-popup">
+    <div class="modal-content">
+        <div class="modal-header">
+          <h2>
+            <i class="fa {{ alertIcon }}"></i>
+            {{ alertHeader }}
+          </h2>
+        </div>
+        <div class="modal-body">
+          <p>{{ alertMessage }}</p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-md btn-default" data-dismiss="modal">{{ dismissLabel }}</button>
+        </div>
+    </div>
+</div>

--- a/src/icp/js/src/core/modals/views.js
+++ b/src/icp/js/src/core/modals/views.js
@@ -8,6 +8,7 @@ var _ = require('underscore'),
     modalConfirmTmpl = require('./templates/confirmModal.html'),
     modalInputTmpl = require('./templates/inputModal.html'),
     modalShareTmpl = require('./templates/shareModal.html'),
+    modalAlertTmpl = require('./templates/alertModal.html'),
 
     ENTER_KEYCODE = 13,
     BASIC_MODAL_CLASS = 'modal modal-basic fade';
@@ -70,6 +71,26 @@ var ModalBaseView = Marionette.ItemView.extend({
 
     hide: function() {
         this.$el.modal('hide');
+    }
+});
+
+var AlertView = ModalBaseView.extend({
+    template: modalAlertTmpl,
+
+    ui: {
+        dismiss: '.btn-default'
+    },
+
+    events: _.defaults({
+        'click @ui.dismiss': 'dismissAction'
+    }, ModalBaseView.prototype.events),
+
+    dismissAction: function() {
+        this.triggerMethod('dismiss');
+    },
+
+    templateHelpers: function() {
+        return _.extend(this.model.get('alertType'), { alertMessage: this.model.get('alertMessage') });
     }
 });
 
@@ -193,8 +214,34 @@ var ShareView = ModalBaseView.extend({
     }
 });
 
+function showAlert(message, alertType) {
+    var alertView = new AlertView({
+        model: new models.AlertModel({
+            alertMessage: message,
+            alertType: alertType,
+        })
+    });
+    alertView.render();
+}
+
+function showError(message) {
+    showAlert(message, models.AlertTypes.error);
+}
+
+function showInfo(message) {
+    showAlert(message, models.AlertTypes.info);
+}
+
+function showWarning(message) {
+    showAlert(message, models.AlertTypes.warn);
+}
+
+
 module.exports = {
     ShareView: ShareView,
     InputView: InputView,
     ConfirmView: ConfirmView,
+    showError: showError,
+    showInfo: showInfo,
+    showWarning: showWarning,
 };

--- a/src/icp/js/src/core/views.js
+++ b/src/icp/js/src/core/views.js
@@ -116,11 +116,9 @@ var HeaderView = Marionette.ItemView.extend({
                     window.location.replace(cloneUrl);
                 })
                 .fail(function() {
-                    window.alert(
-                        'There was an error trying to clone that project. ' +
+                    modalViews.showError('There was an error trying to clone that project. ' +
                         'Please ensure that the project ID is valid and ' +
-                        'that you have permission to view the project.'
-                    );
+                        'that you have permission to view the project.');
                 });
         });
         view.render();
@@ -582,7 +580,7 @@ var MapView = Marionette.ItemView.extend({
         this._modificationsLayer.clearLayers();
     },
 
-    // Add GeoJSON layer for each modification model in the given scenario's 
+    // Add GeoJSON layer for each modification model in the given scenario's
     // shared and specific modification collections.
     updateModifications: function(scenario) {
         var self = this,

--- a/src/icp/js/src/draw/views.js
+++ b/src/icp/js/src/draw/views.js
@@ -18,7 +18,8 @@ var $ = require('jquery'),
     drawTmpl = require('./templates/draw.html'),
     resetDrawTmpl = require('./templates/reset.html'),
     windowTmpl = require('./templates/window.html'),
-    settings = require('../core/settings');
+    settings = require('../core/settings'),
+    modalViews = require('../core/modals/views');
 
 var MAX_DRAW_ACRES = 400; // About 5/8's of a square mile
 var codeToLayer = {}; // code to layer mapping
@@ -50,14 +51,12 @@ function validateShape(polygon) {
         var errorMsg = 'This watershed shape is invalid because it intersects ' +
                        'itself. Try drawing the shape again without crossing ' +
                        'over its own border.';
-        window.alert(errorMsg);
         d.reject(errorMsg);
     } else if (area > MAX_DRAW_ACRES) {
         var message = 'Sorry, your Area of Interest is too large.\n\n' +
                       Math.floor(area).toLocaleString() + ' acres were selected, ' +
                       'but the maximum supported size is currently ' +
                       MAX_DRAW_ACRES.toLocaleString() + ' acres.';
-        window.alert(message);
         d.reject(message);
     } else {
         d.resolve(polygon);
@@ -161,8 +160,11 @@ var DrawWindow = Marionette.LayoutView.extend({
                     isDrawing: false,
                     isDrawn: true
                 });
-            }).fail(function() {
+            }).fail(function(message) {
                 revertLayer();
+                if (message) {
+                    modalViews.showWarning(message);
+                }
                 self.model.set({
                     isDrawing: false,
                     isDrawn: false

--- a/src/icp/js/src/draw/views.js
+++ b/src/icp/js/src/draw/views.js
@@ -65,20 +65,6 @@ function validateShape(polygon) {
     return d.promise();
 }
 
-function validateClickedPointWithinDRB(latlng) {
-    var point = L.marker(latlng).toGeoJSON(),
-        d = $.Deferred(),
-        streamLayers = settings.get('stream_layers'),
-        drbPerimeter = _.findWhere(streamLayers, {code:'drb_streams_v2'}).perimeter;
-    if (turfIntersect(point, drbPerimeter)) {
-        d.resolve(latlng);
-    } else {
-        var message = 'Selected point is outside the Delaware River Basin';
-        d.reject(message);
-    }
-    return d.promise();
-}
-
 function makePointGeoJson(coords, props) {
     return {
         geometry: {

--- a/src/icp/js/src/draw/views.js
+++ b/src/icp/js/src/draw/views.js
@@ -20,7 +20,7 @@ var $ = require('jquery'),
     windowTmpl = require('./templates/window.html'),
     settings = require('../core/settings');
 
-var MAX_AREA = 27500000; // About the size of a large state (in acres)
+var MAX_DRAW_ACRES = 400; // About 5/8's of a square mile
 var codeToLayer = {}; // code to layer mapping
 
 function actOnUI(datum, bool) {
@@ -52,11 +52,11 @@ function validateShape(polygon) {
                        'over its own border.';
         window.alert(errorMsg);
         d.reject(errorMsg);
-    } else if (area > MAX_AREA) {
+    } else if (area > MAX_DRAW_ACRES) {
         var message = 'Sorry, your Area of Interest is too large.\n\n' +
                       Math.floor(area).toLocaleString() + ' acres were selected, ' +
                       'but the maximum supported size is currently ' +
-                      MAX_AREA.toLocaleString() + ' acres.';
+                      MAX_DRAW_ACRES.toLocaleString() + ' acres.';
         window.alert(message);
         d.reject(message);
     } else {

--- a/src/icp/js/src/modeling/models.js
+++ b/src/icp/js/src/modeling/models.js
@@ -9,7 +9,8 @@ var $ = require('jquery'),
     coreModels = require('../core/models'),
     turfArea = require('turf-area'),
     turfErase = require('turf-erase'),
-    turfIntersect = require('turf-intersect');
+    turfIntersect = require('turf-intersect'),
+    modalViews = require('../core/modals/views');
 
 var YIELD_TASK = 'yield';
 var YIELD_PACKAGE = 'yield';
@@ -775,11 +776,9 @@ var ScenariosCollection = Backbone.Collection.extend({
         });
 
         if (match) {
-            window.alert("There is another scenario with the same name. " +
-                    "Please choose a unique name for this scenario.");
-
             console.log('This name is already in use.');
-
+            modalViews.showWarning('There is another scenario with the same name. ' +
+                'Please choose a unique name for this scenario.');
             return false;
         } else if (model.get('name') !== newName) {
             return model.set('name', newName);

--- a/src/icp/js/src/modeling/views.js
+++ b/src/icp/js/src/modeling/views.js
@@ -180,7 +180,7 @@ var ProjectMenuView = Marionette.ItemView.extend({
             if (xhr) {
                 xhr.done(navigateAfterDelete)
                     .fail(function() {
-                        window.alert('Could not delete this project.');
+                        modalViews.showError('Could not delete this project.');
                     });
             } else {
                 navigateAfterDelete();

--- a/src/icp/js/src/projects/views.js
+++ b/src/icp/js/src/projects/views.js
@@ -152,7 +152,7 @@ var ProjectRowView = Marionette.ItemView.extend({
             self.model
                 .destroy({ wait: true })
                 .fail(function() {
-                    window.alert('Could not delete this project.');
+                    modalViews.showError('Could not delete this project.');
                 });
         });
     }


### PR DESCRIPTION
## Overview

Model only intended for fields of up to 400 acres, so the max size has been updated.

We were using `window.alert()` to show the error message, so I've ported over the MMW modals.

Connects #138 

## Demo

### Too big
![screen shot 2017-02-02 at 5 15 38 pm](https://cloud.githubusercontent.com/assets/7633670/22570875/3e0b088a-e96b-11e6-81ab-b8df9ec397f6.png)

### Duplicate scenario name
![screen shot 2017-02-02 at 4 28 51 pm](https://cloud.githubusercontent.com/assets/7633670/22569540/e353c558-e965-11e6-9f59-68d12f781138.png)

## Testing instructions 
* Pull this branch and bundle up
* Draw an AOI > ~5/8ths of a square mile
   - should see error
* Draw good, little sized AOI, should succeed
* Rename scenarios to duplicate names/make stuff fail -- confirm there are no more `window.alert`