### PR TITLE
Set Number of Hives to 0 upon erasure

### DIFF
--- a/src/icp/js/src/modeling/controls.js
+++ b/src/icp/js/src/modeling/controls.js
@@ -235,11 +235,14 @@ var NumberOfHivesView = ControlView.extend({
     },
 
     onInputChange: function() {
-        var value = parseFloat(this.ui.input.val());
+        var value = parseFloat(this.ui.input.val()) || 0;
+
         this.addOrReplaceInput(new models.ModificationModel({
             name: this.getControlName(),
             value: value
         }));
+
+        this.ui.input.val(value);
     },
 
     templateHelpers: function() {


### PR DESCRIPTION
## Overview

If the user erases the value of Number of Hives, we take it to mean "Reset" and set the value to 0.

The first commit was an attempt to discard the empty value, and revert to the previous value, assuming the erasure was accidental. I'll squash it before merging.

Connects #166 

## Testing Instructions

 * Check out this branch and bundle scripts `./scripts/bundle.sh --debug`
 * Get to the Modeling view, and erase the value of Number of Hives. Ensure that it updates to "0" when you leave the text box.
 * Set the value to 2. Wait for the model run to finish. Then erase the value. Ensure that since the previous value was different, it triggers a model run.
 * Erase the value again and leave the text box again. Ensure that since the previous value was 0, it does not trigger a model run.
 * Ensure that setting values normally via keyboard and via the up/down arrows works.
 * Ensure the Compare view works correctly.