### PR TITLE
Map click adds marker to map and updates state

### DIFF
--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -2,4 +2,4 @@ import { createAction } from 'redux-act';
 
 export const setSort = createAction('Set apiary sort');
 export const setForageRange = createAction('Set forage range');
-export const setApiaryList = createAction('Adds a location to the apiary list');
+export const setApiaryList = createAction('Set the apiary list');

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -2,3 +2,4 @@ import { createAction } from 'redux-act';
 
 export const setSort = createAction('Set apiary sort');
 export const setForageRange = createAction('Set forage range');
+export const addApiary = createAction('Adds a location to the apiary list');

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -2,4 +2,4 @@ import { createAction } from 'redux-act';
 
 export const setSort = createAction('Set apiary sort');
 export const setForageRange = createAction('Set forage range');
-export const addApiary = createAction('Adds a location to the apiary list');
+export const setApiaryList = createAction('Adds a location to the apiary list');

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -1,27 +1,49 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { Map as LeafletMap, TileLayer } from 'react-leaflet';
 import { connect } from 'react-redux';
+import { arrayOf, object } from 'prop-types';
 
 import { MAP_CENTER, MAP_ZOOM } from '../constants';
 
-const Map = () => (
-    <div className="map">
-        <LeafletMap
-            center={MAP_CENTER}
-            zoom={MAP_ZOOM}
-        >
-            <TileLayer
-                attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-            />
-        </LeafletMap>
-    </div>
-);
+class Map extends Component {
+    constructor() {
+        super();
+        this.onClickAddMarker = this.onClickAddMarker.bind(this);
+    }
+
+    onClickAddMarker(event) {
+        window.console.log(event);
+        const { apiaries } = this.props;
+        apiaries.push({
+            name: 'Geocoded name',
+            location: event.latlng,
+        });
+    }
+
+    render() {
+        return (
+            <div className="map">
+                <LeafletMap
+                    center={MAP_CENTER}
+                    zoom={MAP_ZOOM}
+                    onClick={this.onClickAddMarker}
+                >
+                    <TileLayer
+                        attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
+                        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                    />
+                </LeafletMap>
+            </div>
+        );
+    }
+}
 
 function mapStateToProps(state) {
     return state.main;
 }
 
-Map.propTypes = {};
+Map.propTypes = {
+    apiaries: arrayOf(object).isRequired,
+};
 
 export default connect(mapStateToProps)(Map);

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import { Map as LeafletMap, TileLayer, Marker } from 'react-leaflet';
 import { connect } from 'react-redux';
-import { arrayOf, object, func } from 'prop-types';
+import { arrayOf, func } from 'prop-types';
 
+import { Apiary } from '../propTypes';
 import { setApiaryList } from '../actions';
-import { MAP_CENTER, MAP_ZOOM } from '../constants';
+import { MAP_CENTER, MAP_ZOOM, RASTERS } from '../constants';
 
 class Map extends Component {
     constructor() {
@@ -16,7 +17,32 @@ class Map extends Component {
         const { apiaries, dispatch } = this.props;
         const newApiaryList = apiaries.concat({
             name: 'dummy name',
+            marker: 'F',
             location: event.latlng,
+            scores: {
+                threeKm: {
+                    [RASTERS.HIVE_DENSITY]: { data: 26, error: null },
+                    [RASTERS.HABITAT]: { data: 13, error: null },
+                    [RASTERS.PESTICIDE]: { data: 20, error: null },
+                    [RASTERS.FORAGE_SPRING]: { data: 61, error: null },
+                    [RASTERS.FORAGE_SUMMER]: { data: 54, error: null },
+                    [RASTERS.FORAGE_FALL]: { data: 45, error: null },
+                    [RASTERS.OVERALL]: { data: 45, error: null },
+                },
+                fiveKm: {
+                    [RASTERS.HIVE_DENSITY]: { data: 26, error: null },
+                    [RASTERS.HABITAT]: { data: 13, error: null },
+                    [RASTERS.PESTICIDE]: { data: 20, error: null },
+                    [RASTERS.FORAGE_SPRING]: { data: 61, error: null },
+                    [RASTERS.FORAGE_SUMMER]: { data: 54, error: null },
+                    [RASTERS.FORAGE_FALL]: { data: 45, error: null },
+                    [RASTERS.OVERALL]: { data: 45, error: null },
+                },
+            },
+            fetching: false,
+            selected: false,
+            starred: false,
+            surveyed: false,
         });
         dispatch(setApiaryList(newApiaryList));
     }
@@ -24,7 +50,7 @@ class Map extends Component {
     render() {
         const { apiaries } = this.props;
         const markers = apiaries.map((apiary, idx) => {
-            const key = apiary.name + toString(idx);
+            const key = apiary.name + String.fromCharCode(idx);
             return (
                 <Marker
                     key={key}
@@ -56,7 +82,7 @@ function mapStateToProps(state) {
 }
 
 Map.propTypes = {
-    apiaries: arrayOf(object).isRequired,
+    apiaries: arrayOf(Apiary).isRequired,
     dispatch: func.isRequired,
 };
 

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -3,7 +3,7 @@ import { Map as LeafletMap, TileLayer, Marker } from 'react-leaflet';
 import { connect } from 'react-redux';
 import { arrayOf, object, func } from 'prop-types';
 
-import { addApiary } from '../actions';
+import { setApiaryList } from '../actions';
 import { MAP_CENTER, MAP_ZOOM } from '../constants';
 
 class Map extends Component {
@@ -15,16 +15,23 @@ class Map extends Component {
     onClickAddMarker(event) {
         const { apiaries, dispatch } = this.props;
         const newApiaryList = apiaries.concat({
+            name: 'dummy name',
             location: event.latlng,
         });
-        dispatch(addApiary(newApiaryList));
+        dispatch(setApiaryList(newApiaryList));
     }
 
     render() {
         const { apiaries } = this.props;
-        const markers = apiaries.map(apiary => (
-            <Marker position={[apiary.location.lat, apiary.location.lng]} />
-        ));
+        const markers = apiaries.map((apiary, idx) => {
+            const key = apiary.name + toString(idx);
+            return (
+                <Marker
+                    key={key}
+                    position={[apiary.location.lat, apiary.location.lng]}
+                />
+            );
+        });
 
         return (
             <div className="map">

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -50,6 +50,8 @@ class Map extends Component {
     render() {
         const { apiaries } = this.props;
         const markers = apiaries.map((apiary, idx) => {
+            // TODO: Replace unique key generator once app uses real, complete data
+            // Currently solution appeases React unique key error
             const key = apiary.name + String.fromCharCode(idx);
             return (
                 <Marker

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
-import { Map as LeafletMap, TileLayer } from 'react-leaflet';
+import { Map as LeafletMap, TileLayer, Marker } from 'react-leaflet';
 import { connect } from 'react-redux';
-import { arrayOf, object } from 'prop-types';
+import { arrayOf, object, func } from 'prop-types';
 
+import { addApiary } from '../actions';
 import { MAP_CENTER, MAP_ZOOM } from '../constants';
 
 class Map extends Component {
@@ -12,15 +13,19 @@ class Map extends Component {
     }
 
     onClickAddMarker(event) {
-        window.console.log(event);
-        const { apiaries } = this.props;
-        apiaries.push({
-            name: 'Geocoded name',
+        const { apiaries, dispatch } = this.props;
+        const newApiaryList = apiaries.concat({
             location: event.latlng,
         });
+        dispatch(addApiary(newApiaryList));
     }
 
     render() {
+        const { apiaries } = this.props;
+        const markers = apiaries.map(apiary => (
+            <Marker position={[apiary.location.lat, apiary.location.lng]} />
+        ));
+
         return (
             <div className="map">
                 <LeafletMap
@@ -32,6 +37,7 @@ class Map extends Component {
                         attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
                         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                     />
+                    {markers}
                 </LeafletMap>
             </div>
         );
@@ -44,6 +50,7 @@ function mapStateToProps(state) {
 
 Map.propTypes = {
     apiaries: arrayOf(object).isRequired,
+    dispatch: func.isRequired,
 };
 
 export default connect(mapStateToProps)(Map);

--- a/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
@@ -12,9 +12,10 @@ const Sidebar = ({ apiaries }) => {
         return <Splash />;
     }
 
-    const apiaryCards = apiaries.map(apiary => (
-        <ApiaryCard key={apiary.marker} apiary={apiary} />
-    ));
+    const apiaryCards = apiaries.map((apiary, idx) => {
+        const key = String.fromCharCode(idx);
+        return <ApiaryCard key={key} apiary={apiary} />;
+    });
 
     return (
         <div className="sidebar">

--- a/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
@@ -13,6 +13,8 @@ const Sidebar = ({ apiaries }) => {
     }
 
     const apiaryCards = apiaries.map((apiary, idx) => {
+        // TODO: Replace unique key generator once app uses real, complete data
+        // Currently solution appeases React unique key error
         const key = String.fromCharCode(idx);
         return <ApiaryCard key={key} apiary={apiary} />;
     });

--- a/src/icp/apps/beekeepers/js/src/reducers.js
+++ b/src/icp/apps/beekeepers/js/src/reducers.js
@@ -2,7 +2,7 @@ import { createReducer } from 'redux-act';
 import update from 'immutability-helper';
 
 import { SORT_CREATED, FORAGE_RANGE_3K, RASTERS } from './constants';
-import { setSort, setForageRange } from './actions';
+import { setSort, setForageRange, addApiary } from './actions';
 
 const initialState = {
     sortBy: SORT_CREATED,
@@ -145,6 +145,8 @@ const mainReducer = createReducer({
         (state, payload) => update(state, { sortBy: { $set: payload } }),
     [setForageRange]:
         (state, payload) => update(state, { forageRange: { $set: payload } }),
+    [addApiary]:
+        (state, payload) => update(state, { apiaries: { $set: payload } }),
 }, initialState);
 
 // Placeholder reducer for parts of state that will be persisted to localStorage

--- a/src/icp/apps/beekeepers/js/src/reducers.js
+++ b/src/icp/apps/beekeepers/js/src/reducers.js
@@ -2,7 +2,8 @@ import { createReducer } from 'redux-act';
 import update from 'immutability-helper';
 
 import { SORT_CREATED, FORAGE_RANGE_3K, RASTERS } from './constants';
-import { setSort, setForageRange, addApiary } from './actions';
+import { setSort, setForageRange, setApiaryList } from './actions';
+
 
 const initialState = {
     sortBy: SORT_CREATED,
@@ -145,7 +146,7 @@ const mainReducer = createReducer({
         (state, payload) => update(state, { sortBy: { $set: payload } }),
     [setForageRange]:
         (state, payload) => update(state, { forageRange: { $set: payload } }),
-    [addApiary]:
+    [setApiaryList]:
         (state, payload) => update(state, { apiaries: { $set: payload } }),
 }, initialState);
 


### PR DESCRIPTION
## Overview

The app user's map usage will be pretty simple -- if the user clicks the map, an apiary marker should be added. There should also be markers for all apiaries in the list. This PR adds that functionality.

Connects #300 

### Demo
<img width="754" alt="screen shot 2018-11-02 at 4 07 46 pm" src="https://user-images.githubusercontent.com/10568752/47938137-76e78300-deb9-11e8-8fcb-298c87ba6811.png">

<img width="780" alt="screen shot 2018-11-02 at 4 07 40 pm" src="https://user-images.githubusercontent.com/10568752/47938136-76e78300-deb9-11e8-8c10-867ae5b84408.png">


### Notes

Follow up work:
- Map should handle double click zooms vs single clicks to add a marker
- Marker styling should be a circle matching its corresponding card

## Testing Instructions

Click the map and see markers are added. Once a marker is added aka an apiary is added to the state's list of apiaries, the sidebar should change to the apiary card list. They are still dummy cards.

The `main` store also updates! You will need to add `main` to the store whitelist if you want to observe main persisting.
