### PR TITLE
Frontend fetches real data

### DIFF
--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -11,21 +11,20 @@ export const completeFetchApiaryScores = createAction('Completed fetching apiary
 
 export function fetchApiaryScores(apiary, forageRange) {
     return (dispatch, getState) => {
-        dispatch(startFetchApiaryScores());
-
         if (!apiary || !forageRange) {
             const err = !apiary
                 ? 'No apiary provided' : 'No forage range provided';
             window.console.warn(err);
-            return dispatch(failFetchApiaryScores(err));
+            return false;
         }
 
         // check if data for that apiary already exists
         // return the scores and complete the action loop if it exists
-        // TODO?: perform this sooner, perhaps here or in the component
         if (apiary.scores[forageRange].data) {
-            return dispatch(completeFetchApiaryScores());
+            return true;
         }
+
+        dispatch(startFetchApiaryScores());
 
         const {
             main: {
@@ -50,7 +49,7 @@ export function fetchApiaryScores(apiary, forageRange) {
                 // For unauthenticated user relying purely on redux/
                 // localStorage, manually update the apiary listing with data
                 const removedApiaryList = apiaries.filter(a => (
-                    a.location !== apiary.location
+                    !a.location.equals(apiary.location)
                 ));
                 const newList = removedApiaryList.concat(updatedApiary);
 

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -1,4 +1,5 @@
 import { createAction } from 'redux-act';
+import update from 'immutability-helper';
 import axios from 'axios';
 import { INDICATORS } from './constants';
 
@@ -39,8 +40,11 @@ export function fetchApiaryScores(apiary, forageRange) {
                 indicators: Object.values(INDICATORS),
             })
             .then(({ data }) => {
-                const updatedApiary = Object.assign({}, apiary);
-                updatedApiary.scores[forageRange] = data;
+                const updatedApiary = update(apiary, {
+                    scores: {
+                        [forageRange]: { $set: data },
+                    },
+                });
 
                 // TODO: Authenticated user should save apiaryWithData to
                 // the database and update the redux store of apiaries

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -48,6 +48,7 @@ export function fetchApiaryScores(apiaryList, forageRange) {
             }
             return apiary;
         });
+        dispatch(setApiaryList(fetchingApiaries));
 
         const locationList = apiaryList.map(apiary => apiary.location);
 
@@ -65,16 +66,14 @@ export function fetchApiaryScores(apiaryList, forageRange) {
                 // For unauthenticated user relying purely on redux/
                 // localStorage, manually update the apiary listings with data
                 const nonFetchingApiaryList = fetchingApiaries.filter(a => !a.fetching);
-                const apiaryListWithData = apiaryList.map((apiary) => {
-                    const latLngName = String(apiary.location.lat.toFixed(10))
-                        + String(apiary.location.lng.toFixed(10));
-                    return update(apiary, {
+                const apiaryListWithData = apiaryList.map((apiary, idx) => (
+                    update(apiary, {
                         scores: {
-                            [forageRange]: { $set: data[latLngName] },
+                            [forageRange]: { $set: data[idx] },
                         },
                         fetching: { $set: false },
-                    });
-                });
+                    })
+                ));
 
                 const newList = nonFetchingApiaryList.concat(apiaryListWithData);
 

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -11,7 +11,6 @@ export const completeFetchApiaryScores = createAction('Completed fetching apiary
 
 export function fetchApiaryScores(apiary, forageRange) {
     return (dispatch, getState) => {
-        // dispatch initial action declaration
         dispatch(startFetchApiaryScores());
 
         if (!apiary || !forageRange) {
@@ -22,8 +21,8 @@ export function fetchApiaryScores(apiary, forageRange) {
         }
 
         // check if data for that apiary already exists
-        // return the scores and complete action if exists
-        // perform this sooner, perhaps here or in the component
+        // return the scores and complete the action loop if it exists
+        // TODO?: perform this sooner, perhaps here or in the component
         if (apiary.scores[forageRange].data) {
             return dispatch(completeFetchApiaryScores());
         }
@@ -47,7 +46,18 @@ export function fetchApiaryScores(apiary, forageRange) {
                             [forageRange]: data,
                         },
                     });
-                const newList = apiaries.concat(apiaryWithData);
+
+                // TODO: Authenticated user should save apiaryWithData to
+                // the database and update the redux store of apiaries
+                // from a GET/list call
+
+                // For unauthenticated user relying purely on redux/
+                // localStorage, manually update the apiary listing with data
+                const removedApiaryList = apiaries.filter(a => (
+                    a.location !== apiary.location
+                ));
+                const newList = removedApiaryList.concat(apiaryWithData);
+
                 dispatch(completeFetchApiaryScores());
                 dispatch(setApiaryList(newList));
             })

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -1,5 +1,60 @@
 import { createAction } from 'redux-act';
+import axios from 'axios';
+import { INDICATORS } from './constants';
 
 export const setSort = createAction('Set apiary sort');
 export const setForageRange = createAction('Set forage range');
 export const setApiaryList = createAction('Set the apiary list');
+export const startFetchApiaryScores = createAction('Start fetching apiary scores');
+export const failFetchApiaryScores = createAction('Failed to fetch apiary scores');
+export const completeFetchApiaryScores = createAction('Completed fetching apiary scores');
+
+export function fetchApiaryScores(apiary, forageRange) {
+    return (dispatch, getState) => {
+        // dispatch initial action declaration
+        dispatch(startFetchApiaryScores());
+
+        if (!apiary || !forageRange) {
+            const err = !apiary
+                ? 'No apiary provided' : 'No forage range provided';
+            window.console.warn(err);
+            return dispatch(failFetchApiaryScores(err));
+        }
+
+        // check if data for that apiary already exists
+        // return the scores and complete action if exists
+        // perform this sooner, perhaps here or in the component
+        if (apiary.scores[forageRange].data) {
+            return dispatch(completeFetchApiaryScores());
+        }
+
+        const {
+            main: {
+                apiaries,
+            },
+        } = getState();
+
+        return axios
+            .post('/beekeepers/fetch/', {
+                location: apiary.location,
+                forage_range: forageRange,
+                indicators: Object.values(INDICATORS),
+            })
+            .then(({ data }) => {
+                const apiaryWithData = Object.assign(apiary,
+                    {
+                        scores: {
+                            [forageRange]: data,
+                        },
+                    });
+                const newList = apiaries.concat(apiaryWithData);
+                dispatch(completeFetchApiaryScores());
+                dispatch(setApiaryList(newList));
+            })
+            .catch((error) => {
+                window.console.warn(error);
+                // enclose error in a response object
+                return dispatch(failFetchApiaryScores(error));
+            });
+    };
+}

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -40,13 +40,7 @@ export function fetchApiaryScores(apiary, forageRange) {
                 indicators: Object.values(INDICATORS),
             })
             .then(({ data }) => {
-                const updatedApiary = update(apiary, {
-                    scores: {
-                        [forageRange]: { $set: data },
-                    },
-                });
-
-                // TODO: Authenticated user should save apiaryWithData to
+                // TODO: Authenticated user should save updatedApiary to
                 // the database and update the redux store of apiaries
                 // from a GET/list call
 
@@ -55,15 +49,31 @@ export function fetchApiaryScores(apiary, forageRange) {
                 const removedApiaryList = apiaries.filter(a => (
                     !a.location.equals(apiary.location)
                 ));
+                const updatedApiary = update(apiary, {
+                    scores: {
+                        [forageRange]: { $set: data },
+                    },
+                    fetching: { $set: false },
+                });
                 const newList = removedApiaryList.concat(updatedApiary);
 
                 dispatch(completeFetchApiaryScores());
                 dispatch(setApiaryList(newList));
             })
             .catch((error) => {
-                window.console.warn(error);
+                const removedApiaryList = apiaries.filter(a => (
+                    !a.location.equals(apiary.location)
+                ));
+                const updatedApiary = update(apiary, {
+                    fetching: { $set: false },
+                });
+                const newList = removedApiaryList.concat(updatedApiary);
+
+                dispatch(setApiaryList(newList));
+
                 // enclose error in a response object
-                return dispatch(failFetchApiaryScores(error));
+                window.console.warn(error);
+                dispatch(failFetchApiaryScores(error));
             });
     };
 }

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -1,6 +1,7 @@
 import { createAction } from 'redux-act';
 import update from 'immutability-helper';
 import axios from 'axios';
+
 import { INDICATORS } from './constants';
 
 export const setSort = createAction('Set apiary sort');
@@ -10,22 +11,24 @@ export const startFetchApiaryScores = createAction('Start fetching apiary scores
 export const failFetchApiaryScores = createAction('Failed to fetch apiary scores');
 export const completeFetchApiaryScores = createAction('Completed fetching apiary scores');
 
-export function fetchApiaryScores(apiary, forageRange) {
+export function fetchApiaryScores(apiaryList, forageRange) {
     return (dispatch, getState) => {
-        if (!apiary || !forageRange) {
-            const err = !apiary
+        if (!apiaryList || !forageRange) {
+            const err = !apiaryList
                 ? 'No apiary provided' : 'No forage range provided';
             window.console.warn(err);
             return false;
         }
 
-        // check if data for that apiary already exists
-        // return the scores and complete the action loop if it exists
-        if (apiary.scores[forageRange].data) {
-            return true;
+        if (!Array.isArray(apiaryList)) {
+            window.console.warn('Must send in an array of propType Apiary');
+            return false;
         }
 
-        dispatch(startFetchApiaryScores());
+        // check if data for the apiaries already exist
+        if (apiaryList.every(apiary => apiary.scores[forageRange].data)) {
+            return true;
+        }
 
         const {
             main: {
@@ -33,47 +36,63 @@ export function fetchApiaryScores(apiary, forageRange) {
             },
         } = getState();
 
+        // finally, declare starting to fetch scores
+        dispatch(startFetchApiaryScores());
+
+        // mark apiaries from input list as fetching data
+        const fetchingApiaries = apiaries.map((apiary) => {
+            if (apiaryList.find(a => Object.is(a.location, apiary.location))) {
+                return update(apiary, {
+                    fetching: { $set: true },
+                });
+            }
+            return apiary;
+        });
+
+        const locationList = apiaryList.map(apiary => apiary.location);
+
         return axios
             .post('/beekeepers/fetch/', {
-                location: apiary.location,
+                locations: locationList,
                 forage_range: forageRange,
                 indicators: Object.values(INDICATORS),
             })
             .then(({ data }) => {
-                // TODO: Authenticated user should save updatedApiary to
+                // TODO: Authenticated user should save apiaryListWithData to
                 // the database and update the redux store of apiaries
                 // from a GET/list call
 
                 // For unauthenticated user relying purely on redux/
-                // localStorage, manually update the apiary listing with data
-                const removedApiaryList = apiaries.filter(a => (
-                    !a.location.equals(apiary.location)
-                ));
-                const updatedApiary = update(apiary, {
-                    scores: {
-                        [forageRange]: { $set: data },
-                    },
-                    fetching: { $set: false },
+                // localStorage, manually update the apiary listings with data
+                const nonFetchingApiaryList = fetchingApiaries.filter(a => !a.fetching);
+                const apiaryListWithData = apiaryList.map((apiary) => {
+                    const latLngName = String(apiary.location.lat.toFixed(10))
+                        + String(apiary.location.lng.toFixed(10));
+                    return update(apiary, {
+                        scores: {
+                            [forageRange]: { $set: data[latLngName] },
+                        },
+                        fetching: { $set: false },
+                    });
                 });
-                const newList = removedApiaryList.concat(updatedApiary);
+
+                const newList = nonFetchingApiaryList.concat(apiaryListWithData);
 
                 dispatch(completeFetchApiaryScores());
                 dispatch(setApiaryList(newList));
             })
             .catch((error) => {
-                const removedApiaryList = apiaries.filter(a => (
-                    !a.location.equals(apiary.location)
+                const nonFetchingApiaryList = fetchingApiaries.filter(a => !a.fetching);
+                const apiaryListWithData = apiaryList.map(apiary => (
+                    update(apiary, {
+                        fetching: { $set: false },
+                    })
                 ));
-                const updatedApiary = update(apiary, {
-                    fetching: { $set: false },
-                });
-                const newList = removedApiaryList.concat(updatedApiary);
+                const newList = nonFetchingApiaryList.concat(apiaryListWithData);
 
-                dispatch(setApiaryList(newList));
-
-                // enclose error in a response object
                 window.console.warn(error);
                 dispatch(failFetchApiaryScores(error));
+                dispatch(setApiaryList(newList));
             });
     };
 }

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -40,12 +40,8 @@ export function fetchApiaryScores(apiary, forageRange) {
                 indicators: Object.values(INDICATORS),
             })
             .then(({ data }) => {
-                const apiaryWithData = Object.assign(apiary,
-                    {
-                        scores: {
-                            [forageRange]: data,
-                        },
-                    });
+                const updatedApiary = Object.assign({}, apiary);
+                updatedApiary.scores[forageRange] = data;
 
                 // TODO: Authenticated user should save apiaryWithData to
                 // the database and update the redux store of apiaries
@@ -56,7 +52,7 @@ export function fetchApiaryScores(apiary, forageRange) {
                 const removedApiaryList = apiaries.filter(a => (
                     a.location !== apiary.location
                 ));
-                const newList = removedApiaryList.concat(apiaryWithData);
+                const newList = removedApiaryList.concat(updatedApiary);
 
                 dispatch(completeFetchApiaryScores());
                 dispatch(setApiaryList(newList));

--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -1,15 +1,13 @@
 import React from 'react';
-import { string, func } from 'prop-types';
-import { connect } from 'react-redux';
+import { string } from 'prop-types';
 
 import { Apiary } from '../propTypes';
 import { INDICATORS } from '../constants';
-import { fetchApiaryScores } from '../actions';
 
 import CardButton from './CardButton';
 import ScoresLabel from './ScoresLabel';
 
-const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
+const ApiaryCard = ({ apiary, forageRange }) => {
     const {
         marker,
         name,
@@ -37,27 +35,29 @@ const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
         return '';
     })();
 
-    if (!Object.keys(apiary.scores[forageRange]).length) {
-        dispatch(fetchApiaryScores(apiary, forageRange));
-        return (
-            <li className="card">
-                <div className="card__top">
-                    <div className="card__identification">
-                        <div className={`marker ${markerMod}`}>{marker}</div>
-                        <div className="card__name">{name}</div>
-                    </div>
-                    <div className="card__buttons">
-                        <CardButton icon="star" filled={starred} />
-                        <CardButton icon="clipboard" filled={surveyed} />
-                        <CardButton icon="trash" filled />
-                    </div>
-                </div>
-                <div className="card__bottom">
-                    TODO: Insert spinner
-                </div>
-            </li>
+    const scoresBody = !Object.keys(apiary.scores[forageRange]).length
+        ? 'TODO: Insert spinner'
+        : (
+            <div className="indicator-container">
+                <ScoresLabel
+                    indicator={INDICATORS.NESTING_QUALITY}
+                    scores={[values[INDICATORS.NESTING_QUALITY]]}
+                />
+                <ScoresLabel
+                    indicator={INDICATORS.PESTICIDE}
+                    scores={[values[INDICATORS.PESTICIDE]]}
+                />
+                <ScoresLabel
+                    indicator="forage"
+                    scores={[
+                        values[INDICATORS.FORAGE_SPRING],
+                        values[INDICATORS.FORAGE_SUMMER],
+                        values[INDICATORS.FORAGE_FALL],
+                    ]}
+                />
+            </div>
         );
-    }
+
     return (
         <li className="card">
             <div className="card__top">
@@ -72,24 +72,7 @@ const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
                 </div>
             </div>
             <div className="card__bottom">
-                <div className="indicator-container">
-                    <ScoresLabel
-                        indicator={INDICATORS.NESTING_QUALITY}
-                        scores={[values[INDICATORS.NESTING_QUALITY]]}
-                    />
-                    <ScoresLabel
-                        indicator={INDICATORS.PESTICIDE}
-                        scores={[values[INDICATORS.PESTICIDE]]}
-                    />
-                    <ScoresLabel
-                        indicator="forage"
-                        scores={[
-                            values[INDICATORS.FORAGE_SPRING],
-                            values[INDICATORS.FORAGE_SUMMER],
-                            values[INDICATORS.FORAGE_FALL],
-                        ]}
-                    />
-                </div>
+                {scoresBody}
             </div>
         </li>
     );
@@ -98,11 +81,6 @@ const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
 ApiaryCard.propTypes = {
     apiary: Apiary.isRequired,
     forageRange: string.isRequired,
-    dispatch: func.isRequired,
 };
 
-function mapStateToProps(state) {
-    return state.main;
-}
-
-export default connect(mapStateToProps)(ApiaryCard);
+export default ApiaryCard;

--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
-import { string } from 'prop-types';
+import { string, func } from 'prop-types';
+import { connect } from 'react-redux';
 
 import { Apiary } from '../propTypes';
 import { INDICATORS } from '../constants';
+import { fetchApiaryScores } from '../actions';
 
 import CardButton from './CardButton';
 import ScoresLabel from './ScoresLabel';
 
-const ApiaryCard = ({ apiary, forageRange }) => {
+const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
     const {
         marker,
         name,
@@ -35,7 +37,8 @@ const ApiaryCard = ({ apiary, forageRange }) => {
         return '';
     })();
 
-    if (!apiary.scores[forageRange]) {
+    if (!Object.keys(apiary.scores[forageRange]).length) {
+        dispatch(fetchApiaryScores(apiary, forageRange));
         return (
             <li className="card">
                 <div className="card__top">
@@ -50,7 +53,7 @@ const ApiaryCard = ({ apiary, forageRange }) => {
                     </div>
                 </div>
                 <div className="card__bottom">
-                    Spinner
+                    TODO: Insert spinner
                 </div>
             </li>
         );
@@ -95,6 +98,11 @@ const ApiaryCard = ({ apiary, forageRange }) => {
 ApiaryCard.propTypes = {
     apiary: Apiary.isRequired,
     forageRange: string.isRequired,
+    dispatch: func.isRequired,
 };
 
-export default ApiaryCard;
+function mapStateToProps(state) {
+    return state.main;
+}
+
+export default connect(mapStateToProps)(ApiaryCard);

--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -35,6 +35,26 @@ const ApiaryCard = ({ apiary, forageRange }) => {
         return '';
     })();
 
+    if (!apiary.scores[forageRange]) {
+        return (
+            <li className="card">
+                <div className="card__top">
+                    <div className="card__identification">
+                        <div className={`marker ${markerMod}`}>{marker}</div>
+                        <div className="card__name">{name}</div>
+                    </div>
+                    <div className="card__buttons">
+                        <CardButton icon="star" filled={starred} />
+                        <CardButton icon="clipboard" filled={surveyed} />
+                        <CardButton icon="trash" filled />
+                    </div>
+                </div>
+                <div className="card__bottom">
+                    Spinner
+                </div>
+            </li>
+        );
+    }
     return (
         <li className="card">
             <div className="card__top">

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -7,14 +7,13 @@ import {
     ZoomControl,
 } from 'react-leaflet';
 import { connect } from 'react-redux';
-import { arrayOf, func } from 'prop-types';
+import { arrayOf, func, string } from 'prop-types';
 
 import { Apiary } from '../propTypes';
-import { setApiaryList } from '../actions';
+import { fetchApiaryScores } from '../actions';
 import {
     MAP_CENTER,
     MAP_ZOOM,
-    INDICATORS,
     FORAGE_RANGE_3KM,
     FORAGE_RANGE_5KM,
 } from '../constants';
@@ -59,33 +58,22 @@ class Map extends Component {
     }
 
     onClickAddMarker(event) {
-        const { apiaries, dispatch } = this.props;
-        const newApiaryList = apiaries.concat({
+        const { forageRange, dispatch } = this.props;
+        const newApiary = {
             name: 'dummy name',
             marker: 'F',
             location: event.latlng,
             scores: {
-                [FORAGE_RANGE_3KM]: {
-                    [INDICATORS.NESTING_QUALITY]: { data: 26, error: null },
-                    [INDICATORS.PESTICIDE]: { data: 20, error: null },
-                    [INDICATORS.FORAGE_SPRING]: { data: 61, error: null },
-                    [INDICATORS.FORAGE_SUMMER]: { data: 54, error: null },
-                    [INDICATORS.FORAGE_FALL]: { data: 45, error: null },
-                },
-                [FORAGE_RANGE_5KM]: {
-                    [INDICATORS.NESTING_QUALITY]: { data: 26, error: null },
-                    [INDICATORS.PESTICIDE]: { data: 20, error: null },
-                    [INDICATORS.FORAGE_SPRING]: { data: 61, error: null },
-                    [INDICATORS.FORAGE_SUMMER]: { data: 54, error: null },
-                    [INDICATORS.FORAGE_FALL]: { data: 45, error: null },
-                },
+                [FORAGE_RANGE_3KM]: {},
+                [FORAGE_RANGE_5KM]: {},
             },
             fetching: false,
             selected: false,
             starred: false,
             surveyed: false,
-        });
-        dispatch(setApiaryList(newApiaryList));
+        };
+        // const newApiaryList = apiaries.concat(newApiary);
+        dispatch(fetchApiaryScores(newApiary, forageRange));
     }
 
     render() {
@@ -129,6 +117,7 @@ function mapStateToProps(state) {
 
 Map.propTypes = {
     apiaries: arrayOf(Apiary).isRequired,
+    forageRange: string.isRequired,
     dispatch: func.isRequired,
 };
 

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -59,6 +59,13 @@ class Map extends Component {
 
     onClickAddMarker(event) {
         const { forageRange, apiaries, dispatch } = this.props;
+
+        // Traffic cop, prevent simultaneous, clobbered updates to the state
+        // by only allowing 1 new apiary at a time
+        if (apiaries.find(a => !!a.fetching)) {
+            return;
+        }
+
         const newApiary = {
             name: 'dummy name',
             marker: 'F',
@@ -67,7 +74,7 @@ class Map extends Component {
                 [FORAGE_RANGE_3KM]: {},
                 [FORAGE_RANGE_5KM]: {},
             },
-            fetching: false,
+            fetching: true,
             selected: false,
             starred: false,
             surveyed: false,

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -81,7 +81,7 @@ class Map extends Component {
         };
         const newApiaryList = apiaries.concat(newApiary);
         dispatch(setApiaryList(newApiaryList));
-        dispatch(fetchApiaryScores(newApiary, forageRange));
+        dispatch(fetchApiaryScores([newApiary], forageRange));
     }
 
     render() {

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -74,7 +74,7 @@ class Map extends Component {
                 [FORAGE_RANGE_3KM]: {},
                 [FORAGE_RANGE_5KM]: {},
             },
-            fetching: true,
+            fetching: false,
             selected: false,
             starred: false,
             surveyed: false,

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 import { arrayOf, func, string } from 'prop-types';
 
 import { Apiary } from '../propTypes';
-import { fetchApiaryScores } from '../actions';
+import { fetchApiaryScores, setApiaryList } from '../actions';
 import {
     MAP_CENTER,
     MAP_ZOOM,
@@ -58,7 +58,7 @@ class Map extends Component {
     }
 
     onClickAddMarker(event) {
-        const { forageRange, dispatch } = this.props;
+        const { forageRange, apiaries, dispatch } = this.props;
         const newApiary = {
             name: 'dummy name',
             marker: 'F',
@@ -72,7 +72,8 @@ class Map extends Component {
             starred: false,
             surveyed: false,
         };
-        // const newApiaryList = apiaries.concat(newApiary);
+        const newApiaryList = apiaries.concat(newApiary);
+        dispatch(setApiaryList(newApiaryList));
         dispatch(fetchApiaryScores(newApiary, forageRange));
     }
 

--- a/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
@@ -5,7 +5,8 @@ import { Score } from '../propTypes';
 import { toDashedString, toSpacedString } from '../utils';
 
 const ScoresLabel = ({ indicator, scores }) => {
-    const score = scores[0] ? scores.map(({ data, error }) => (error ? NaN : Math.round(data))).join('/') : '!';
+    const formattedScores = scores.map(({ data, error }) => (error ? NaN : Math.round(data))).join('/');
+    const score = formattedScores[0] ? formattedScores : '!';
     return (
         <div className={`indicator indicator--${toDashedString(indicator)}`}>
             <div className="indicator__number">

--- a/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
@@ -4,8 +4,13 @@ import { arrayOf, string } from 'prop-types';
 import { Score } from '../propTypes';
 import { toDashedString, toSpacedString } from '../utils';
 
+
+function generateScore(data, error) {
+    return error ? NaN : Math.round(data);
+}
+
 const ScoresLabel = ({ indicator, scores }) => {
-    const formattedScores = scores.map(({ data, error }) => (error ? NaN : Math.round(data))).join('/');
+    const formattedScores = scores.map(({ data, err }) => generateScore(data, err)).join('/');
     const score = formattedScores[0] ? formattedScores : '!';
     return (
         <div className={`indicator indicator--${toDashedString(indicator)}`}>

--- a/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
@@ -4,14 +4,17 @@ import { arrayOf, string } from 'prop-types';
 import { Score } from '../propTypes';
 import { toDashedString, toSpacedString } from '../utils';
 
-const ScoresLabel = ({ indicator, scores }) => (
-    <div className={`indicator indicator--${toDashedString(indicator)}`}>
-        <div className="indicator__number">
-            {scores.map(({ data, error }) => (error ? '!' : data)).join('/')}
+const ScoresLabel = ({ indicator, scores }) => {
+    const score = scores[0] ? scores.map(({ data, error }) => (error ? '!' : Math.round(data))).join('/') : '!';
+    return (
+        <div className={`indicator indicator--${toDashedString(indicator)}`}>
+            <div className="indicator__number">
+                {score}
+            </div>
+            <div className="indicator__name">{toSpacedString(indicator)}</div>
         </div>
-        <div className="indicator__name">{toSpacedString(indicator)}</div>
-    </div>
-);
+    );
+};
 
 ScoresLabel.propTypes = {
     indicator: string.isRequired,

--- a/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
@@ -5,7 +5,7 @@ import { Score } from '../propTypes';
 import { toDashedString, toSpacedString } from '../utils';
 
 const ScoresLabel = ({ indicator, scores }) => {
-    const score = scores[0] ? scores.map(({ data, error }) => (error ? '!' : Math.round(data))).join('/') : '!';
+    const score = scores[0] ? scores.map(({ data, error }) => (error ? NaN : Math.round(data))).join('/') : '!';
     return (
         <div className={`indicator indicator--${toDashedString(indicator)}`}>
             <div className="indicator__number">

--- a/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
@@ -33,18 +33,13 @@ const Sidebar = ({
         ));
     }
 
-    const apiaryCards = sortedApiaries.map((apiary, idx) => {
-        // TODO: Replace unique key generator once app uses real, complete data
-        // Currently solution appeases React unique key error
-        const key = String.fromCharCode(idx);
-        return (
-            <ApiaryCard
-                key={key}
-                apiary={apiary}
-                forageRange={forageRange}
-            />
-        );
-    });
+    const apiaryCards = sortedApiaries.map(apiary => (
+        <ApiaryCard
+            key={apiary.location}
+            apiary={apiary}
+            forageRange={forageRange}
+        />
+    ));
 
     const onSelectSort = (selection) => {
         dispatch(setSort(selection.target.value));

--- a/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
@@ -38,15 +38,14 @@ class Sidebar extends Component {
             return <Splash />;
         }
 
-        let sortedApiaries;
         if (sortBy === DEFAULT_SORT) {
-            sortedApiaries = apiaries.sort((a, b) => {
+            apiaries.sort((a, b) => {
                 if (a.marker < b.marker) { return -1; }
                 if (a.marker > b.marker) { return 1; }
                 return 0;
             });
         } else {
-            sortedApiaries = apiaries.sort((a, b) => {
+            apiaries.sort((a, b) => {
                 if (!b.scores[forageRange][sortBy] || !a.scores[forageRange][sortBy]) {
                     return 0;
                 }
@@ -54,7 +53,7 @@ class Sidebar extends Component {
             });
         }
 
-        const apiaryCards = sortedApiaries.map(apiary => (
+        const apiaryCards = apiaries.map(apiary => (
             <ApiaryCard
                 key={apiary.location}
                 apiary={apiary}

--- a/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
@@ -28,9 +28,12 @@ const Sidebar = ({
             return 0;
         });
     } else {
-        sortedApiaries = apiaries.sort((a, b) => (
-            b.scores[forageRange][sortBy].data - a.scores[forageRange][sortBy].data
-        ));
+        sortedApiaries = apiaries.sort((a, b) => {
+            if (!b.scores[forageRange][sortBy] || !a.scores[forageRange][sortBy]) {
+                return 0;
+            }
+            return b.scores[forageRange][sortBy].data - a.scores[forageRange][sortBy].data;
+        });
     }
 
     const apiaryCards = sortedApiaries.map(apiary => (

--- a/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
@@ -1,80 +1,99 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { arrayOf, func, string } from 'prop-types';
 import { connect } from 'react-redux';
 
 import { Apiary } from '../propTypes';
-import { setForageRange, setSort } from '../actions';
+import { setForageRange, setSort, fetchApiaryScores } from '../actions';
 import { FORAGE_RANGES, SORT_OPTIONS, DEFAULT_SORT } from '../constants';
 
 import ApiaryCard from './ApiaryCard';
 import DropdownSelector from './DropdownSelector';
 import Splash from './Splash';
 
-const Sidebar = ({
-    apiaries,
-    dispatch,
-    sortBy,
-    forageRange,
-}) => {
-    if (apiaries.length === 0) {
-        return <Splash />;
+
+class Sidebar extends Component {
+    shouldComponentUpdate(nextProps) {
+        const { apiaries, forageRange: nextForageRange } = nextProps;
+        const { forageRange, dispatch } = this.props;
+
+        if (forageRange !== nextForageRange) {
+            apiaries.forEach((apiary) => {
+                if (!Object.keys(apiary.scores[nextForageRange]).length) {
+                    dispatch(fetchApiaryScores(apiary, nextForageRange));
+                }
+            });
+        }
+        return nextProps;
     }
 
-    let sortedApiaries;
-    if (sortBy === DEFAULT_SORT) {
-        sortedApiaries = apiaries.sort((a, b) => {
-            if (a.marker < b.marker) { return -1; }
-            if (a.marker > b.marker) { return 1; }
-            return 0;
-        });
-    } else {
-        sortedApiaries = apiaries.sort((a, b) => {
-            if (!b.scores[forageRange][sortBy] || !a.scores[forageRange][sortBy]) {
+    render() {
+        const {
+            apiaries,
+            forageRange,
+            sortBy,
+            dispatch,
+        } = this.props;
+
+        if (apiaries.length === 0) {
+            return <Splash />;
+        }
+
+        let sortedApiaries;
+        if (sortBy === DEFAULT_SORT) {
+            sortedApiaries = apiaries.sort((a, b) => {
+                if (a.marker < b.marker) { return -1; }
+                if (a.marker > b.marker) { return 1; }
                 return 0;
-            }
-            return b.scores[forageRange][sortBy].data - a.scores[forageRange][sortBy].data;
-        });
-    }
+            });
+        } else {
+            sortedApiaries = apiaries.sort((a, b) => {
+                if (!b.scores[forageRange][sortBy] || !a.scores[forageRange][sortBy]) {
+                    return 0;
+                }
+                return b.scores[forageRange][sortBy].data - a.scores[forageRange][sortBy].data;
+            });
+        }
 
-    const apiaryCards = sortedApiaries.map(apiary => (
-        <ApiaryCard
-            key={apiary.location}
-            apiary={apiary}
-            forageRange={forageRange}
-        />
-    ));
+        const apiaryCards = sortedApiaries.map(apiary => (
+            <ApiaryCard
+                key={apiary.location}
+                apiary={apiary}
+                forageRange={forageRange}
+            />
+        ));
 
-    const onSelectSort = (selection) => {
-        dispatch(setSort(selection.target.value));
-    };
+        const onSelectSort = (selection) => {
+            dispatch(setSort(selection.target.value));
+        };
 
-    const onSelectForageRange = (selection) => {
-        dispatch(setForageRange(selection.target.value));
-    };
+        const onSelectForageRange = (selection) => {
+            dispatch(setForageRange(selection.target.value));
+        };
 
-    return (
-        <div className="sidebar">
-            <div className="sidebar__header">
-                <h2>Locations</h2>
-                <div className="sidebar__controls">
-                    <DropdownSelector
-                        title="Sort by:"
-                        options={SORT_OPTIONS}
-                        onOptionClick={onSelectSort}
-                    />
-                    <DropdownSelector
-                        title="Forage range:"
-                        options={FORAGE_RANGES}
-                        onOptionClick={onSelectForageRange}
-                    />
+        return (
+            <div className="sidebar">
+                <div className="sidebar__header">
+                    <h2>Locations</h2>
+                    <div className="sidebar__controls">
+                        <DropdownSelector
+                            title="Sort by:"
+                            options={SORT_OPTIONS}
+                            onOptionClick={onSelectSort}
+                        />
+                        <DropdownSelector
+                            title="Forage range:"
+                            options={FORAGE_RANGES}
+                            onOptionClick={onSelectForageRange}
+                        />
+                    </div>
                 </div>
+                <ul className="card-container">
+                    {apiaryCards}
+                </ul>
             </div>
-            <ul className="card-container">
-                {apiaryCards}
-            </ul>
-        </div>
-    );
-};
+        );
+    }
+}
 
 Sidebar.propTypes = {
     apiaries: arrayOf(Apiary).isRequired,

--- a/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
@@ -17,12 +17,12 @@ class Sidebar extends Component {
         const { forageRange, dispatch } = this.props;
 
         if (forageRange !== nextForageRange) {
-            apiaries.forEach((apiary) => {
-                if (!Object.keys(apiary.scores[nextForageRange]).length) {
-                    dispatch(fetchApiaryScores(apiary, nextForageRange));
-                }
-            });
+            const apiariesSansData = apiaries.filter(apiary => (
+                !Object.keys(apiary.scores[nextForageRange]).length
+            ));
+            dispatch(fetchApiaryScores(apiariesSansData, nextForageRange));
         }
+
         return nextProps;
     }
 

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -14,5 +14,5 @@ export const INDICATORS = {
 
 export const SORT_OPTIONS = [DEFAULT_SORT].concat(Object.values(INDICATORS));
 
-export const MAP_CENTER = [37.899, -97.079];
+export const MAP_CENTER = [40.0, -76.079];
 export const MAP_ZOOM = 10;

--- a/src/icp/apps/beekeepers/js/src/propTypes.js
+++ b/src/icp/apps/beekeepers/js/src/propTypes.js
@@ -18,7 +18,7 @@ export const Score = shape({
 });
 
 export const Scores = shape(Object.keys(INDICATORS).reduce(
-    (map, r) => Object.assign(map, { [INDICATORS[r]]: Score.isRequired }),
+    (map, r) => Object.assign(map, { [INDICATORS[r]]: Score }),
     {},
 ));
 

--- a/src/icp/apps/beekeepers/js/src/reducers.js
+++ b/src/icp/apps/beekeepers/js/src/reducers.js
@@ -7,8 +7,14 @@ import {
     INDICATORS,
     FORAGE_RANGE_5KM,
 } from './constants';
-import { setSort, setForageRange, setApiaryList } from './actions';
-
+import {
+    setSort,
+    setForageRange,
+    setApiaryList,
+    startFetchApiaryScores,
+    failFetchApiaryScores,
+    completeFetchApiaryScores,
+} from './actions';
 
 const initialState = {
     sortBy: DEFAULT_SORT,
@@ -137,6 +143,9 @@ const mainReducer = createReducer({
         (state, payload) => update(state, { forageRange: { $set: payload } }),
     [setApiaryList]:
         (state, payload) => update(state, { apiaries: { $set: payload } }),
+    [startFetchApiaryScores]: state => update(state, { apiaries: { fetching: { $set: true } } }),
+    [failFetchApiaryScores]: state => update(state, { apiaries: { fetching: { $set: false } } }),
+    [completeFetchApiaryScores]: state => update(state, { apiaries: { fetching: { $set: true } } }),
 }, initialState);
 
 // Placeholder reducer for parts of state that will be persisted to localStorage

--- a/src/icp/apps/beekeepers/js/src/reducers.js
+++ b/src/icp/apps/beekeepers/js/src/reducers.js
@@ -9,9 +9,6 @@ import {
     setSort,
     setForageRange,
     setApiaryList,
-    startFetchApiaryScores,
-    failFetchApiaryScores,
-    completeFetchApiaryScores,
 } from './actions';
 
 const initialState = {
@@ -27,10 +24,6 @@ const mainReducer = createReducer({
         (state, payload) => update(state, { forageRange: { $set: payload } }),
     [setApiaryList]:
         (state, payload) => update(state, { apiaries: { $set: payload } }),
-    // TODO: Replace reducers below with real behavior
-    [startFetchApiaryScores]: state => update(state, { apiaries: { fetching: { $set: true } } }),
-    [failFetchApiaryScores]: state => update(state, { apiaries: { fetching: { $set: false } } }),
-    [completeFetchApiaryScores]: state => update(state, { apiaries: { fetching: { $set: true } } }),
 }, initialState);
 
 // Placeholder reducer for parts of state that will be persisted to localStorage

--- a/src/icp/apps/beekeepers/js/src/reducers.js
+++ b/src/icp/apps/beekeepers/js/src/reducers.js
@@ -4,8 +4,6 @@ import update from 'immutability-helper';
 import {
     DEFAULT_SORT,
     FORAGE_RANGE_3KM,
-    INDICATORS,
-    FORAGE_RANGE_5KM,
 } from './constants';
 import {
     setSort,
@@ -19,121 +17,7 @@ import {
 const initialState = {
     sortBy: DEFAULT_SORT,
     forageRange: FORAGE_RANGE_3KM,
-    apiaries: [
-        // TODO Remove dummy data
-        {
-            name: '423 Waltz Road',
-            marker: 'A',
-            location: {
-                lat: 1.0,
-                lng: 1.0,
-            },
-            scores: {
-                [FORAGE_RANGE_3KM]: {
-                    [INDICATORS.NESTING_QUALITY]: { data: 16, error: null },
-                    [INDICATORS.PESTICIDE]: { data: 30, error: null },
-                    [INDICATORS.FORAGE_SPRING]: { data: 61, error: null },
-                    [INDICATORS.FORAGE_SUMMER]: { data: 54, error: null },
-                    [INDICATORS.FORAGE_FALL]: { data: 45, error: null },
-                },
-                [FORAGE_RANGE_5KM]: {
-                    [INDICATORS.NESTING_QUALITY]: { data: 36, error: null },
-                    [INDICATORS.PESTICIDE]: { data: 30, error: null },
-                    [INDICATORS.FORAGE_SPRING]: { data: 71, error: null },
-                    [INDICATORS.FORAGE_SUMMER]: { data: 64, error: null },
-                    [INDICATORS.FORAGE_FALL]: { data: 55, error: null },
-                },
-            },
-            fetching: false,
-            selected: false,
-            starred: false,
-            surveyed: false,
-        },
-        {
-            name: '990 Spring Garden',
-            marker: 'B',
-            location: {
-                lat: 1.0,
-                lng: 1.0,
-            },
-            scores: {
-                [FORAGE_RANGE_3KM]: {
-                    [INDICATORS.NESTING_QUALITY]: { data: 56, error: null },
-                    [INDICATORS.PESTICIDE]: { data: 20, error: null },
-                    [INDICATORS.FORAGE_SPRING]: { data: 61, error: null },
-                    [INDICATORS.FORAGE_SUMMER]: { data: 54, error: null },
-                    [INDICATORS.FORAGE_FALL]: { data: 45, error: null },
-                },
-                [FORAGE_RANGE_5KM]: {
-                    [INDICATORS.NESTING_QUALITY]: { data: 36, error: null },
-                    [INDICATORS.PESTICIDE]: { data: 30, error: null },
-                    [INDICATORS.FORAGE_SPRING]: { data: 71, error: null },
-                    [INDICATORS.FORAGE_SUMMER]: { data: 64, error: null },
-                    [INDICATORS.FORAGE_FALL]: { data: 55, error: null },
-                },
-            },
-            fetching: true,
-            selected: false,
-            starred: true,
-            surveyed: true,
-        },
-        {
-            name: '341 N 12th Street',
-            marker: 'C',
-            location: {
-                lat: 1.0,
-                lng: 1.0,
-            },
-            scores: {
-                [FORAGE_RANGE_3KM]: {
-                    [INDICATORS.NESTING_QUALITY]: { data: 26, error: null },
-                    [INDICATORS.PESTICIDE]: { data: 10, error: null },
-                    [INDICATORS.FORAGE_SPRING]: { data: 61, error: null },
-                    [INDICATORS.FORAGE_SUMMER]: { data: 54, error: null },
-                    [INDICATORS.FORAGE_FALL]: { data: 45, error: null },
-                },
-                [FORAGE_RANGE_5KM]: {
-                    [INDICATORS.NESTING_QUALITY]: { data: 36, error: null },
-                    [INDICATORS.PESTICIDE]: { data: 30, error: null },
-                    [INDICATORS.FORAGE_SPRING]: { data: 71, error: null },
-                    [INDICATORS.FORAGE_SUMMER]: { data: 64, error: null },
-                    [INDICATORS.FORAGE_FALL]: { data: 55, error: null },
-                },
-            },
-            fetching: false,
-            selected: false,
-            starred: true,
-            surveyed: false,
-        },
-        {
-            name: '1234 Market Street',
-            marker: 'D',
-            location: {
-                lat: 1.0,
-                lng: 1.0,
-            },
-            scores: {
-                [FORAGE_RANGE_3KM]: {
-                    [INDICATORS.NESTING_QUALITY]: { data: 23, error: null },
-                    [INDICATORS.PESTICIDE]: { data: 50, error: null },
-                    [INDICATORS.FORAGE_SPRING]: { data: 61, error: null },
-                    [INDICATORS.FORAGE_SUMMER]: { data: 54, error: null },
-                    [INDICATORS.FORAGE_FALL]: { data: 45, error: null },
-                },
-                [FORAGE_RANGE_5KM]: {
-                    [INDICATORS.NESTING_QUALITY]: { data: 36, error: null },
-                    [INDICATORS.PESTICIDE]: { data: 30, error: null },
-                    [INDICATORS.FORAGE_SPRING]: { data: 71, error: null },
-                    [INDICATORS.FORAGE_SUMMER]: { data: 64, error: null },
-                    [INDICATORS.FORAGE_FALL]: { data: 55, error: null },
-                },
-            },
-            fetching: false,
-            selected: true,
-            starred: false,
-            surveyed: false,
-        },
-    ],
+    apiaries: [],
 };
 
 const mainReducer = createReducer({

--- a/src/icp/apps/beekeepers/js/src/reducers.js
+++ b/src/icp/apps/beekeepers/js/src/reducers.js
@@ -27,6 +27,7 @@ const mainReducer = createReducer({
         (state, payload) => update(state, { forageRange: { $set: payload } }),
     [setApiaryList]:
         (state, payload) => update(state, { apiaries: { $set: payload } }),
+    // TODO: Replace reducers below with real behavior
     [startFetchApiaryScores]: state => update(state, { apiaries: { fetching: { $set: true } } }),
     [failFetchApiaryScores]: state => update(state, { apiaries: { fetching: { $set: false } } }),
     [completeFetchApiaryScores]: state => update(state, { apiaries: { fetching: { $set: true } } }),

--- a/src/icp/apps/beekeepers/views.py
+++ b/src/icp/apps/beekeepers/views.py
@@ -19,20 +19,29 @@ def fetch_data(request):
     """
     Return the cell values from rasters on s3 and any errors.
 
-    :param location: Dict with lat and lng values, i.e {lat: float, lng: float}
+    :param locations: List of dicts with lat and lng values,
+        i.e [{lat: float, lng: float}]
     :param forage_range: A string value of "3km" or "5km"
     :param indicators: An array of indicator names corresponding to s3 rasters
     """
 
-    location = request.DATA['location']
+    locations = request.DATA['locations']
     forage_range = request.DATA['forage_range']
     indicators = request.DATA['indicators']
 
     resp = {}
-    for indicator in indicators:
-        s3_filename = '{}_{}.tif'.format(indicator, forage_range)
-        s3_url = 's3://{}/{}/{}'.format(DATA_BUCKET, forage_range, s3_filename)
-        data = sample_at_point(location, s3_url)
-        resp.update({indicator: data})
+    for location in locations:
+        lat_lng_name = '{0:.10f}{1:.10f}'.format(
+            location['lat'], location['lng'])
+        resp.update({lat_lng_name: {}})
+        for indicator in indicators:
+            s3_filename = '{}_{}.tif'.format(indicator, forage_range)
+            s3_url = 's3://{}/{}/{}'.format(
+                DATA_BUCKET,
+                forage_range,
+                s3_filename
+            )
+            data = sample_at_point(location, s3_url)
+            resp[lat_lng_name].update({indicator: data})
 
     return Response(resp)

--- a/src/icp/apps/beekeepers/views.py
+++ b/src/icp/apps/beekeepers/views.py
@@ -29,11 +29,9 @@ def fetch_data(request):
     forage_range = request.DATA['forage_range']
     indicators = request.DATA['indicators']
 
-    resp = {}
+    resp = []
     for location in locations:
-        lat_lng_name = '{0:.10f}{1:.10f}'.format(
-            location['lat'], location['lng'])
-        resp.update({lat_lng_name: {}})
+        all_location_data = {}
         for indicator in indicators:
             s3_filename = '{}_{}.tif'.format(indicator, forage_range)
             s3_url = 's3://{}/{}/{}'.format(
@@ -42,6 +40,7 @@ def fetch_data(request):
                 s3_filename
             )
             data = sample_at_point(location, s3_url)
-            resp[lat_lng_name].update({indicator: data})
+            all_location_data.update({indicator: data})
+        resp.append(all_location_data)
 
     return Response(resp)


### PR DESCRIPTION
## Overview

The fetch endpoint for data already existed for a location/forage range/indicators. The front end has enough structure to request real data now instead of using mock dummy data. This PR hooks up the front and back ends officially and sets up the flow for when the database exists, authentication exists, and we save apiaries there.

I sketched this out as my train of thought. I can explain verbally if this doesn't make sense:
![img_20181116_105318](https://user-images.githubusercontent.com/10568752/48653519-dbcfcc80-e9d3-11e8-85b3-23f3a37277b3.jpg)

Connects #304 

### Demo

![back-front-connect](https://user-images.githubusercontent.com/10568752/48653802-ba6fe000-e9d5-11e8-92bf-780db5a528d3.gif)


![sort](https://user-images.githubusercontent.com/10568752/48653792-9f9d6b80-e9d5-11e8-8bf8-200ce89ea00a.gif)

### Notes

- I based this branch off the Geocoder branch accidentally. I'll fix later or hopefully the other PR gets approved and merged first haha

- If you click outside PA, the requests loop infinitely because the front end doesn't know how to handle server errors from the fetch endpoint. I'll make a followup issue.

## Testing Instructions

Click points within PA and try to use the dropdowns. All functionality should be maintained, plus real data now. 