### PR TITLE
Beekeeper raster endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,9 @@ Beekeepers is a separate front-end app that takes advantage of the API infrastru
 
 The app can be viewed at [http://localhost:8000/?beekeepers](http://localhost:8000/?beekeepers).
 
+## AWS Credentials
+Raster data used by Beekeeper is stored and accessed from a private s3 bucket. To authenticate your requests, get your own IAM credentials and add them under an `icp_bees` profile to `~/.aws/credentials`. Ensure your `~/.aws/credentials` file has at least read permissions, else run `chmod -R 644 ~/.aws`. Provision your VM to mount the AWS credentials with Ansible.
+
 To build the Beekeepers App, run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Beekeepers is a separate front-end app that takes advantage of the API infrastru
 The app can be viewed at [http://localhost:8000/?beekeepers](http://localhost:8000/?beekeepers).
 
 ## AWS Credentials
-Raster data used by Beekeeper is stored and accessed from a private s3 bucket. To authenticate your requests, get your own IAM credentials and add them under an `icp_bees` profile to `~/.aws/credentials`. Ensure your `~/.aws/credentials` file has at least read permissions, else run `chmod -R 644 ~/.aws`. Provision your VM to mount the AWS credentials with Ansible.
+Raster data used by Beekeeper is stored and accessed from a private s3 bucket. To authenticate your requests, get your own IAM credentials and add them under an `icp-bees` profile to `~/.aws/credentials`. Ensure your `~/.aws/credentials` file has at least read permissions, else run `chmod -R 644 ~/.aws`. Provision your VM to mount the AWS credentials with Ansible.
 
 To build the Beekeepers App, run:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -112,6 +112,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     app.vm.hostname = "app"
     app.vm.network "private_network", ip: ENV.fetch("ICP_APP_IP", "33.33.34.10")
 
+    app.vm.synced_folder "~/.aws", "/home/vagrant/.aws", type: "rsync"
+    app.vm.synced_folder "~/.aws", "/var/lib/icp/.aws", type: "rsync", owner: "icp", group: "icp", :mount_options =>[dmode=644,fmode=644]
+
     if Vagrant::Util::Platform.windows? || Vagrant::Util::Platform.cygwin?
       app.vm.synced_folder "src/icp", "/opt/app/", type: "rsync", rsync__exclude: ["node_modules/", "apps/"]
       app.vm.synced_folder "src/icp/apps", "/opt/app/apps"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -113,7 +113,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     app.vm.network "private_network", ip: ENV.fetch("ICP_APP_IP", "33.33.34.10")
 
     app.vm.synced_folder "~/.aws", "/home/vagrant/.aws", type: "rsync"
-    app.vm.synced_folder "~/.aws", "/var/lib/icp/.aws", type: "rsync", owner: "icp", group: "icp", :mount_options =>[dmode=644,fmode=644]
+    app.vm.synced_folder "~/.aws", "/var/lib/icp/.aws", type: "rsync"
 
     if Vagrant::Util::Platform.windows? || Vagrant::Util::Platform.cygwin?
       app.vm.synced_folder "src/icp", "/opt/app/", type: "rsync", rsync__exclude: ["node_modules/", "apps/"]

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -42,3 +42,5 @@ docker_version: "18.*"
 
 model_data_path: "/opt/icp-crop-data"
 numpy_version: "1.11.1"
+
+ubuntu_ssl_certs: "/etc/ssl/certs/ca-certificates.crt"

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -43,4 +43,4 @@ docker_version: "18.*"
 model_data_path: "/opt/icp-crop-data"
 numpy_version: "1.11.1"
 
-ubuntu_ssl_certs: "/etc/ssl/certs/ca-certificates.crt"
+ubuntu_ssl_cert_path: "/etc/ssl/certs/ca-certificates.crt"

--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -23,6 +23,7 @@ celery_processes_per_worker: 1
 
 docker_options: "-H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock --storage-driver=aufs"
 
-aws_profile: "icp-stg"
+aws_profile: "icp_bees"
+aws_beekeepers_data_bucket: "beekeepers-staging-data-us-east-1"
 
 stack_type: "Development"

--- a/deployment/ansible/group_vars/development
+++ b/deployment/ansible/group_vars/development
@@ -23,7 +23,7 @@ celery_processes_per_worker: 1
 
 docker_options: "-H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock --storage-driver=aufs"
 
-aws_profile: "icp_bees"
+aws_profile: "icp-bees"
 aws_beekeepers_data_bucket: "beekeepers-staging-data-us-east-1"
 
 stack_type: "Development"

--- a/deployment/ansible/group_vars/test
+++ b/deployment/ansible/group_vars/test
@@ -19,5 +19,6 @@ celery_number_of_workers: 2
 celery_processes_per_worker: 1
 
 aws_profile: "icp-stg"
+aws_beekeepers_data_bucket: "beekeepers-staging-data-us-east-1"
 
 stack_type: "Testing"

--- a/deployment/ansible/roles/bee-pollinator.base/defaults/main.yml
+++ b/deployment/ansible/roles/bee-pollinator.base/defaults/main.yml
@@ -14,3 +14,5 @@ envdir_config:
   ROLLBAR_SERVER_SIDE_ACCESS_TOKEN: "Unknown"
   AWS_PROFILE: "{{ aws_profile }}"
   AWS_BEEKEEPERS_DATA_BUCKET: "{{ aws_beekeepers_data_bucket }}"
+  CURL_CA_BUNDLE: "{{ ubuntu_ssl_certs }}"
+  

--- a/deployment/ansible/roles/bee-pollinator.base/defaults/main.yml
+++ b/deployment/ansible/roles/bee-pollinator.base/defaults/main.yml
@@ -14,5 +14,5 @@ envdir_config:
   ROLLBAR_SERVER_SIDE_ACCESS_TOKEN: "Unknown"
   AWS_PROFILE: "{{ aws_profile }}"
   AWS_BEEKEEPERS_DATA_BUCKET: "{{ aws_beekeepers_data_bucket }}"
-  CURL_CA_BUNDLE: "{{ ubuntu_ssl_certs }}"
+  CURL_CA_BUNDLE: "{{ ubuntu_ssl_cert_path }}"
   

--- a/deployment/ansible/roles/bee-pollinator.base/defaults/main.yml
+++ b/deployment/ansible/roles/bee-pollinator.base/defaults/main.yml
@@ -12,3 +12,5 @@ envdir_config:
   ICP_STACK_COLOR: "{{ stack_color }}"
   ICP_STACK_TYPE: "{{ stack_type }}"
   ROLLBAR_SERVER_SIDE_ACCESS_TOKEN: "Unknown"
+  AWS_PROFILE: "{{ aws_profile }}"
+  AWS_BEEKEEPERS_DATA_BUCKET: "{{ aws_beekeepers_data_bucket }}"

--- a/deployment/ansible/roles/bee-pollinator.beekeepers/tasks/main.yml
+++ b/deployment/ansible/roles/bee-pollinator.beekeepers/tasks/main.yml
@@ -43,12 +43,3 @@
         group="icp"
         owner="icp"
   when: "['development', 'test'] | some_are_in(group_names)"
-
-- name: Create tls certs dir
-  file: path="/etc/pki/tls/certs/"
-        state=directory
-
-- name: Symlink ca-certs
-  file: path="/etc/pki/tls/certs/ca-bundle.crt"
-        state=link
-        src="/etc/ssl/certs/ca-certificates.crt"

--- a/deployment/ansible/roles/bee-pollinator.beekeepers/tasks/main.yml
+++ b/deployment/ansible/roles/bee-pollinator.beekeepers/tasks/main.yml
@@ -37,3 +37,17 @@
   file: path="{{ beekeepers_static_root }}"
         src="{{ beekeepers_home }}/dist"
         state=link
+
+- name: Change AWS credentials access to the icp user
+  file: path="/var/lib/icp/.aws"
+        group="icp"
+        owner="icp"
+
+- name: Create tls certs dir
+  file: path="/etc/pki/tls/certs/"
+        state=directory
+
+- name: Symlink ca-certs
+  file: path="/etc/pki/tls/certs/ca-bundle.crt"
+        state=link
+        src="/etc/ssl/certs/ca-certificates.crt"

--- a/deployment/ansible/roles/bee-pollinator.beekeepers/tasks/main.yml
+++ b/deployment/ansible/roles/bee-pollinator.beekeepers/tasks/main.yml
@@ -42,6 +42,7 @@
   file: path="/var/lib/icp/.aws"
         group="icp"
         owner="icp"
+  when: "['development', 'test'] | some_are_in(group_names)"
 
 - name: Create tls certs dir
   file: path="/etc/pki/tls/certs/"

--- a/src/icp/apps/beekeepers/tasks.py
+++ b/src/icp/apps/beekeepers/tasks.py
@@ -1,74 +1,31 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
 
-import os
 import rasterio
 from pyproj import Proj
-
-from rest_framework import decorators
-from rest_framework.response import Response
-from rest_framework.permissions import AllowAny
-
-DATA_BUCKET = os.environ['AWS_BEEKEEPERS_DATA_BUCKET']
-# TODO: Move the filenames somewhere more permanent in the front end.
-# Filenames will eventually be sent to the fetch_data endpoint
-FILENAMES = {
-    '3k': [
-        'pesticide_3k.tif',
-        'forage_spring_3k.tif',
-        'forage_sum_3k.tif',
-        'forage_fall_3k.tif'
-    ],
-    '5k': [
-        'forage_spring_5k.tif',
-        'forage_sum_5k.tif',
-        'forage_fall_5k.tif'
-    ]
-}
 
 
 def sample_at_point(geom, raster_path):
     """
-    Return the cell value for a raster at a provided lat lon coordinate
-    Args:
-        geom({x: float, y: float}): A EPSG:4326 point in the same SRS as the
-            target raster defining the point to extract the cell value.
-        raster_path (string): A file path to a geographic raster
-            containing the value to extract.
-    Returns:
-        The cell value, in the data type of the input raster, at the point geom
+    Return the cell value for a raster at a provided lat lon coordinate.
+
+    :param geom: An EPSG:4326 point at which to extract the cell value
+                 from the target raster.
+    :param raster_path: A file path to a geographic raster containing
+                        the value to extract.
+
+    :type geom: Dict with lat and lon values, like {lat: float, lon: float}
+    :type raster_path: String
     """
-    with rasterio.open(raster_path, mode='r') as src:
-        # reproject xy to coords in the same SRS as the target raster
-        to_proj = Proj(src.crs)
-        x, y = to_proj(geom['y'], geom['x'])
+    try:
+        with rasterio.open(raster_path, mode='r') as src:
+            # reproject latlon to coords in the same SRS as the target raster
+            to_proj = Proj(src.crs)
+            x, y = to_proj(geom['lon'], geom['lat'])
 
-        # Sample the raster at the given coordinates
-        value_gen = src.sample([(x, y)], indexes=[1])
-        value = value_gen.next().item(0)
-        return value
-
-
-@decorators.api_view(['POST'])
-@decorators.permission_classes((AllowAny, ))
-def fetch_data(request):
-    """
-    Return the cell values from rasters on s3
-
-    TODO: Receives validated geom, forage range, and filename(s) from the
-    request
-    """
-    geom = {
-        'x': 39.9473832311,
-        'y': -76.9297742315,
-    }
-    forage_range = '3k'
-
-    filenames_at_buffer = FILENAMES[forage_range]
-    resp = {}
-    for filename in filenames_at_buffer:
-        s3_url = 's3://{}/{}/{}'.format(DATA_BUCKET, forage_range, filename)
-        value = sample_at_point(geom, s3_url)
-        resp.update({filename: value})
-
-    return Response(resp)
+            # Sample the raster at the given coordinates
+            value_gen = src.sample([(x, y)], indexes=[1])
+            value = value_gen.next().item(0)
+    except rasterio.RasterioIOError as e:
+        value = e
+    return value

--- a/src/icp/apps/beekeepers/tasks.py
+++ b/src/icp/apps/beekeepers/tasks.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+
+import os
+import rasterio
+from pyproj import Proj
+
+from rest_framework import decorators
+from rest_framework.response import Response
+from rest_framework.permissions import AllowAny
+
+DATA_BUCKET = os.environ['AWS_BEEKEEPERS_DATA_BUCKET']
+# TODO: Move the filenames somewhere more permanent in the front end.
+# Filenames will eventually be sent to the fetch_data endpoint
+FILENAMES = {
+    '3k': [
+        'pesticide_3k.tif',
+        'forage_spring_3k.tif',
+        'forage_sum_3k.tif',
+        'forage_fall_3k.tif'
+    ],
+    '5k': [
+        'forage_spring_5k.tif',
+        'forage_sum_5k.tif',
+        'forage_fall_5k.tif'
+    ]
+}
+
+
+def sample_at_point(geom, raster_path):
+    """
+    Return the cell value for a raster at a provided lat lon coordinate
+    Args:
+        geom({x: float, y: float}): A EPSG:4326 point in the same SRS as the
+            target raster defining the point to extract the cell value.
+        raster_path (string): A file path to a geographic raster
+            containing the value to extract.
+    Returns:
+        The cell value, in the data type of the input raster, at the point geom
+    """
+    with rasterio.open(raster_path, mode='r') as src:
+        # reproject xy to coords in the same SRS as the target raster
+        to_proj = Proj(src.crs)
+        x, y = to_proj(geom['y'], geom['x'])
+
+        # Sample the raster at the given coordinates
+        value_gen = src.sample([(x, y)], indexes=[1])
+        value = value_gen.next().item(0)
+        return value
+
+
+@decorators.api_view(['POST'])
+@decorators.permission_classes((AllowAny, ))
+def fetch_data(request):
+    """
+    Return the cell values from rasters on s3
+
+    TODO: Receives validated geom, forage range, and filename(s) from the
+    request
+    """
+    geom = {
+        'x': 39.9473832311,
+        'y': -76.9297742315,
+    }
+    forage_range = '3k'
+
+    filenames_at_buffer = FILENAMES[forage_range]
+    resp = {}
+    for filename in filenames_at_buffer:
+        s3_url = 's3://{}/{}/{}'.format(DATA_BUCKET, forage_range, filename)
+        value = sample_at_point(geom, s3_url)
+        resp.update({filename: value})
+
+    return Response(resp)

--- a/src/icp/apps/beekeepers/urls.py
+++ b/src/icp/apps/beekeepers/urls.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.conf.urls import patterns, url
+
+from apps.beekeepers import tasks
+
+urlpatterns = patterns(
+    '',
+    url(r'fetch/$', tasks.fetch_data, name='fetch_data'),
+)

--- a/src/icp/apps/beekeepers/urls.py
+++ b/src/icp/apps/beekeepers/urls.py
@@ -5,9 +5,9 @@ from __future__ import division
 
 from django.conf.urls import patterns, url
 
-from apps.beekeepers import tasks
+from apps.beekeepers import views
 
 urlpatterns = patterns(
     '',
-    url(r'fetch/$', tasks.fetch_data, name='fetch_data'),
+    url(r'fetch/$', views.fetch_data, name='fetch_data'),
 )

--- a/src/icp/apps/beekeepers/views.py
+++ b/src/icp/apps/beekeepers/views.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+
+import os
+
+from rest_framework import decorators
+from rest_framework.response import Response
+from rest_framework.permissions import AllowAny
+
+from tasks import sample_at_point
+
+
+DATA_BUCKET = os.environ['AWS_BEEKEEPERS_DATA_BUCKET']
+# TODO: Move the filenames somewhere more permanent in the front end.
+# Filenames will eventually be sent to the fetch_data endpoint
+FILENAMES = {
+    '3k': [
+        'pesticide_3k.tif',
+        'forage_spring_3k.tif',
+        'forage_sum_3k.tif',
+        'forage_fall_3k.tif'
+    ],
+    '5k': [
+        'forage_spring_5k.tif',
+        'forage_sum_5k.tif',
+        'forage_fall_5k.tif'
+    ]
+}
+
+
+@decorators.api_view(['POST'])
+@decorators.permission_classes((AllowAny, ))
+def fetch_data(request):
+    """
+    Return the cell values from rasters on s3.
+
+    TODO: Receive validated geom, forage range, and filename(s) from the
+    request
+    """
+    geom = {
+        'lat': 39.9473832311,
+        'lon': -76.9297742315,
+    }
+    forage_range = '3k'
+
+    filenames_at_buffer = FILENAMES[forage_range]
+    resp = {}
+    for filename in filenames_at_buffer:
+        s3_url = 's3://{}/{}/{}'.format(DATA_BUCKET, forage_range, filename)
+        value = sample_at_point(geom, s3_url)
+        resp.update({filename: value})
+
+    return Response(resp)

--- a/src/icp/icp/urls.py
+++ b/src/icp/icp/urls.py
@@ -15,12 +15,14 @@ import apps.home.urls
 import apps.home.views
 import apps.user.urls
 import apps.monitoring.urls
+import apps.beekeepers.urls
 
 admin.autodiscover()
 
 urlpatterns = patterns(
     '',
     url(r'^', include(apps.home.urls)),
+    url(r'^beekeepers/', include(apps.beekeepers.urls)),
     url(r'^health-check/', include(apps.monitoring.urls)),
     url(r'^api-auth/', include(rest_framework.urls,
                                namespace='rest_framework')),

--- a/src/icp/requirements/base.txt
+++ b/src/icp/requirements/base.txt
@@ -13,3 +13,6 @@ requests==2.9.1
 rollbar==0.12.1
 retry==0.9.1
 django-webpack-loader==0.6.0
+rasterio[s3]==1.0.8
+pyproj==1.9.5.1
+boto3==1.8.0


### PR DESCRIPTION
## Overview

The beekeeper app will need to query rasters in s3 to get data at a point. The rasters are pre-processed by the client for single-value lookups and the data sets may be updated by the client directly on s3. This PR setups up beekeeper's first API endpoint with this functionality.

Connects #288 

### Demo
<img width="443" alt="screen shot 2018-10-23 at 3 01 15 pm" src="https://user-images.githubusercontent.com/10568752/47384239-8b1acb80-d6d4-11e8-915f-20d5d00ef1e1.png">

### Notes

Wow, AWS permissions were a serious doozy and delayed this PR significantly.
Rasterio making requests to s3 requires AWS IAM credentials. While boto3 under the hood of Rasterio automatically picks up various env variables pointing to or specifying AWS cred info, several manual steps by Ansible were necessary to make the AWS creds file readable from within Django by boto3.
- Correct `read` permissions on `~/.aws/` and its contents
- Mounting `~/.aws` to the correct user `$HOME` dir in the `app` VM (the user is `icp` and said user is created by Ansible so isn't avail until provision is run)
- Ensuring the correct permissions on `~/.aws` as the `icp` user within the VM
- Setting Ansible env variables (particularly `AWS_PROFILE` because boto3 picks that up automatically to read `~/.aws/credentials`)
- Making available an HTTPS cert required by rasterio to query s3 (`/etc/ssl/certs/ca-certificates.crt`)
- Working around this rasterio [clobbered creds issue ](https://github.com/mapbox/rasterio/issues/1507)(fixed as of 10/24/18)

Known follow-up work (different cards):
- Have the endpoint take geom, forage-range, and filenames data
- Getting the homepage and the beekeeper app urls on the same url scheme (currently `?beekeepers` and `/beekeepers`). The [ADR discussed ](https://github.com/project-icp/bee-pollinator-app/blob/develop/doc/phase-2/000_project_architecture_adr.md#consequences)something like the latter.

### Testing Instructions
- Get AWS IAM credentials for Bees and add them to an `icp_bees` profile in your `~/.aws/credentials` file
- Follow the Beekeepers section of the README (if anything is unclear or doesn't work, good time for feedback). If you haven't rebuilt your VM since before #294 I suggest destroying your VM first.
- Once you do the above, hit http://localhost:8000/beekeepers/fetch/ and click "Post". 
- You should get back data
- Feel free to play with the `geom` or `forage_range` in `beekeepers/tasks.py` to test different data
