### PR TITLE
Small UI changes

### DIFF
--- a/src/icp/js/src/core/templates/header.html
+++ b/src/icp/js/src/core/templates/header.html
@@ -1,5 +1,5 @@
 <nav id="app-header" class="navbar-watershed">
-    <div class="brand"><a href="/">Pollination Mapper</a></div>
+    <div class="brand"><a href="/">Pollination Mapper <sup>BETA</sup></a></div>
     <div class="navigation">
         <ul class="main">
             {% if guest %}

--- a/src/icp/js/src/core/templates/modificationPopup.html
+++ b/src/icp/js/src/core/templates/modificationPopup.html
@@ -1,6 +1,6 @@
 <h3>
     {{ value|modName }}
-    <small class="text-muted">{{ area|round(2)|toLocaleString(2) }} {{ units }}</small>
+    <small class="text-muted">{{ area|round(1)|toLocaleString(1) }} {{ units }}</small>
 </h3>
 
 {% if isCurrentConditions %}

--- a/src/icp/js/src/core/templates/sharedModificationPopup.html
+++ b/src/icp/js/src/core/templates/sharedModificationPopup.html
@@ -1,6 +1,6 @@
 <h3>
     {{ value|modName }}
-    <small class="text-muted">{{ area|round(2)|toLocaleString(2) }} {{ units }}</small>
+    <small class="text-muted">{{ area|round(1)|toLocaleString(1) }} {{ units }}</small>
 </h3>
 
 <p>

--- a/src/icp/js/src/draw/templates/splash.html
+++ b/src/icp/js/src/draw/templates/splash.html
@@ -11,7 +11,7 @@
     <li>Compare how different scenarios impact your crop’s pollination and yield.</li>
 </ol>
 <p>
-    This <a href="http://icpbees.org/tools-for-growers/help/"><b><i class="fa fa-book"></i> Help Page</b></a> will walk you through the process in more detail.
+This <a target="_blank" rel="noopener noreferrer" href="http://pollinationmapper.org"><b><i class="fa fa-book"></i> Help Page</b></a> will walk you through the process in more detail.
 </p>
 <div class="action-button">
     <button id="get-started" class="btn btn-active btn-lg btn-block" type="button">Get started <i class="fa fa-arrow-right"></i></button>

--- a/src/icp/js/src/modeling/templates/yieldScenarioToolbarTabContent.html
+++ b/src/icp/js/src/modeling/templates/yieldScenarioToolbarTabContent.html
@@ -32,7 +32,7 @@
                             {% for model in models %}
                                 <tr>
                                     <td>{{ model.get('value')|modName }}</td>
-                                    <td class="strong text-right">{{ model.get('effectiveArea')|round(2)|toLocaleString(2) }} {{ model.get('effectiveUnits') }}</td>
+                                    <td class="strong text-right">{{ model.get('effectiveArea')|round(1)|toLocaleString(1) }} {{ model.get('effectiveUnits') }}</td>
                                     {% if editable %}
                                         <td class="text-right"><button class="btn btn-sm btn-icon dark" type="button" data-delete="{{ model.cid }}">
                                             <i class="fa fa-trash"></i>

--- a/src/icp/js/src/modeling/tours.js
+++ b/src/icp/js/src/modeling/tours.js
@@ -42,7 +42,7 @@ var newScenarioTour = createTour(
         steps: [
             {
                 target: "add-pollinator-planting-btn",
-                content: 'Select a pollinator planting type from this menu, then draw it on the scenario map. Plantings can be drawn outside of the selected farm or field area, but cannot be stacked on top of each other. The minimum planting size is 100 ft &times; 100 ft. See <a target="_blank" rel="noopener noreferrer" href="http://icpbees.org/tools-for-growers/help/")>help guide</a> for more information.',
+                content: 'Select a pollinator planting type from this menu, then draw it on the scenario map. Plantings can be drawn outside of the selected farm or field area, but cannot be stacked on top of each other. The minimum planting size is 100 ft &times; 100 ft. See <a target="_blank" rel="noopener noreferrer" href="http://pollinationmapper.org")>help guide</a> for more information.',
                 placement: "bottom"
             },
             {

--- a/src/icp/js/src/modeling/yield/templates/tableRow.html
+++ b/src/icp/js/src/modeling/yield/templates/tableRow.html
@@ -1,5 +1,5 @@
 <td>{{ cropType }}</td>
 {% if not isCurrentConditions %}
-    <td class="strong text-right">{{ currentConditionsYield|round(3)|toLocaleString(3) }}</td>
+    <td class="strong text-right">{{ currentConditionsYield|round(1)|toLocaleString(1) }}</td>
 {% endif %}
-<td class="strong text-right">{{ scenarioYield|round(3)|toLocaleString(3) }}</td>
+<td class="strong text-right">{{ scenarioYield|round(1)|toLocaleString(1) }}</td>

--- a/src/icp/sass/pages/_compare.scss
+++ b/src/icp/sass/pages/_compare.scss
@@ -167,7 +167,7 @@ $compare-chart-table-height: calc(100vh - #{$height-lg} - #{$compare-footer-heig
                   padding: 2px;
                 }
                 .modification-area {
-                  color: $brand-primary;
+                  color: $brand-secondary;
                   text-align: right;
                 }
               }


### PR DESCRIPTION
## Overview

Some small fixups requested by the client:
* Number are uniformly rounded to a single decimal place.
* Yuba Blue is used for output text color on compare
* "BETA" is added to the header branding.
* Updates helpguide link to new window & pollinationmapper.org

Connects #254 
Connects #225 
Connects #251 
Connects #249 

## Notes
~~I matched the header style from the issue for the beta text, but also tried a version as a <sup>superscript</sup> as is common.  Looks like the following, we can do that if consensus indicates it looks better, I do.  I also did not add it to the tab title since we're not changing it to say "beta" every place within the app that it appears, let me know if you think otherwise.~~

*Update: we decided to user the superscript text as represented in Demo*


## Demo

**Rounding and color**
![screenshot from 2017-07-17 10 57 10](https://user-images.githubusercontent.com/1014341/28275294-710c7834-6ae1-11e7-8d58-ad4d982c2dcd.png)
![screenshot from 2017-07-17 10 50 13](https://user-images.githubusercontent.com/1014341/28275295-710d25cc-6ae1-11e7-904e-ef7f7bf1338f.png)
![screenshot from 2017-07-17 10 49 29](https://user-images.githubusercontent.com/1014341/28275296-710d8242-6ae1-11e7-95e7-88f2c154a9dc.png)

**Header text**
![screenshot from 2017-07-17 11 03 57](https://user-images.githubusercontent.com/1014341/28275273-647b02f2-6ae1-11e7-9285-e7cd58eb14c4.png)

### Testing
Verify that all numeric output text is rounded to a decimal place and is the appropriate color.  This includes:
* Shared and scenario popups
* Modification dropdown
* Compare output
* Yield model output

Check that `BETA` is in the header, as well.