### PR TITLE
Release/0.1.0

### DIFF
--- a/deployment/RELEASES.md
+++ b/deployment/RELEASES.md
@@ -34,7 +34,7 @@ If you cannot see columns for `Branch`, `Environment`, and `Service`, use the ge
 
 ## Release Testing
 
-After the `staging-deployment` job completes, `icp-dev.azavea.com` should reflect the current release. Be sure to run any outstanding database migrations or data imports.
+After the `staging-deployment` job completes, `staging.pollinator-modeling-app.azavea.com` should reflect the current release. Be sure to run any outstanding database migrations or data imports.
 
 ## AMI Promotion
 
@@ -77,7 +77,7 @@ $ ./icp_stack.py launch-stacks --aws-profile icp-prd \
                                --activate-dns
 ```
 
-Within 60 seconds, `app.wikiwatershed.org` and `mmw.azavea.com` should reflect the current release.
+Within 60 seconds, `pollinator-modeling-app.azavea.com` should reflect the current release.
 
 ## Repository & Jenkins Cleanup
 

--- a/src/icp/icp/settings/production.py
+++ b/src/icp/icp/settings/production.py
@@ -25,6 +25,7 @@ if not instance_metadata:
 # See: https://docs.djangoproject.com/en/1.5/releases/1.5/#allowed-hosts-required-in-production  # NOQA
 ALLOWED_HOSTS = [
     'pollinator-modeling-app.azavea.com',
+    'staging.pollinator-modeling-app.azavea.com',
     '.elb.amazonaws.com',
     'localhost'
 ]


### PR DESCRIPTION
In addition to the `pollinator-modeling-app.azavea.com` domain, add support for the `staging.pollinator-modeling-app.azavea.com` domain as well. Also, ensure that operations to determine the current stack color and count are scoped by `StackType == Staging`. This ensures that production CloudFormation stacks are not inadvertently used in CI based deployments.

Addresses part of #227 

**Note**: This pull request is not intended to be merged. Instead, this branch will be merged back into `develop` and `master` as part of a `git-flow` release process.

---

**Testing**

See the logs for the following deployment jobs:

- http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-staging-deployment/47/
- http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-staging-deployment/48/
- http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-staging-deployment/49/