### PR TITLE
Add Apiary Django model

### DIFF
--- a/src/icp/apps/beekeepers/migrations/0001_add_beekeepers_apiary_model.py
+++ b/src/icp/apps/beekeepers/migrations/0001_add_beekeepers_apiary_model.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Apiary',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('lat', models.FloatField()),
+                ('lng', models.FloatField()),
+                ('marker', models.CharField(help_text='Code displayed on textual marker symbol', max_length=255)),
+                ('name', models.CharField(help_text='Short text identifier for apiary', max_length=255)),
+                ('scores', models.TextField(help_text='JSON representation of raster values at lat/lng', null=True)),
+                ('starred', models.BooleanField(default=False, help_text='Has the apiary been starred in the UI?')),
+                ('surveyed', models.BooleanField(default=False, help_text='Has the apiary been designated as requiring surveys?')),
+                ('updateded_at', models.DateTimeField(auto_now=True, null=True)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/src/icp/apps/beekeepers/migrations/0001_add_beekeepers_apiary_model.py
+++ b/src/icp/apps/beekeepers/migrations/0001_add_beekeepers_apiary_model.py
@@ -24,7 +24,7 @@ class Migration(migrations.Migration):
                 ('scores', models.TextField(help_text='JSON representation of raster values at lat/lng', null=True)),
                 ('starred', models.BooleanField(default=False, help_text='Has the apiary been starred in the UI?')),
                 ('surveyed', models.BooleanField(default=False, help_text='Has the apiary been designated as requiring surveys?')),
-                ('updateded_at', models.DateTimeField(auto_now=True, null=True)),
+                ('updated_at', models.DateTimeField(auto_now=True, null=True)),
                 ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
             ],
         ),

--- a/src/icp/apps/beekeepers/models.py
+++ b/src/icp/apps/beekeepers/models.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django.db import models
+from django.conf import settings
+
+AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+
+
+class Apiary(models.Model):
+    """An Apiary represents a real or possible physical location
+    where multiple honeybee colonies are located.
+    """
+    created_at = models.DateTimeField(
+        auto_now_add=True)
+    lat = models.FloatField()
+    lng = models.FloatField()
+    marker = models.CharField(
+        max_length=255,
+        help_text='Code displayed on textual marker symbol')
+    name = models.CharField(
+        max_length=255,
+        help_text='Short text identifier for apiary')
+    scores = models.TextField(
+        null=True,
+        help_text='JSON representation of raster values at lat/lng')
+    starred = models.BooleanField(
+        default=False,
+        help_text='Has the apiary been starred in the UI?')
+    surveyed = models.BooleanField(
+        default=False,
+        help_text='Has the apiary been designated as requiring surveys?')
+    updateded_at = models.DateTimeField(
+        auto_now=True,
+        null=True)
+    user = models.ForeignKey(
+        AUTH_USER_MODEL,
+        null=False)
+
+    def __unicode__(self):
+        return unicode('{}:{}'.format(self.user.username, self.name))

--- a/src/icp/apps/beekeepers/models.py
+++ b/src/icp/apps/beekeepers/models.py
@@ -13,25 +13,32 @@ class Apiary(models.Model):
     where multiple honeybee colonies are located.
     """
     created_at = models.DateTimeField(
-        auto_now_add=True)
-    lat = models.FloatField()
-    lng = models.FloatField()
+        auto_now_add=True,
+        null=False)
+    lat = models.FloatField(
+        null=False)
+    lng = models.FloatField(
+        null=False)
     marker = models.CharField(
         max_length=255,
+        null=False,
         help_text='Code displayed on textual marker symbol')
     name = models.CharField(
         max_length=255,
+        null=False,
         help_text='Short text identifier for apiary')
     scores = models.TextField(
         null=True,
         help_text='JSON representation of raster values at lat/lng')
     starred = models.BooleanField(
         default=False,
+        null=False,
         help_text='Has the apiary been starred in the UI?')
     surveyed = models.BooleanField(
         default=False,
+        null=False,
         help_text='Has the apiary been designated as requiring surveys?')
-    updateded_at = models.DateTimeField(
+    updated_at = models.DateTimeField(
         auto_now=True,
         null=True)
     user = models.ForeignKey(


### PR DESCRIPTION
## Overview

Django model and migration to add ORM model for Apiary features.

Connects #332 

## Testing Instructions

* Check out branch and run migrations
   `./scripts/manage.sh migrate`
* Interact with model in shell
  ```python
   > ./scripts/manage.sh shell
   from apps.beekeepers import models
   from django.contrib.auth.models import User

   user = User.objects.first()
   bee = models.Apiary(
       lat=34.34,
       lng=-34.342,
       marker="D",
       name="Matt's Cool Apiary",
       user=user
    )

    bee.save()


    print(bee)
    print(bee.id)
   ```
* Confirm apiary is persisted to DB

   ```shell
    > ./scripts/manage.sh dbshell
    select * from beekeepers_apiary;
    ```