### PR TITLE
Update CDL Tile URL To Corrected Tiles

### DIFF
--- a/src/icp/icp/settings/base.py
+++ b/src/icp/icp/settings/base.py
@@ -365,7 +365,7 @@ BASEMAPS = [
 ]
 
 OVERLAY = {
-    'url': 'https://tiles.pollinator-modeling-app.azavea.com/{z}/{x}/{y}.png',
+    'url': 'https://{s}.tiles.azavea.com/cdl-reclass/{z}/{x}/{y}.png',
     'maxNativeZoom': 15
 }
 


### PR DESCRIPTION
Switches the painted CDL over to the new one created as a result of #229 and locationtech/geotrellis#2170. 

![dqotcyqzgf](https://user-images.githubusercontent.com/7633670/27084697-ccfcdcec-501a-11e7-923b-d9584cc657df.gif)

## Testing
- Pull this branch
- Switch the CDL layer on
- Zoom and pan around!

Connects #234 