### PR TITLE
Rotate crop chart label to prevent crowding

### DIFF
--- a/src/icp/js/src/core/chart.js
+++ b/src/icp/js/src/core/chart.js
@@ -135,13 +135,15 @@ function renderGroupedVerticalBarChart(chartEl, data, options) {
 
     options = options || {};
     _.defaults(options, {
-        margin: {top: 20, right: 30, bottom: 40, left: 60},
+        margin: {top: 20, right: 30, bottom: 45, left: 60},
         maxBarWidth: 150,
         showLegend: true,
         disableToggle: true,
     });
 
     nv.addGraph(function() {
+        var cropCountBeforeRotate = options.compareMode ? 2 : 3;
+
         chart.showLegend(options.showLegend)
              .showControls(false)
              .reduceXTicks(false)
@@ -150,6 +152,11 @@ function renderGroupedVerticalBarChart(chartEl, data, options) {
 
         if (options.compareMode) {
             addSvgClass($svg, 'compare');
+        }
+
+        // Rotate the labels to conserve space when there are X+ items
+        if (options.barClasses.length > cropCountBeforeRotate) {
+            chart.rotateLabels(18);
         }
 
         setChartWidth();


### PR DESCRIPTION
## Overview

When the number of crops is above 2 on compare, or 3 on the main
output, rotate the crop name slightly to avoid squished text. The
labels are not rotated under all circumstances because they look off
when there is plenty of room but are still rotated.

Connects #273 

## Demo

### Main output, changes at 3 crops
![screenshot from 2017-07-31 10 23 02](https://user-images.githubusercontent.com/1014341/28782351-da5ec536-75da-11e7-9ee5-57a9a4b53130.png)
![screenshot from 2017-07-31 10 22 31](https://user-images.githubusercontent.com/1014341/28782348-d82b090a-75da-11e7-8c25-0e43d28395f3.png)

### Compare output, changes at 2 crops
![screenshot from 2017-07-31 10 19 53](https://user-images.githubusercontent.com/1014341/28782349-d82dc4e2-75da-11e7-80bd-d2bda6932512.png)
![screenshot from 2017-07-31 10 18 52](https://user-images.githubusercontent.com/1014341/28782347-d8275c06-75da-11e7-8a4c-ecc6a52969c4.png)
