### PR TITLE
Add swapfile to application server

### DIFF
--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -81,3 +81,6 @@
 
 - src: azavea.memcached
   version: 0.1.0
+
+- src: azavea.swapfile
+  version: 0.1.0

--- a/deployment/ansible/roles/bee-pollinator.app/meta/main.yml
+++ b/deployment/ansible/roles/bee-pollinator.app/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
   - { role: "bee-pollinator.base" }
+  - { role: "azavea.swapfile" }
   - { role: "azavea.python", python_development: True }
   - { role: "azavea.pip" }
   - { role: "azavea.nodejs" }


### PR DESCRIPTION
## Overview

During Ansible provisioning runs, the `Install NPM Dependencies` Beekeepers task occasionally causes the Node.js process to run out of memory. In an effort to allow this one-off process to have more memory to operate, a swapfile was added to boost virtual memory.

Fixes https://github.com/project-icp/bee-pollinator-app/issues/346

## Testing Instructions

Review the contents of the following PR build logs:

- http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-pull-requests/205/
- http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-pull-requests/206/
- http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-pull-requests/208/
- http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-pull-requests/209/
- http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-pull-requests/210/

Also, you can apply the changes in this branch to your `app` virtual machine and determine if swap is enabled:

```bash
$ vagrant up --provision app
$ vagrant ssh app
vagrant@app:~$ sudo swapon -s
Filename                                Type            Size    Used    Priority
/swapfile                               file            976556  0       -1
```