### PR TITLE
Basemaps

### DIFF
--- a/src/icp/apps/core/templates/base.html
+++ b/src/icp/apps/core/templates/base.html
@@ -50,9 +50,6 @@
     {% endblock modals %}
 
     {% block javascript %}
-        <script type="text/javascript"
-                src="https://maps.googleapis.com/maps/api/js?key={{ google_maps_api_key }}">
-        </script>
         <script type="text/javascript">
             window.clientSettings = {{ client_settings | safe }};
         </script>

--- a/src/icp/apps/home/views.py
+++ b/src/icp/apps/home/views.py
@@ -86,8 +86,7 @@ def get_client_settings(request):
             'draw_tools': settings.DRAW_TOOLS,
             'map_controls': settings.MAP_CONTROLS,
             'mapshed_max_area': settings.DRAW_CONFIG['MaxAoIArea']
-        }),
-        'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY,
+        })
     }
 
     return client_settings

--- a/src/icp/icp/settings/base.py
+++ b/src/icp/icp/settings/base.py
@@ -354,11 +354,13 @@ GEOP = {}
 BASEMAPS = [
     {
         'display': 'street',
-        'url': 'https://server.arcgisonline.com/arcgis/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}'  # noqa
+        'url': 'https://server.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}',  # noqa
+        'attribution': 'Tiles &copy; Esri'
     },
     {
         'display': 'satellite',
-        'url': 'https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'  # noqa
+        'url': 'https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',  # noqa
+        'attribution': 'Tiles &copy; Esri'
     },
 ]
 

--- a/src/icp/icp/settings/development.py
+++ b/src/icp/icp/settings/development.py
@@ -49,8 +49,5 @@ LOGGING = {
 }
 # END LOGGING CONFIGURATION
 
-# API key for testing/development
-GOOGLE_MAPS_API_KEY = 'AIzaSyB0D5gjoIHpmy-xdP2cr_0I-E7K6s_L0k4'
-
 # azaveadev@azavea.com account
 GOOGLE_ANALYTICS_ACCOUNT = 'UA-67319750-1'

--- a/src/icp/icp/settings/production.py
+++ b/src/icp/icp/settings/production.py
@@ -107,8 +107,5 @@ DISABLED_MODEL_PACKAGES = []
 
 # END UI CONFIGURATION
 
-# Google API key for production deployment
-GOOGLE_MAPS_API_KEY = 'AIzaSyCXdkywU7rps_i1CeKqWxlBi97vyGeXsqk'
-
 # Stroud account
 GOOGLE_ANALYTICS_ACCOUNT = 'UA-47047573-7'

--- a/src/icp/icp/settings/test.py
+++ b/src/icp/icp/settings/test.py
@@ -28,8 +28,5 @@ REST_FRAMEWORK = {
     )
 }
 
-# API key for testing/development
-GOOGLE_MAPS_API_KEY = 'AIzaSyB0D5gjoIHpmy-xdP2cr_0I-E7K6s_L0k4'
-
 # azaveadev@azavea.com account
 GOOGLE_ANALYTICS_ACCOUNT = 'UA-67319750-1'

--- a/src/icp/js/src/core/views.js
+++ b/src/icp/js/src/core/views.js
@@ -375,7 +375,9 @@ var MapView = Marionette.ItemView.extend({
                     zIndex: zIndex,
                     attribution: '',
                     minZoom: 0});
-                leafletLayer = new L.TileLayer(tileUrl, layer);
+                leafletLayer = new L.TileLayer(tileUrl, layer, {
+                    attribution: layer.attribution
+                });
             } else {
                 leafletLayer = new L.TileLayer('', layer);
             }


### PR DESCRIPTION
## Overview
Adds a neutral and free streets basemap from ESRI.  The previous streets basemap had poor coverage at high zoom levels.  Also add attribution for the source of these basemaps.  The imagery basemap remains the default and expected primary layer for this app.  Additionally

Connects #134 

## Demo
![screenshot from 2017-02-20 17 21 08](https://cloud.githubusercontent.com/assets/1014341/23143733/fe79e964-f790-11e6-986a-181aaa3eca1c.png)

![screenshot from 2017-02-20 17 24 35](https://cloud.githubusercontent.com/assets/1014341/23143826/78449f50-f791-11e6-8edb-426f6d0e054c.png)

## Testing
* Rebundle the branch `./scripts/bundle.sh --debug`
* Verify that the new streets layer loads
  * Additionally check that the basemap can be "zoomed in" without displaying "no data" as it does on staging presently.
* Verify that `ESRI` attribution is displayed on the leaflet map for both layers.