### PR TITLE
Increase z-index of tour bubble

### DIFF
--- a/src/icp/sass/base/_tour.scss
+++ b/src/icp/sass/base/_tour.scss
@@ -20,7 +20,7 @@ button.hopscotch-nav-button.next.hopscotch-next {
 }
 
 div.hopscotch-bubble {
-    z-index: 100;
+    z-index: 201; //Allows bubble over Compare and Scenario dropdowns
     border: none;
     filter: drop-shadow(rgba(0, 0, 0, 0.3) 0 2px 10px);
 


### PR DESCRIPTION
## Overview

To ensure the tour is placed over all page elements, including the
Compare button, the z-index has been increased.  The value was chosen
as 1 larger than the Compare z-index, which was set to place _it_ over
the scenario drop down icon/menu.

Connects #270 

### Demo
![screenshot from 2017-07-25 14 49 58](https://user-images.githubusercontent.com/1014341/28588747-8d44a59e-7149-11e7-80b6-0e81caeb69a1.png)


## Testing
* After rebundling, clear your application data cache for the localhost site.  This will enable the tour.
* Advance to a project and cycle through the tour elements.  Ensure that there is no placement issue where the Compare button is over the bubble.