### PR TITLE
Update supported domains; remove unused Nginx cache

### DIFF
--- a/deployment/RELEASES.md
+++ b/deployment/RELEASES.md
@@ -34,7 +34,7 @@ If you cannot see columns for `Branch`, `Environment`, and `Service`, use the ge
 
 ## Release Testing
 
-After the `staging-deployment` job completes, `staging.pollinator-modeling-app.azavea.com` should reflect the current release. Be sure to run any outstanding database migrations or data imports.
+After the `staging-deployment` job completes, `staging.app.pollinationmapper.org` should reflect the current release. Be sure to run any outstanding database migrations or data imports.
 
 ## AMI Promotion
 
@@ -77,7 +77,7 @@ $ ./icp_stack.py launch-stacks --aws-profile icp-prd \
                                --activate-dns
 ```
 
-Within 60 seconds, `pollinator-modeling-app.azavea.com` should reflect the current release.
+Within 60 seconds, `app.pollinationmapper.org` should reflect the current release.
 
 ## Repository & Jenkins Cleanup
 

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -38,5 +38,3 @@ graphite_web_version: "0.9.13-pre1"
 
 model_data_path: "/opt/icp-crop-data"
 numpy_version: "1.11.1"
-
-nginx_cache_dir: "/var/cache/nginx"

--- a/deployment/ansible/roles/bee-pollinator.app/tasks/reverse-proxy.yml
+++ b/deployment/ansible/roles/bee-pollinator.app/tasks/reverse-proxy.yml
@@ -1,12 +1,4 @@
 ---
-- name: Ensure Nginx cache directory exists
-  file: path="{{ nginx_cache_dir }}"
-        state=directory
-        owner=www-data
-        group=www-data
-  notify:
-    - Restart Nginx
-
 - name: Configure Nginx site
   template: src=nginx-app.conf.j2
             dest=/etc/nginx/sites-available/icp-app.conf

--- a/deployment/ansible/roles/bee-pollinator.app/templates/nginx-app.conf.j2
+++ b/deployment/ansible/roles/bee-pollinator.app/templates/nginx-app.conf.j2
@@ -1,10 +1,3 @@
-# Protects against scenarios where DNS records for the
-# site being proxied change.
-resolver 8.8.8.8 valid=300s;
-resolver_timeout 10s;
-
-proxy_cache_path {{ nginx_cache_dir }} levels=1:2 keys_zone=OBSERVATION:10m max_size=100m;
-
 server {
   listen *:80;
   server_name _;

--- a/src/icp/icp/settings/production.py
+++ b/src/icp/icp/settings/production.py
@@ -24,8 +24,8 @@ if not instance_metadata:
 # HOST CONFIGURATION
 # See: https://docs.djangoproject.com/en/1.5/releases/1.5/#allowed-hosts-required-in-production  # NOQA
 ALLOWED_HOSTS = [
-    'pollinator-modeling-app.azavea.com',
-    'staging.pollinator-modeling-app.azavea.com',
+    'app.pollinationmapper.org',
+    'staging.app.pollinationmapper.org',
     '.elb.amazonaws.com',
     'localhost'
 ]
@@ -38,7 +38,7 @@ ALLOWED_HOSTS.append(instance_metadata['local-ipv4'])
 
 # EMAIL CONFIGURATION
 EMAIL_BACKEND = 'django_amazon_ses.backends.boto.EmailBackend'
-DEFAULT_FROM_EMAIL = 'noreply@pollinator-modeling-app.azavea.com'
+DEFAULT_FROM_EMAIL = 'noreply@pollinationmapper.org'
 # END EMAIL CONFIGURATION
 
 # MIDDLEWARE CONFIGURATION


### PR DESCRIPTION
Ensure that pollinationmapper.org domains are used for all environments. Also, update the `DEFAULT_EMAIL_FROM` address so that the pollinationmapper.org domain is used.

Lastly, disable the unused Nginx OBSERVATION cache.

---

**Testing**

Navigate to the [new staging domain](https://staging.app.pollinationmapper.org/) and ensure that:

- The site works
- The certificate is valid
- The registration email comes from an pollinationmapper.org address