### PR TITLE
Update deployment pipeline

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define "services" do |services|
     services.vm.hostname = "services"
     services.vm.network "private_network", ip: ENV.fetch("ICP_SERVICES_IP", "33.33.34.30")
+    services.vm.synced_folder "~/.aws", "/home/vagrant/.aws"
 
     # Graphite Web
     services.vm.network "forwarded_port", {

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -18,9 +18,9 @@ postgresql_database: icp
 
 postgresql_version: "9.4"
 postgresql_package_version: "9.4.*.pgdg14.04+1"
-postgresql_support_repository_channel: "main"
-postgresql_support_libpq_version: "10.5-*.pgdg14.04+1"
-postgresql_support_psycopg2_version: "2.7"
+postgresql_support_repository_channel: "9.4"
+postgresql_support_libpq_version: "9.4.*"
+postgresql_support_psycopg2_version: "2.6.*"
 postgis_version: "2.1"
 postgis_package_version: "2.1.*.pgdg14.04+1"
 

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -69,3 +69,15 @@
 
 - src: azavea.docker
   version: 4.0.0
+
+- src: azavea.python
+  version: 0.1.0
+
+- src: azavea.unzip
+  version: 0.1.2
+
+- src: azavea.apache2
+  version: 0.2.4
+
+- src: azavea.memcached
+  version: 0.1.0

--- a/deployment/ansible/roles/bee-pollinator.base/meta/main.yml
+++ b/deployment/ansible/roles/bee-pollinator.base/meta/main.yml
@@ -3,6 +3,4 @@ dependencies:
   - { role: "azavea.ntp" }
   - { role: "azavea.git" }
   - { role: "azavea.daemontools" }
-  - role: "azavea.postgresql-support"
-    postgresql_support_libpq_version: "9.3.*"
-    postgresql_support_psycopg2_version: "2.6.*"
+  - { role: "azavea.postgresql-support" }

--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -89,7 +89,8 @@
                 "sleep 5",
                 "sudo apt-get update -qq",
                 "sudo apt-get install python-pip python-dev libffi-dev libssl-dev -y",
-                "sudo pip install ansible==2.2.1.0",
+                "sudo pip install --upgrade pip",
+                "sudo pip install ansible==2.5.4.0",
                 "sudo /bin/sh -c 'echo {{user `version`}} > /srv/version.txt'"
             ]
         },

--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.2.1.0
+ansible==2.5.4.0
 majorkirby>=0.2.0,<0.2.99
 troposphere>=1.9.1
 boto==2.45.0


### PR DESCRIPTION
# Overview
This PR includes fixes for some of the inconsistencies I found when doing a Staging deployment. Changes are mostly version bumps and making sure dependencies are consistent across environments.

## Changes
- [ ]  Add missing Ansible dependencies to `roles.yml`
- [ ]  Make `libpq` and `psycopg2` versions consistent across environments
- [ ]  Lookup Ubuntu AMI IDs with `boto` instead of manually parsing Ubuntu's `releases.current.txt` file.
- [ ] Bump Ansible version to `2.5.4`

# Notes
-  The `libpq` and `psycopg2` versions in `group_vars/all` were being overridden by hardcoded values in `bee-pollination.base/meta/main.yml`. As a result, the App servers are/have been using `psycopg2==2.6.*` and `libpq-dev=9.3.*`. According to https://github.com/project-icp/bee-pollinator-app/commit/5fe0b9500c7b9507d40c042bc325c831f5df4b95  that's the version that we _should_ be at, so I chose to use those versions instead of the newer ones in `group_vars/all`

# Deployment checklist
- [x] deploy using Jenkins CI pipeline
- [x] run migrations
- [x] Add Admin user
        - [ ] Save credentials in LastPass
- [x] Verify new user sign up and email functionality
- [x] Verify modeling endpoint functionality
- [x] Verify project creation/sharing functionality

# Testing
- I deployed this project to Staging using Jenkins. See http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-develop/68/console
- See https://staging.app.pollinationmapper.org
- Verify ELK stack is functioning at ~https://monitoring.staging.app.pollinationmapper.org:5601~ http://monitoring.staging.app.pollinationmapper.org:5601