### PR TITLE
Scenario rename behavior enhancements

### DIFF
--- a/src/icp/js/src/modeling/models.js
+++ b/src/icp/js/src/modeling/models.js
@@ -763,12 +763,15 @@ var ScenariosCollection = Backbone.Collection.extend({
             return model.get('name').toLowerCase() === newName.toLowerCase();
         });
 
-        if (match) {
+        if (model.get('name') === newName || !newName) {
+            return false;
+        }
+        else if (match) {
             console.log('This name is already in use.');
             modalViews.showWarning('There is another scenario with the same name. ' +
                 'Please choose a unique name for this scenario.');
             return false;
-        } else if (model.get('name') !== newName) {
+        } else {
             return model.set('name', newName);
         }
     },

--- a/src/icp/js/src/modeling/tests.js
+++ b/src/icp/js/src/modeling/tests.js
@@ -921,6 +921,50 @@ describe('Modeling', function() {
                     assert.isTrue(spyAlert.calledOnce);
                     assert.equal(collection.at(1).get('name'), 'New Scenario 1');
                 });
+
+
+                it('will not show error when trying to save name as is', function() {
+                    var collection = getTestScenarioCollection(),
+                        view = new views.ScenarioTabPanelsView({ collection: collection });
+
+                    view.render();
+                    var childViews = _.values(view.children._views);
+
+                    childViews[1].ui.rename.trigger('click');
+                    childViews[1].ui.nameField.text('New Scenario 1');
+                    childViews[1].ui.nameField.trigger('blur');
+
+                    assert.isFalse(spyAlert.calledOnce);
+                    assert.equal(collection.at(1).get('name'), 'New Scenario 1');
+                });
+
+                it('resets name if set to empty string', function() {
+                    var collection = getTestScenarioCollection(),
+                        view = new views.ScenarioTabPanelsView({ collection: collection });
+
+                    view.render();
+                    var childViews = _.values(view.children._views);
+
+                    childViews[1].ui.rename.trigger('click');
+                    childViews[1].ui.nameField.text('');
+                    childViews[1].ui.nameField.trigger('blur');
+
+                    assert.equal(collection.at(1).get('name'), 'New Scenario 1');
+                });
+
+                it('resets name if set to just spaces', function() {
+                    var collection = getTestScenarioCollection(),
+                        view = new views.ScenarioTabPanelsView({ collection: collection });
+
+                    view.render();
+                    var childViews = _.values(view.children._views);
+
+                    childViews[1].ui.rename.trigger('click');
+                    childViews[1].ui.nameField.text(' ');
+                    childViews[1].ui.nameField.trigger('blur');
+
+                    assert.equal(collection.at(1).get('name'), 'New Scenario 1');
+                });
             });
 
             describe('#duplicateScenario', function() {

--- a/src/icp/js/src/modeling/views.js
+++ b/src/icp/js/src/modeling/views.js
@@ -350,8 +350,18 @@ var ScenarioTabPanelView = Marionette.ItemView.extend({
                 if (!self.model.collection.updateScenarioName(self.model, name)) {
                     self.render();
                 }
+            },
+
+            selectScenarioTabText = function() {
+                // Select scenario name's text
+                var range = document.createRange(),
+                    selection = window.getSelection();
+                range.selectNodeContents(self.ui.nameField[0]);
+                selection.removeAllRanges();
+                selection.addRange(range);
             };
 
+        selectScenarioTabText();
         this.ui.nameField.attr('contenteditable', true).focus();
 
         this.ui.nameField.on('keyup', function(e) {
@@ -369,6 +379,12 @@ var ScenarioTabPanelView = Marionette.ItemView.extend({
 
                 setScenarioName($(this).text());
             }
+        });
+
+        this.ui.nameField.on('click', function(e) {
+            // Don't let the outer <a> swallow clicks and exit rename mode
+            // Allows selecting text on double click
+            e.stopImmediatePropagation();
         });
 
         this.ui.nameField.on('blur', function() {

--- a/src/icp/sass/base/_header.scss
+++ b/src/icp/sass/base/_header.scss
@@ -157,7 +157,7 @@ header {
         width: 5000px;
 
         .nav-tabs a.tab-name[contenteditable=true] span {
-            border: 1px solid maroon;
+            border: 1px solid $brand-secondary;
         }
 
         .scenario-btn-dropdown {


### PR DESCRIPTION
## Overview

- add additional unit tests for renaming scenario behavior
- allow renaming to same name as the scenario already had
- disallow renaming to blank name
- allow double click on text to highlight
- start with all text highlighted

(This PR is basically identical to WikiWatershed/model-my-watershed#1683)

Connects #150 

## Demo
![lg3uax1xb6](https://user-images.githubusercontent.com/7633670/28085015-73692a52-6648-11e7-950b-9f991d093071.gif)

## Testing instructions
- Rename scenarios confirming they begin highlighted, can be double clicked, and cannot be named another scenario's name or an empty string
