### PR TITLE
Add debug output for rasters

### DIFF
--- a/src/icp/pollinator/tests/tests.py
+++ b/src/icp/pollinator/tests/tests.py
@@ -38,7 +38,8 @@ class ReadTests(unittest.TestCase):
         Test a read in of a portion of the crop raster corresponding to a
         field and test that it read the correct area.
         """
-        field, mask = raster_ops.extract(self.field_geom, self.crop_tif)
+        field, mask, win, meta = raster_ops.extract(self.field_geom,
+                                                    self.crop_tif)
         values, counts = np.unique(field.compressed(), return_counts=True)
         count_map = dict(zip(map(str, values), counts))
 
@@ -68,8 +69,8 @@ class ReadTests(unittest.TestCase):
 
         expected_count = sum(self.field_counts.values())
 
-        field, mask = raster_ops.extract(self.field_geom, self.crop_tif,
-                                         reclass)
+        field, mask, win, meta = raster_ops.extract(self.field_geom,
+                                                    self.crop_tif, reclass)
         values, counts = np.unique(field.compressed(), return_counts=True)
 
         self.assertEqual(values, [almonds],


### PR DESCRIPTION
## Overview
To help validate the model and share results, a method which can be
enabled manually has been added, which saves intermediate rasters to
disk.

Connects #205 

## Notes
Using these saved rasters, I compared our output to that supplied by the ICP team.  At `2000m` buffer that we've been using, there is some noticeable misalignment of values, although they are distributed very similarly.  Increasing the buffer to `5000m` produced nearly identical results.  The comparison can be seen here: 
[Pollinator DST Model comparison.pdf](https://github.com/project-icp/bee-pollinator-app/files/971504/Pollinator.DST.Model.comparison.pdf)

Additionally, even though the farm abundance layer is created with differences at the two buffer values, there is a very marginal net change to the yield calculation output.

#### 5km buffer
Crop | Yield
----|----
Orchard | 65.408
Almonds |	64.404


#### 2.5km buffer
Crop | Yield
----|----
Orchard	| 65.365
Almonds	| 64.44

We've provided this information and the tifs to the ICP team for them to evaluate the appropriate buffer value to use.

## Testing
* Change `DEBUG=True`
* Update the model installation `sudo python setup.py install` or `vagrant provision worker`
* Verify that the rasters are saved to disk
* Verify they are not saved when `DEBUG=False`