### PR TITLE
Add Beekeepers Survey Model

### DIFF
--- a/src/icp/apps/beekeepers/migrations/0002_add_beekeepers_survey_model.py
+++ b/src/icp/apps/beekeepers/migrations/0002_add_beekeepers_survey_model.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('beekeepers', '0001_add_beekeepers_apiary_model'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Survey',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('month_year', models.CharField(help_text='MMYYYY formatted value indicating the month of this survey', max_length=255)),
+                ('num_colonies', models.IntegerField(help_text='Number of colonies in this survey')),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('survey_type', models.CharField(help_text='The kind of survey this is', max_length=255, choices=[('APRIL', 'April'), ('NOVEMBER', 'November'), ('MONTHLY', 'Monthly')])),
+                ('apiary', models.ForeignKey(related_name='surveys', to='beekeepers.Apiary')),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='survey',
+            unique_together=set([('month_year', 'apiary')]),
+        ),
+    ]

--- a/src/icp/apps/beekeepers/models.py
+++ b/src/icp/apps/beekeepers/models.py
@@ -47,3 +47,42 @@ class Apiary(models.Model):
 
     def __unicode__(self):
         return unicode('{}:{}'.format(self.user.username, self.name))
+
+
+class Survey(models.Model):
+    """Survey of questions for an Apiary for a given month"""
+    APRIL = 'APRIL'
+    NOVEMBER = 'NOVEMBER'
+    MONTHLY = 'MONTHLY'
+
+    SURVEY_TYPES = (
+        (APRIL, 'April'),
+        (NOVEMBER, 'November'),
+        (MONTHLY, 'Monthly'),
+    )
+
+    month_year = models.CharField(
+        max_length=255,
+        null=False,
+        help_text='MMYYYY formatted value indicating the month of this survey')
+    num_colonies = models.IntegerField(
+        null=False,
+        help_text='Number of colonies in this survey')
+    apiary = models.ForeignKey(
+        Apiary,
+        related_name='surveys',
+        null=False)
+    created_at = models.DateTimeField(
+        auto_now=False,
+        auto_now_add=True)
+    survey_type = models.CharField(
+        choices=SURVEY_TYPES,
+        max_length=255,
+        null=False,
+        help_text='The kind of survey this is')
+
+    class Meta:
+        unique_together = ('month_year', 'apiary')
+
+    def __unicode__(self):
+        return self.month_year


### PR DESCRIPTION
## Overview

Adds model for Survey.

Connects #334 

### Notes

Includes an additional `surveytype` field not specified in the original card, since now we have to support more than one kind of survey: a long one and a short one, as discussed in [this document](https://docs.google.com/document/d/1WBEbPIAoex_kRQydom1420s_gBrEAk9Sh2sByYFHFjE/edit), the final details are still being worked out.

## Testing Instructions

* Check out this branch and run `manage.sh migrate`
* Ensure the table is created appropriately