### PR TITLE
Fix compare view overlap on short viewports

### DIFF
--- a/src/icp/js/src/compare/templates/compareScenario.html
+++ b/src/icp/js/src/compare/templates/compareScenario.html
@@ -4,6 +4,8 @@
     <div class="map-region">
         <div class="map-container"></div>
     </div>
-    <div class="modeling-region"></div>
-    <div class="modifications-region"></div>
+    <div class="chart-table-regions">
+        <div class="modeling-region"></div>
+        <div class="modifications-region"></div>
+    </div>
 </div>

--- a/src/icp/sass/pages/_compare.scss
+++ b/src/icp/sass/pages/_compare.scss
@@ -1,10 +1,15 @@
+$compare-footer-height: 50px;
+$compare-map-height: 25vh;
+// Calculate the height between the header and footer, and below the map
+$compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-height} - #{$compare-map-height});
+
 .compare-scenarios-container {
   overflow: hidden;
   position: absolute;
   top: $height-lg;
   left: 0;
   right: 0;
-  bottom: 50px;
+  bottom: $compare-footer-height;
   z-index: 100;
   background-color: $ui-light;
   transition: 0.3s ease left, 0.3s ease right;
@@ -15,7 +20,7 @@
     .scenario-overlay {
       position: absolute;
       z-index: 100;
-      height: 22%;
+      height: $compare-map-height;
       width: 100%;
       background-color: black;
       opacity: 0.25;
@@ -68,7 +73,7 @@
           }
 
           .map-region {
-            height: 22%;
+            height: $compare-map-height;
             width: 100%;
 
             .map-container {
@@ -105,15 +110,20 @@
             }
           }
 
+          .chart-table-regions {
+              height: $compare-chart-table-height;
+              overflow-y: auto;
+              overflow-x: hidden;
+          }
+
           .modeling-region {
             width: 100%;
-            height: 38vh;
 
             .modeling-container {
               position: relative;
               width: auto;
               height: 100%;
-              padding: 1rem;
+              padding: 1rem 1rem 0 1rem;
 
               .fa-spin {
                 margin-left: 8px;
@@ -140,20 +150,18 @@
 
           .modifications-region {
             width: 100%;
-            height: 30vh;
 
             .modifications-container {
               position: relative;
               width: 100%;
               height: 100%;
-              padding: 1rem;
-              overflow-y: auto;
+              padding: 0.5rem 1rem;
 
               .modifications-table {
                 font-size: 0.7rem;
                 width: 100%;
                 td {
-                  padding: 8px;
+                  padding: 2px;
                 }
                 .modification-area {
                   color: $brand-primary;
@@ -202,7 +210,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  height: 50px;
+  height: $compare-footer-height;
   background-color: $ui-light;
   z-index: 100;
 
@@ -213,6 +221,10 @@
 
   h3 {
     display: inline-block;
-    padding: 1rem;
+    vertical-align: top;
+    line-height: $compare-footer-height;
+    padding-left: 1rem;
+    position: relative;
+    height: 100%;
   }
 }


### PR DESCRIPTION
### Overview

The compare view charts overlapped with the modeling info below them on short viewports:
![image](https://cloud.githubusercontent.com/assets/7633670/25629834/f94cc54e-2f38-11e7-8d45-974a29d276d2.png)

If we move the modifications table down, it will be entirely off the screen on shorter viewports, so this PR just sets the entire compare column to scroll.

It also makes some styling updates per @jfrankl's suggestion: the spacing around the modification was unnecessarily large. I've also centered the "Navigate Scenarios" text on the back arrow.

Connects #179 

### Demo
![hv2qavh0sr](https://cloud.githubusercontent.com/assets/7633670/25629804/dd5eb996-2f38-11e7-9db9-5024eb046b81.gif)

### Testing instructions
- Pull and `./scripts/bundle.sh` (make sure updated css files get written)
- Draw an AoI over somewhere with data (ie the triangle near `yuba city`)
- Go to "Compare"
- Confirm view is useable at a variety of window sizes
