### PR TITLE
Update CDL raster snapshot

### DIFF
--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -41,7 +41,7 @@
             "ami_block_device_mappings": [
                 {
                     "device_name": "/dev/sdf",
-                    "snapshot_id": "snap-08a7849bd57c08286",
+                    "snapshot_id": "snap-08429591cf7ae1fb7",
                     "volume_type": "gp2",
                     "delete_on_termination": true
                 }


### PR DESCRIPTION
An updated version of the CDL raster was added to this snapshot and
will be associated with `icp-worker` instance types. 

Connects #155 

![screenshot from 2017-02-08 16 14 52](https://cloud.githubusercontent.com/assets/1014341/22757656/be4c841c-ee19-11e6-9be3-18004b286421.png)
