### PR TITLE
Account for NODATA values in yield calculation

### DIFF
--- a/src/icp/pollinator/src/pollinator/crop_yield.py
+++ b/src/icp/pollinator/src/pollinator/crop_yield.py
@@ -138,6 +138,10 @@ def yield_calc(crop_id, abundance, managed_hives, config):
     Returns
         yield (float): The predicted yield for this cell position
     """
+
+    if crop_id not in config:
+        return 0
+
     demand = config[crop_id]['demand']
     rec_hives = config[crop_id]['density']
 

--- a/src/icp/pollinator/tests/tests.py
+++ b/src/icp/pollinator/tests/tests.py
@@ -145,6 +145,22 @@ class ModelTests(unittest.TestCase):
         self.assertEqual(cell_yield, 0.886,
                          "Yield not calculated correctly for psuedo-crop 1")
 
+    def test_nodata_yield(self):
+        """
+        Test that NODATA values are handled properly.
+        """
+        config = {
+            1: {'demand': 0.95, 'density': 2.5}
+        }
+
+        nodata = 0
+        abundance_idx = 0.4
+        managed_hives = 1
+        cell_yield = yield_calc(nodata, abundance_idx, managed_hives, config)
+
+        self.assertEqual(cell_yield, 0,
+                         "NODATA should return 0 value for yield")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Overview

When `NODATA (0)` values are present in the CDL the model now assumes there is no yield for that cell. This scenario would be encountered when drawing an area on an a lake, or near a lake when the entire "beeshed" was taken into account.

The previous behavior was to generate an exception on trying to look up crop configuration based on the `NODATA` value.  A unit test has been added to verify this fix.

Connects #163 

## Demo
![screenshot from 2017-02-17 17 11 10](https://cloud.githubusercontent.com/assets/1014341/23085178/1dd8a700-f534-11e6-82cd-04c1e739c007.png)


## Testing
* Install the updated model `vagrant ssh worker -c "cd /opt/app/pollinator && sudo python setup.py install"`
* Restart celery if needed, or `./scripts/debugcelery.sh`
* Search for Wildwood, Michigan and find the farm in the screenshot, just to the east of the geocoded point.  In fact, you can draw anywhere in that region that within ~2km of Lake Michigan (which contains the `NODATA` cells).  That farm initiated the first observation for the error.
* Run a model in that area, get expected results (non-error, there don't happen to be registered crops at that location)
* Ensure new tests passes