### PR TITLE
Add ESRI geocoder to map

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -41,6 +41,13 @@ class Map extends Component {
             expanded: true,
             collapseAfterResult: false,
             position: 'topleft',
+            /*
+                The geocoder and leaflet error without `useMapBounds` and
+                `zoomToResult` set to false.
+                See: https://github.com/Esri/esri-leaflet-geocoder/issues/209
+            */
+            useMapBounds: false,
+            zoomToResult: false,
         }).addTo(map);
 
         geocoder.on('results', ({ results }) => {

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -1,5 +1,6 @@
-import React, { Component } from 'react';
+import React, { Component, createRef } from 'react';
 import { Map as LeafletMap, TileLayer, Marker } from 'react-leaflet';
+import * as esri from 'esri-leaflet-geocoder';
 import { connect } from 'react-redux';
 import { arrayOf, func } from 'prop-types';
 
@@ -17,6 +18,25 @@ class Map extends Component {
     constructor() {
         super();
         this.onClickAddMarker = this.onClickAddMarker.bind(this);
+        this.mapRef = createRef();
+    }
+
+    componentDidMount() {
+        const geocoderUrl = 'https://utility.arcgis.com/usrsvcs/appservices/OvpAtyJwoLLdQcLC/rest/services/World/GeocodeServer/';
+        const map = this.mapRef.current.leafletElement;
+        new esri.Geosearch({
+            providers: [
+                new esri.ArcgisOnlineProvider({
+                    url: geocoderUrl,
+                    maxResults: 5,
+                    categories: ['Address', 'Postal'],
+                }),
+            ],
+            placeholder: 'Find location',
+            expanded: true,
+            collapseAfterResult: true,
+            position: 'topleft',
+        }).addTo(map);
     }
 
     onClickAddMarker(event) {
@@ -69,6 +89,7 @@ class Map extends Component {
                     center={MAP_CENTER}
                     zoom={MAP_ZOOM}
                     onClick={this.onClickAddMarker}
+                    ref={this.mapRef}
                 >
                     <TileLayer
                         attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -1,6 +1,11 @@
 import React, { Component, createRef } from 'react';
-import { Map as LeafletMap, TileLayer, Marker } from 'react-leaflet';
 import * as esri from 'esri-leaflet-geocoder';
+import {
+    Map as LeafletMap,
+    TileLayer,
+    Marker,
+    ZoomControl,
+} from 'react-leaflet';
 import { connect } from 'react-redux';
 import { arrayOf, func } from 'prop-types';
 
@@ -24,19 +29,26 @@ class Map extends Component {
     componentDidMount() {
         const geocoderUrl = 'https://utility.arcgis.com/usrsvcs/appservices/OvpAtyJwoLLdQcLC/rest/services/World/GeocodeServer/';
         const map = this.mapRef.current.leafletElement;
-        new esri.Geosearch({
+        const geocoder = new esri.Geosearch({
             providers: [
                 new esri.ArcgisOnlineProvider({
                     url: geocoderUrl,
-                    maxResults: 5,
+                    maxResults: 7,
                     categories: ['Address', 'Postal'],
                 }),
             ],
             placeholder: 'Find location',
             expanded: true,
-            collapseAfterResult: true,
+            collapseAfterResult: false,
             position: 'topleft',
         }).addTo(map);
+
+        geocoder.on('results', ({ results }) => {
+            const selectedResult = results && results[0];
+            if (selectedResult) {
+                map.panTo(selectedResult.latlng);
+            }
+        });
     }
 
     onClickAddMarker(event) {
@@ -88,6 +100,7 @@ class Map extends Component {
                 <LeafletMap
                     center={MAP_CENTER}
                     zoom={MAP_ZOOM}
+                    zoomControl={false}
                     onClick={this.onClickAddMarker}
                     ref={this.mapRef}
                 >
@@ -95,6 +108,7 @@ class Map extends Component {
                         attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
                         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                     />
+                    <ZoomControl position="bottomleft" />
                     {markers}
                 </LeafletMap>
             </div>

--- a/src/icp/apps/beekeepers/package.json
+++ b/src/icp/apps/beekeepers/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/project-icp/bee-pollinator-app",
   "dependencies": {
     "axios": "~0.18.0",
+    "esri-leaflet-geocoder": "~2.2.13",
     "immutability-helper": "~2.6.6",
     "leaflet": "~1.3.1",
     "prop-types": "~15.6.1",

--- a/src/icp/apps/beekeepers/sass/06_components/_map.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_map.scss
@@ -8,19 +8,4 @@
 .leaflet-container {
     width: 100%;
     height: 100%;
-
-    .leaflet-bar {
-        border: none;
-    }
-
-    .geocoder-control {
-        font: $font-base;
-
-        &-input {
-            padding: 10px;
-        }
-
-        // .geocoder-control-suggestions {
-        // }
-    }
 }

--- a/src/icp/apps/beekeepers/sass/06_components/_map.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_map.scss
@@ -8,4 +8,19 @@
 .leaflet-container {
     width: 100%;
     height: 100%;
+
+    .leaflet-bar {
+        border: none;
+    }
+
+    .geocoder-control {
+        font: $font-base;
+
+        &-input {
+            padding: 10px;
+        }
+
+        // .geocoder-control-suggestions {
+        // }
+    }
 }

--- a/src/icp/apps/beekeepers/sass/main.scss
+++ b/src/icp/apps/beekeepers/sass/main.scss
@@ -1,3 +1,5 @@
+@import '../node_modules/esri-leaflet-geocoder/dist/esri-leaflet-geocoder.css';
+
 @import '01_settings/**/*.scss';
 
 @import '02_tools/**/*.scss';

--- a/src/icp/apps/beekeepers/webpack.config.js
+++ b/src/icp/apps/beekeepers/webpack.config.js
@@ -15,6 +15,7 @@ module.exports = ({ production }) => {
             app: ['@babel/polyfill', './js/src/main.jsx'],
             vendor: [
                 'axios',
+                'esri-leaflet-geocoder',
                 'immutability-helper',
                 'leaflet',
                 'react',

--- a/src/icp/apps/beekeepers/yarn.lock
+++ b/src/icp/apps/beekeepers/yarn.lock
@@ -680,6 +680,10 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@esri/arcgis-to-geojson-utils@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@esri/arcgis-to-geojson-utils/-/arcgis-to-geojson-utils-1.3.0.tgz#79ab65bf3e40c039dbdebceff4b3b0ec088b189c"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -3009,6 +3013,21 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
+esri-leaflet-geocoder@~2.2.13:
+  version "2.2.13"
+  resolved "https://registry.yarnpkg.com/esri-leaflet-geocoder/-/esri-leaflet-geocoder-2.2.13.tgz#b56660e6d27e6974adbe687f700892c9282dc45c"
+  dependencies:
+    esri-leaflet "^2.1.4"
+    leaflet "^1.0.0"
+
+esri-leaflet@^2.1.4:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/esri-leaflet/-/esri-leaflet-2.2.3.tgz#858d9b84641d121d9115753db45aeffb67ad72e8"
+  dependencies:
+    "@esri/arcgis-to-geojson-utils" "^1.3.0"
+    leaflet-virtual-grid "^1.0.7"
+    tiny-binary-search "^1.0.3"
+
 estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
@@ -4732,6 +4751,16 @@ lcid@^2.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
   dependencies:
     invert-kv "^2.0.0"
+
+leaflet-virtual-grid@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/leaflet-virtual-grid/-/leaflet-virtual-grid-1.0.7.tgz#0dbb0dacd506b6e6d291314da5022d348729f8ad"
+  dependencies:
+    leaflet "^1.0.0"
+
+leaflet@^1.0.0:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.3.4.tgz#7f006ea5832603b53d7269ef5c595fd773060a40"
 
 leaflet@~1.3.1:
   version "1.3.1"
@@ -8380,6 +8409,10 @@ timers-browserify@^2.0.4:
 timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
+
+tiny-binary-search@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-binary-search/-/tiny-binary-search-1.0.3.tgz#9d52e3d16dd1171eb74486caf704ba08c0c62186"
 
 title-case@^2.1.0:
   version "2.1.1"


### PR DESCRIPTION
## Overview

The user should be able to search for a location on the map. This PR adds the ESRI geocoder, which is Civic Apps' standard geocoder choice. ESRI Geocoder will be helpful in the future when we have to reverse geocode apiary points for the default apiary name.

Connects #301 

### Demo

<img width="388" alt="screen shot 2018-11-13 at 4 25 10 pm" src="https://user-images.githubusercontent.com/10568752/48444072-eafb1400-e760-11e8-81a4-a0057d4bd3a5.png">


### Notes

I was digging kinda deep trying to clean this console issue. It doesn't break any app functionality. It is generated every time a geosearched address is selected and the map pans. I thought I'd get the PR up before I spent too much time spinning my wheel, when the non-breaking console error could be pinched off for the future or maybe someone is familiar with it.

<img width="494" alt="screen shot 2018-11-13 at 4 24 14 pm" src="https://user-images.githubusercontent.com/10568752/48444076-ef273180-e760-11e8-8d09-94b4155308b9.png">

Another known issue I'll add to #320 is that clicking the Geocoder sometimes (often) adds a marker underneath. The map clicking needs more finesse.

## Testing Instructions

Use the geocoder! ~ See the map pans to the location.
