### PR TITLE
Have consistent map controls in both development and production

### DIFF
--- a/src/icp/icp/settings/base.py
+++ b/src/icp/icp/settings/base.py
@@ -378,6 +378,7 @@ DRAW_CONFIG = {
 
 MAP_CONTROLS = [
     'LayerAttribution',
+    'LocateMeButton',
     'LayerSelector',
     'ZoomControl',
     'SidebarToggle'

--- a/src/icp/icp/settings/production.py
+++ b/src/icp/icp/settings/production.py
@@ -98,6 +98,7 @@ DRAW_TOOLS = [
 MAP_CONTROLS = [
     'LayerAttribution',
     'LocateMeButton',
+    'LayerSelector',
     'ZoomControl',
     'SidebarToggle'
 ]

--- a/src/icp/js/src/core/views.js
+++ b/src/icp/js/src/core/views.js
@@ -128,26 +128,26 @@ var HeaderView = Marionette.ItemView.extend({
 // Init the locate plugin button and add it to the map.
 function addLocateMeButton(map, maxZoom, maxAge) {
     var locateOptions = {
-        position: 'topright',
-        metric: false,
-        drawCircle: false,
-        showPopup: false,
-        follow: false,
-        markerClass: L.marker,
-        markerStyle: {
-            opacity: 0.0,
-            clickable: false,
-            keyboard: false
-        },
-        locateOptions: {
-            maxZoom: maxZoom,
-            // Cache location response, in ms
-            maximumAge: maxAge
-        },
-        strings: {
-            title: 'Zoom to your location.'
-        }
-    };
+            position: 'bottomright',
+            metric: false,
+            drawCircle: false,
+            showPopup: false,
+            follow: false,
+            markerClass: L.marker,
+            markerStyle: {
+                opacity: 0.0,
+                clickable: false,
+                keyboard: false
+            },
+            locateOptions: {
+                maxZoom: maxZoom,
+                // Cache location response, in ms
+                maximumAge: maxAge
+            },
+            strings: {
+                title: 'Zoom to your location.'
+            }
+        };
 
     L.control.locate(locateOptions).addTo(map);
 }
@@ -259,7 +259,8 @@ var MapView = Marionette.ItemView.extend({
 
         // wrap the zoom & sidebar toggle controls in one div for styling
         $('.leaflet-bottom.leaflet-right>.leaflet-control-sidebar-toggle,' +
-          '.leaflet-bottom.leaflet-right>.leaflet-control-zoom')
+          '.leaflet-bottom.leaflet-right>.leaflet-control-zoom,' +
+          '.leaflet-bottom.leaflet-right>.leaflet-control-locate')
             .wrapAll('<div class="leaflet-bottom-right-controls"></div>');
     },
 


### PR DESCRIPTION
Makes sure that the basemap selector, overlay control and geolocation buttons are all consistently placed in both environments.  Previously, development had the layers but not the location and production had the location but not the layers.

#### Before
![screenshot from 2017-02-09 09 27 19](https://cloud.githubusercontent.com/assets/1014341/22787354/fddb61bc-eea9-11e6-9692-01d7966afa9c.png)

#### After
![screenshot from 2017-02-09 09 28 07](https://cloud.githubusercontent.com/assets/1014341/22787375/16091630-eeaa-11e6-8ff5-e786927a42d2.png)


Connects #158 

#### Testing
* Verify that development control show correctly
* Check production settings are updated to show the layer controls