### PR TITLE
Replace ZeroClipboard with Clipboard

### DIFF
--- a/src/icp/bundle.sh
+++ b/src/icp/bundle.sh
@@ -95,10 +95,6 @@ COPY_FONTS_COMMAND="cp -r \
     ./node_modules/font-awesome/fonts/* \
     $STATIC_FONTS_DIR"
 
-COPY_ZEROCLIPBOARD_COMMAND="cp \
-    ./node_modules/zeroclipboard/dist/ZeroClipboard.swf \
-    $STATIC_JS_DIR"
-
 CONCAT_VENDOR_CSS_COMMAND="cat \
     ./node_modules/leaflet/dist/leaflet.css \
     ./node_modules/leaflet-draw/dist/leaflet.draw.css \
@@ -116,6 +112,7 @@ JS_DEPS=(backbone
          bootstrap
          bootstrap-select
          bootstrap-table/dist/bootstrap-table.js
+         clipboard
          d3
          ./js/shim/marionette.transition-region.js
          ./js/shim/nv.d3.js
@@ -133,8 +130,7 @@ JS_DEPS=(backbone
          turf-erase
          turf-intersect
          turf-kinks
-         underscore
-         zeroclipboard)
+         underscore)
 
 BROWSERIFY_EXT=""
 BROWSERIFY_REQ=""
@@ -158,7 +154,6 @@ if [ -n "$BUILD_VENDOR_BUNDLE" ]; then
     VENDOR_COMMAND="
         $COPY_IMAGES_COMMAND &
         $COPY_FONTS_COMMAND &
-        $COPY_ZEROCLIPBOARD_COMMAND &
         $CONCAT_VENDOR_CSS_COMMAND &
         $SYMLINK_HOPSCOTCH_IMG_DIR_COMMAND &
         $BROWSERIFY $BROWSERIFY_REQ \

--- a/src/icp/js/src/core/modals/templates/shareModal.html
+++ b/src/icp/js/src/core/modals/templates/shareModal.html
@@ -8,7 +8,7 @@
                 <p>Sorry, only saved {{ text }}s are able to be shared.  Please log in to share your work.</p>
             {% else %}
                 <div class="custom-input-group">
-                  <input type="text" required value="{{ url }}">
+                  <input id="share-url" type="text" required value="{{ url }}">
                   <span class="highlight"></span>
                   <span class="bar"></span>
                   <label>URL</label>
@@ -21,7 +21,7 @@
                 <button type="button" class="btn btn-md btn-default signin" data-dismiss="modal">Sign In</button>
             {% else %}
                 <button type="button" class="btn btn-md btn-default" data-dismiss="modal">Cancel</button>
-                <button type="button" class="btn btn-md btn-default copy" data-dismiss="modal" data-clipboard-text="{{ url }}">Copy Link</button>
+                <button type="button" class="btn btn-md btn-default copy" data-dismiss="modal" data-clipboard-target="#share-url">Copy Link</button>
             {% endif %}
         </div>
     </div>

--- a/src/icp/js/src/core/modals/views.js
+++ b/src/icp/js/src/core/modals/views.js
@@ -3,7 +3,7 @@
 var _ = require('underscore'),
     coreUtils = require('../utils.js'),
     Marionette = require('../../../shim/backbone.marionette'),
-    ZeroClipboard = require('zeroclipboard'),
+    Clipboard = require('clipboard'),
     models = require('./models'),
     modalConfirmTmpl = require('./templates/confirmModal.html'),
     modalInputTmpl = require('./templates/inputModal.html'),
@@ -167,16 +167,12 @@ var ShareView = ModalBaseView.extend({
         'click @ui.signin': 'signIn'
     }, ModalBaseView.prototype.events),
 
-    initialize: function() {
-        this.zc = new ZeroClipboard();
-    },
-
-    // Override to attach ZeroClipboard to ui.copy button
+    // Override to attach Clipboard to ui.copy button
     onRender: function() {
         var self = this;
 
         this.$el.on('shown.bs.modal', function() {
-            self.zc.clip(self.ui.copy);
+            new Clipboard(self.ui.copy[0]);
         });
 
         if (this.model.get('is_private')) {

--- a/src/icp/js/src/core/setup.js
+++ b/src/icp/js/src/core/setup.js
@@ -31,9 +31,3 @@ L.Icon.Default.imagePath = '/static/images/';
 
 var csrf = require('./csrf');
 $.ajaxSetup(csrf.jqueryAjaxSetupOptions);
-
-var ZeroClipboard = require('zeroclipboard');
-ZeroClipboard.config({
-    hoverClass: 'focus',
-    activeClass: 'active'
-});

--- a/src/icp/npm-shrinkwrap.json
+++ b/src/icp/npm-shrinkwrap.json
@@ -971,6 +971,35 @@
         }
       }
     },
+    "clipboard": {
+      "version": "1.7.1",
+      "from": "clipboard@*",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
+      "dependencies": {
+        "good-listener": {
+          "version": "1.2.2",
+          "from": "good-listener@>=1.2.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+          "dependencies": {
+            "delegate": {
+              "version": "3.1.3",
+              "from": "delegate@>=3.1.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.1.3.tgz"
+            }
+          }
+        },
+        "select": {
+          "version": "1.1.2",
+          "from": "select@>=1.1.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz"
+        },
+        "tiny-emitter": {
+          "version": "2.0.1",
+          "from": "tiny-emitter@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.1.tgz"
+        }
+      }
+    },
     "d3": {
       "version": "3.5.5",
       "from": "https://registry.npmjs.org/d3/-/d3-3.5.5.tgz",
@@ -3961,11 +3990,6 @@
           "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
         }
       }
-    },
-    "zeroclipboard": {
-      "version": "2.2.0",
-      "from": "https://registry.npmjs.org/zeroclipboard/-/zeroclipboard-2.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/zeroclipboard/-/zeroclipboard-2.2.0.tgz"
     }
   }
 }

--- a/src/icp/package.json
+++ b/src/icp/package.json
@@ -26,6 +26,7 @@
     "bootstrap-table": "1.11.0",
     "browserify": "9.0.3",
     "chai": "1.10.0",
+    "clipboard": "1.7.1",
     "d3": "3.5.5",
     "font-awesome": "4.3.0",
     "hopscotch": "0.3.1",
@@ -52,7 +53,6 @@
     "turf-intersect": "1.4.2",
     "turf-kinks": "3.0.12",
     "underscore": "1.8.3",
-    "watchify": "3.1.0",
-    "zeroclipboard": "2.2.0"
+    "watchify": "3.1.0"
   }
 }


### PR DESCRIPTION
## Overview

Flash-based clipboard access was recently removed from Chrome.  Consequently, copying the URL from the share dialogs was failing.  This switches to a JS based version that restores the previous functionality.

Implemented from work done in https://github.com/WikiWatershed/model-my-watershed/pull/2008 with caution around the subsequent findings on shrinkwrap.

Connects #248 

## Testing
* Update your node_modules
  * `rm -rf src/icp/node_modules` & `./scripts/npm.sh install`
* Rebundle both the app js and the vendor js
* Load the app, create a project, add a scenario, and save the project. Use the scenario menu to open the share dialog. Make the project public, and press the "Copy Link" button. Verify that the correct URL was added to the clipboard.
* Go through this process in multiple browsers