### PR TITLE
Always Compare Fresh Scenarios

### DIFF
--- a/src/icp/js/src/compare/utils.js
+++ b/src/icp/js/src/compare/utils.js
@@ -1,0 +1,18 @@
+"use strict";
+
+var _ = require('lodash');
+
+function getChartableCrops(scenarios) {
+    return scenarios.reduce(function(cropTypes, scenario) {
+        var nonZeroCrops = scenario.get('results').map(function(result) {
+            return Object.keys(_.omit(result.get('result'), function(value) {
+                return value === 0;
+            }));
+        });
+        return _.uniq(cropTypes.concat(_.flatten(nonZeroCrops)));
+    }, []);
+}
+
+module.exports = {
+    getChartableCrops: getChartableCrops,
+};

--- a/src/icp/js/src/compare/views.js
+++ b/src/icp/js/src/compare/views.js
@@ -45,6 +45,8 @@ var CompareWindow = Marionette.LayoutView.extend({
         // so the offset of the container needs to be
         // recomputed.
         $(window).bind('resize.app', _.debounce(_.bind(this.updateContainerPos, this)));
+
+        this.model.fetchResultsIfNeeded();
     },
 
     onDestroy: function() {

--- a/src/icp/js/src/compare/views.js
+++ b/src/icp/js/src/compare/views.js
@@ -9,6 +9,7 @@ var _ = require('lodash'),
     coreViews = require('../core/views'),
     modelingViews = require('../modeling/views'),
     modConfigUtils = require('../modeling/modificationConfigUtils'),
+    utils = require('./utils'),
     compareWindowTmpl = require('./templates/compareWindow.html'),
     compareScenariosTmpl = require('./templates/compareScenarios.html'),
     compareScenarioTmpl = require('./templates/compareScenario.html'),
@@ -115,8 +116,7 @@ var CompareScenarioView = Marionette.LayoutView.extend({
     initialize: function(options) {
         this.projectModel = options.projectModel;
         this.scenariosView = options.scenariosView;
-        this.model.set('chartableCrops', options.chartableCrops);
-        this.model.set('selectedCrops', options.chartableCrops);
+        this.model.set('selectedCrops', this.projectModel.get('chartableCrops'));
     },
 
     onShow: function() {
@@ -173,24 +173,18 @@ var CompareScenariosView = Marionette.CompositeView.extend({
         return {
             scenariosView: this,
             projectModel: this.model,
-            chartableCrops: this.chartableCrops
         };
     },
 
     initialize: function() {
-        var scenarios = this.collection;
-
-        // Get the list of crops that have values in any scenario of this project
-        this.chartableCrops = scenarios.reduce(function(cropTypes, scenario) {
-            var nonZeroCrops = scenario.get('results').map(function(result) {
-                return Object.keys(_.omit(result.get('result'), function(value) {
-                    return value === 0;
-                }));
-            });
-            return _.uniq(cropTypes.concat(_.flatten(nonZeroCrops)));
-        }, []);
-
         this.modelingViews = [];
+        this.updateChartableCrops();
+    },
+
+    updateChartableCrops: function() {
+        this.model.set({
+            chartableCrops: utils.getChartableCrops(this.collection),
+        });
     }
 });
 
@@ -216,17 +210,18 @@ var CompareModelingView = Marionette.LayoutView.extend({
     initialize: function(options) {
         this.projectModel = options.projectModel;
         this.model.get('results').makeFirstActive();
-        this.listenTo(this.model.get('results').at(0), 'change:polling', function() {
-            this.render();
-            this.onShow();
-        });
         this.scenariosView = options.scenariosView;
         this.scenariosView.modelingViews.push(this);
+        this.listenTo(this.model.get('results').at(0), 'change:polling', function() {
+            this.scenariosView.updateChartableCrops();
+            this.render();
+            this.updateResult();
+        });
     },
 
     templateHelpers: function() {
         return {
-            chartableCrops: this.model.get('chartableCrops'),
+            chartableCrops: this.projectModel.get('chartableCrops'),
             cropTypes: cropTypes,
             polling: this.model.get('results').at(0).get('polling'),
             results: this.model.get('results').toJSON()
@@ -234,18 +229,18 @@ var CompareModelingView = Marionette.LayoutView.extend({
     },
 
     updateResult: function() {
-        var selection = this.ui.resultSelector.val(),
+        var self = this,
+            selection = this.ui.resultSelector.val(),
             selectedCrops = selection === "all" ?
-                this.model.get('chartableCrops') :
+                this.projectModel.get('chartableCrops') :
                 [selection];
 
         this.model.set('selectedCrops', selectedCrops);
         this.showResult();
 
         _.forEach(this.scenariosView.modelingViews, function(sibling) {
-            if (sibling.ui.resultSelector.val() === selection) {
-                return;
-            } else {
+            if (sibling.cid !== self.cid) {
+                sibling.render();
                 sibling.ui.resultSelector.val(selection);
                 sibling.model.set('selectedCrops', selectedCrops);
                 sibling.showResult();

--- a/src/icp/js/src/modeling/models.js
+++ b/src/icp/js/src/modeling/models.js
@@ -142,6 +142,16 @@ var ProjectModel = Backbone.Model.extend({
 
         this.listenTo(this.get('scenarios'), 'add', this.addIdsToScenarios, this);
         this.get('scenarios').on('change:modification_hash', this.shareGlobalModifications, this);
+
+        this.get('scenarios').on('change:active', function(scenario) {
+            if (scenario.get('active')) {
+                scenario.fetchResultsIfNeeded();
+            }
+        });
+
+        this.get('scenarios').on('add', function(scenario) {
+            scenario.fetchResultsIfNeeded();
+        });
     },
 
     shareGlobalModifications: function(changedScenario) {
@@ -175,16 +185,6 @@ var ProjectModel = Backbone.Model.extend({
 
         this.get('scenarios').forEach(function(scenario) {
             promises.push(scenario.fetchResultsIfNeeded());
-        });
-
-        this.get('scenarios').on('change:active', function(scenario) {
-            if (scenario.get('active')) {
-                scenario.fetchResultsIfNeeded();
-            }
-        });
-
-        this.get('scenarios').on('add', function(scenario) {
-            scenario.fetchResultsIfNeeded();
         });
 
         return $.when.apply($, promises);
@@ -503,10 +503,6 @@ var ScenarioModel = Backbone.Model.extend({
             fetchResultsPromise;
 
         if (!isCurrentConditions) {
-            if (!this.get('active')) {
-                return $.when();
-            }
-
             if (needsResults) {
                 var setResultsFromCurrentConditionsOrFetch = _.bind(
                     self.setResultsFromCurrentConditionsOrFetch, self);

--- a/src/icp/js/src/modeling/models.js
+++ b/src/icp/js/src/modeling/models.js
@@ -502,22 +502,17 @@ var ScenarioModel = Backbone.Model.extend({
             isCurrentConditions = this.get('is_current_conditions'),
             fetchResultsPromise;
 
+        if (!needsResults) {
+            // Return current promise or immediately resolve
+            return self.fetchResultsPromise || $.when();
+        }
+
         if (!isCurrentConditions) {
-            if (needsResults) {
-                var setResultsFromCurrentConditionsOrFetch = _.bind(
-                    self.setResultsFromCurrentConditionsOrFetch, self);
+            fetchResultsPromise = self.setResultsFromCurrentConditionsOrFetch();
+        } else if (self.fetchResultsPromise === undefined) {
+            var promises = this.fetchResults();
 
-                fetchResultsPromise = $.when().then(function() {
-                    setResultsFromCurrentConditionsOrFetch();
-                });
-            }
-        } else if (needsResults && self.fetchResultsPromise === undefined) {
-            var fetchResults = _.bind(self.fetchResults, self);
-
-            fetchResultsPromise = $.when().then(function() {
-                var promises = fetchResults();
-                return $.when(promises.startPromise, promises.pollingPromise);
-            });
+            fetchResultsPromise = $.when(promises.startPromise, promises.pollingPromise);
         }
 
         if (fetchResultsPromise) {
@@ -543,8 +538,7 @@ var ScenarioModel = Backbone.Model.extend({
         // has diverged from this scenario with respect to modifications,
         // fetch them anew
         if (ccIsEmpty || ccInputModHash !== this.get('inputmod_hash')) {
-            var fetchResults = _.bind(this.fetchResults, this),
-                promises = fetchResults();
+            var promises = this.fetchResults();
 
             return $.when(promises.startPromise, promises.pollingPromise);
         } else {
@@ -556,6 +550,8 @@ var ScenarioModel = Backbone.Model.extend({
                 'result': currentConditionResults.get('result'),
                 'inputmod_hash': currentConditionResults.get('inputmod_hash')
             });
+
+            return $.when();
         }
     },
 

--- a/src/icp/js/src/modeling/views.js
+++ b/src/icp/js/src/modeling/views.js
@@ -646,7 +646,9 @@ var ResultsView = Marionette.LayoutView.extend({
             this.lock = options.lock;
         }
 
-        this.model.fetchResultsIfNeeded();
+        scenarios
+            .findWhere({ active: true })
+            .fetchResultsIfNeeded();
     },
 
     onRender: function() {


### PR DESCRIPTION
## Overview

Addresses various issues of the compare view resulting from loading it before all scenarios are done refreshing. Also does some minor refactoring of the fetch code.

See original issue for a detailed description (with animated GIFs) of the problems.

Connects #141

### Notes

There is an interesting (good) side effect of the refactoring: when deleting modifications from a New Scenario so that it is identical to Current Conditions, it no longer polls for results, instead just copies the results from Current Conditions instantly.

When polling does finish in Compare view, all dropdowns will be reset to "All Crops" since a crop the dropdown may have been previously set to may no longer be available.

## Testing Instructions

 * Check out the branch and bundle your scripts `kj bundle --debug`
 * Open the app and ensure you are not logged in

 1. Test that going straight to Compare view from Draw / Modeling without waiting for Current Conditions to finish works correctly
    * This should trigger New Scenario to fetch results as well
    * When Current Conditions returns, its graph and dropdown should be correctly populated
    * When New Scenario returns, its graph and dropdown should be correctly populated
 2. Test that making a change to a scenario (by adding or deleting a modification or input) and moving to the Compare view before results come back works correctly.
    * No additional fetches should be fired
    * When results come back, the proper scenario should be updated
 3. Add a modification to a New Scenario. Wait for it to finish polling. Then go to Current Conditions and add a modification. Go to Compare view before polling finishes.
    * Ensure both Current Conditions and New Scenario are polling, since changes to Current Conditions affects New Scenario as well, and it can't simply copy over Current Conditions since it has modifications of its own
    * Ensure the values are updated correctly
 4. Completely cover New Scenario with a new crop type that isn't listed in the results. Go to Compare view before polling finishes.
    * Ensure when polling finishes, all charts (New Scenario and any siblings) show all crops, including the new one that come back from this fetch.
    * Ensure that all dropdowns list all available crops

 * Test this any other way you can think of

Also tagging @mmcfarland who may want to take a cursory glance.