### PR TITLE
Sort crop legend by legend name

### DIFF
--- a/src/icp/js/src/core/overlayControl.js
+++ b/src/icp/js/src/core/overlayControl.js
@@ -2,6 +2,7 @@
 
 var L = require('leaflet'),
     $ = require('jquery'),
+    _ = require('lodash'),
     Marionette = require('../../shim/backbone.marionette'),
     overlayControlTmpl = require('./templates/overlayControl.html'),
     cropTypes = require('./cropTypes.json');
@@ -92,10 +93,17 @@ var OverlayControlView = Marionette.ItemView.extend({
     },
 
     templateHelpers: function() {
+        var crops = _.chain(cropTypes)
+            .map(function(name, id) {
+                return { id: id, name: name };
+            })
+            .sortBy('name')
+            .value();
+
         return {
             isDisplayed: this.isDisplayed,
             legend: this.isLegendOpen ? "open" : "",
-            cropTypes: cropTypes,
+            cropTypes: crops,
             iconClass: this.isDisplayed ? "fa fa-eye-slash" : "fa fa-eye",
             inputType: this.isDisplayed ? "range" : "hidden",
             layerName: 'Crop Layer',

--- a/src/icp/js/src/core/templates/overlayControl.html
+++ b/src/icp/js/src/core/templates/overlayControl.html
@@ -1,9 +1,9 @@
 <div class="crop-legend-dropdown dropup {{ legend }}">
     <div class="dropdown-menu dropdown-menu-left">
-        {% for id, name in cropTypes %}
+        {% for crop in cropTypes %}
             <div class="legend-item">
-                <span class="legend-color crop-{{ id }}"></span>
-                {{ name }}
+                <span class="legend-color crop-{{ crop.id }}"></span>
+                {{ crop.name }}
             </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
## Overview

Render the CDL entries alphabetically by name.

Connects #209 

## Demo
Giving Alfalfa the prominence it deserves:
![screenshot from 2017-05-05 13 18 13](https://cloud.githubusercontent.com/assets/1014341/25756599/506032cc-3195-11e7-9e60-d5d0e5ecf643.png)

## Testing
* Bundle and ensure the legend order is alphabetical by name