### PR TITLE
Add /beekeepers/apiary/ endpoint

### DIFF
--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -41,7 +41,7 @@ export function fetchApiaryScores(apiaryList, forageRange) {
 
         // mark apiaries from input list as fetching data
         const fetchingApiaries = apiaries.map((apiary) => {
-            if (apiaryList.find(a => Object.is(a.location, apiary.location))) {
+            if (apiaryList.find(a => a.lat === apiary.lat && a.lng === apiary.lng)) {
                 return update(apiary, {
                     fetching: { $set: true },
                 });
@@ -50,7 +50,10 @@ export function fetchApiaryScores(apiaryList, forageRange) {
         });
         dispatch(setApiaryList(fetchingApiaries));
 
-        const locationList = apiaryList.map(apiary => apiary.location);
+        const locationList = apiaryList.map(apiary => ({
+            lat: apiary.lat,
+            lng: apiary.lng,
+        }));
 
         return axios
             .post('/beekeepers/fetch/', {

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -69,7 +69,8 @@ class Map extends Component {
         const newApiary = {
             name: 'dummy name',
             marker: 'F',
-            location: event.latlng,
+            lat: event.latlng.lat,
+            lng: event.latlng.lng,
             scores: {
                 [FORAGE_RANGE_3KM]: {},
                 [FORAGE_RANGE_5KM]: {},
@@ -93,7 +94,7 @@ class Map extends Component {
             return (
                 <Marker
                     key={key}
-                    position={[apiary.location.lat, apiary.location.lng]}
+                    position={[apiary.lat, apiary.lng]}
                 />
             );
         });

--- a/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
@@ -55,7 +55,7 @@ class Sidebar extends Component {
 
         const apiaryCards = apiaries.map(apiary => (
             <ApiaryCard
-                key={apiary.location}
+                key={apiary.lat.toString() + apiary.lng.toString()}
                 apiary={apiary}
                 forageRange={forageRange}
             />

--- a/src/icp/apps/beekeepers/js/src/propTypes.js
+++ b/src/icp/apps/beekeepers/js/src/propTypes.js
@@ -7,11 +7,6 @@ import {
 
 import { INDICATORS, FORAGE_RANGE_3KM, FORAGE_RANGE_5KM } from './constants';
 
-export const LatLng = shape({
-    lat: number.isRequired,
-    lng: number.isRequired,
-});
-
 export const Score = shape({
     data: number,
     error: string,
@@ -25,7 +20,8 @@ export const Scores = shape(Object.keys(INDICATORS).reduce(
 export const Apiary = shape({
     name: string.isRequired,
     marker: string.isRequired,
-    location: LatLng.isRequired,
+    lat: number.isRequired,
+    lng: number.isRequired,
     scores: shape({
         [FORAGE_RANGE_3KM]: Scores,
         [FORAGE_RANGE_5KM]: Scores,

--- a/src/icp/apps/beekeepers/migrations/0003_apiary_deleted.py
+++ b/src/icp/apps/beekeepers/migrations/0003_apiary_deleted.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('beekeepers', '0002_add_beekeepers_survey_model'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='apiary',
+            name='deleted_at',
+            field=models.DateTimeField(help_text='When was the Apiary deleted', null=True),
+        ),
+    ]

--- a/src/icp/apps/beekeepers/models.py
+++ b/src/icp/apps/beekeepers/models.py
@@ -44,6 +44,9 @@ class Apiary(models.Model):
     user = models.ForeignKey(
         AUTH_USER_MODEL,
         null=False)
+    deleted_at = models.DateTimeField(
+        null=True,
+        help_text='When was the Apiary deleted')
 
     def __unicode__(self):
         return unicode('{}:{}'.format(self.user.username, self.name))

--- a/src/icp/apps/beekeepers/serializers.py
+++ b/src/icp/apps/beekeepers/serializers.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+import json
+
+from rest_framework.serializers import (
+    BaseSerializer,
+    CurrentUserDefault,
+    ModelSerializer,
+    PrimaryKeyRelatedField,
+)
+
+from models import Apiary, Survey
+
+
+class JsonField(BaseSerializer):
+    def to_representation(self, obj):
+        return json.loads(obj)
+
+    def to_internal_value(self, obj):
+        return json.dumps(obj)
+
+
+class SurveySerializer(ModelSerializer):
+    class Meta:
+        model = Survey
+
+
+class ApiarySerializer(ModelSerializer):
+    class Meta:
+        model = Apiary
+        fields = ('id', 'lat', 'lng', 'marker', 'name',
+                  'scores', 'surveys',
+                  'starred', 'surveyed',
+                  'created_at', 'updated_at',
+                  'user',)
+
+    scores = JsonField(required=False)
+    surveys = SurveySerializer(many=True, read_only=True)
+    user = PrimaryKeyRelatedField(read_only=True, default=CurrentUserDefault())

--- a/src/icp/apps/beekeepers/urls.py
+++ b/src/icp/apps/beekeepers/urls.py
@@ -3,11 +3,17 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from django.conf.urls import patterns, url
+from django.conf.urls import include, patterns, url
+
+from rest_framework import routers
 
 from apps.beekeepers import views
 
+router = routers.DefaultRouter()
+router.register(r'apiary', views.ApiaryViewSet)
+
 urlpatterns = patterns(
     '',
+    url(r'^', include(router.urls)),
     url(r'fetch/$', views.fetch_data, name='fetch_data'),
 )

--- a/src/icp/apps/beekeepers/views.py
+++ b/src/icp/apps/beekeepers/views.py
@@ -3,10 +3,12 @@ from __future__ import division
 
 import os
 
-from rest_framework import decorators
+from rest_framework import decorators, viewsets
 from rest_framework.response import Response
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated
 
+from models import Apiary
+from serializers import ApiarySerializer
 from tasks import sample_at_point
 
 
@@ -44,3 +46,12 @@ def fetch_data(request):
         resp.append(all_location_data)
 
     return Response(resp)
+
+
+class ApiaryViewSet(viewsets.ModelViewSet):
+    queryset = Apiary.objects.all()
+    serializer_class = ApiarySerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        return Apiary.objects.filter(user=self.request.user)

--- a/src/icp/apps/beekeepers/views.py
+++ b/src/icp/apps/beekeepers/views.py
@@ -3,9 +3,13 @@ from __future__ import division
 
 import os
 
+from django.shortcuts import get_object_or_404
+from django.utils.timezone import now
+
 from rest_framework import decorators, viewsets
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.status import HTTP_204_NO_CONTENT
 
 from models import Apiary
 from serializers import ApiarySerializer
@@ -54,4 +58,16 @@ class ApiaryViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
-        return Apiary.objects.filter(user=self.request.user)
+        return Apiary.objects.filter(user=self.request.user, deleted_at=None)
+
+    def destroy(self, request, pk=None):
+        """Soft deletes Apiaries from user's account"""
+        apiary = get_object_or_404(Apiary,
+                                   id=pk,
+                                   user=request.user,
+                                   deleted_at=None)
+
+        apiary.deleted_at = now()
+        apiary.save()
+
+        return Response(status=HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Overview

- Users can list their own apiaries
- Users can create an apiary
- Users can retrieve an apiary
- Users can update an apiary
- Users can delete an apiary

When creating an Apiary, it should be given the following
arguments:

- lat, lng
- marker
- name

The following can be updated later:

- scores
- starred
- surveyed

The created Apiary is automatically associated with the User.

When users delete an Apiary, it is "soft-deleted". It will no longer be shown to the user, but will continue to exist in the database. A `deleted_at` field is introduced to record the time of soft deletion.

Front-end can upsert Apiaries in bulk at `/apiaries/upsert/` by POSTing an array of apiaries. If an apiary in the list has a matching ID, it will be updated, else inserted as a new apiary.

Connects #338 

### Demo

![image](https://user-images.githubusercontent.com/1430060/49107056-bc963200-f252-11e8-85c5-617095df3fd1.png)

### Notes

~~At one point, we had decided to consolidate the list of indicators in one place, which is currently the front-end. The front-end sends a list of indicators to the `/beekeepers/fetch/` endpoint to get the scores.~~

~~There was also discussion around merging that functionality with saving apiaries to the database. The work here is sort of independent, requiring the front-end to make one API call for fetching the scores and another to save the apiaries.~~

~~I'm going to investigate that workflow and perhaps follow up with a replacement PR.~~

Score fetching is decoupled from saving apiaries. After the scores have been fetched, the front-end will save apiaries separately.

## Testing Instructions

* Run migrations
* Go to :8000/beekeepers/apiary/
* Log in
* Try out the various API actions: create, update, delete, list, get
* Try out upsert by sending the following raw JSON blob:

  ```json
  [
    {
      "name": "dummy name",
      "marker": "F",
      "lat": 40.07071544306936,
      "lng": -76.32476806640626,
      "scores": {
        "3km": {
          "forage_fall": {
            "data": 42.747398376464844,
            "error": null
          },
          "pesticide": {
            "data": 0.07700182497501373,
            "error": null
          },
          "forage_spring": {
            "data": 49.24388885498047,
            "error": null
          },
          "forage_summer": {
            "data": 65.702392578125,
            "error": null
          },
          "nesting_quality": {
            "data": null,
            "error": "'/vsis3/beekeepers-staging-data-us-east-1/3km/nesting_quality_3km.tif' does not exist in the file system, and is not recognized as a supported dataset name."
          }
        },
        "5km": {}
      },
      "fetching": false,
      "selected": false,
      "starred": false,
      "surveyed": false
    },
    {
      "name": "dummy name",
      "marker": "F",
      "lat": 40.063358664163296,
      "lng": -76.24923706054689,
      "scores": {
        "3km": {
          "forage_fall": {
            "data": 41.9705810546875,
            "error": null
          },
          "pesticide": {
            "data": 0.18716716766357422,
            "error": null
          },
          "forage_spring": {
            "data": 40.493778228759766,
            "error": null
          },
          "forage_summer": {
            "data": 59.92522048950195,
            "error": null
          },
          "nesting_quality": {
            "data": null,
            "error": "'/vsis3/beekeepers-staging-data-us-east-1/3km/nesting_quality_3km.tif' does not exist in the file system, and is not recognized as a supported dataset name."
          }
        },
        "5km": {}
      },
      "fetching": false,
      "selected": false,
      "starred": false,
      "surveyed": false
    }
  ]
  ```

  Ensure that two apiaries are created.

* Copy the response and paste it as the new input for the `upsert` endpoint. Change something, like the `starred` status of one of the apiaries. Send it. Ensure that existing apiaries are updated.