### PR TITLE
Record through which app User was created

### DIFF
--- a/src/icp/apps/modeling/models.py
+++ b/src/icp/apps/modeling/models.py
@@ -3,8 +3,10 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from django.conf import settings
 from django.contrib.gis.db import models
-from django.contrib.auth.models import User
+
+AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 
 class Project(models.Model):
@@ -14,7 +16,7 @@ class Project(models.Model):
         (YIELD_MODEL, 'Crop Yield Model'),
     )
 
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(AUTH_USER_MODEL)
     name = models.CharField(
         max_length=255)
     area_of_interest = models.MultiPolygonField(

--- a/src/icp/apps/user/admin.py
+++ b/src/icp/apps/user/admin.py
@@ -2,3 +2,8 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
+
+from django.contrib import admin
+from apps.user.models import UserProfile
+
+admin.site.register(UserProfile)

--- a/src/icp/apps/user/migrations/0001_create_user_profile_model.py
+++ b/src/icp/apps/user/migrations/0001_create_user_profile_model.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             name='UserProfile',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('origin_app', models.CharField(default=(b'POLLINATORS', b'Pollinators'), help_text=b'Record on which app the user signed up', max_length=255, choices=[(b'POLLINATORS', b'Pollinators'), (b'BEEKEEPERS', b'Beekeepers')])),
+                ('origin_app', models.CharField(help_text=b'Record on which app the user signed up', max_length=255, choices=[(b'Pollination', b'Pollination'), (b'Beekeepers', b'Beekeepers')])),
                 ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
             ],
         )

--- a/src/icp/apps/user/migrations/0001_create_user_profile_model.py
+++ b/src/icp/apps/user/migrations/0001_create_user_profile_model.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             name='UserProfile',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('app', django.contrib.postgres.fields.ArrayField(default=[(b'POLL', b'Pollinator')], size=None, base_field=models.CharField(max_length=255, choices=[(b'POLL', b'Pollinator'), (b'BEEK', b'Beekeepers')]), blank=True)),
+                ('origin_app', models.CharField(default=(b'POLLINATORS', b'Pollinators'), help_text=b'Record on which app the user signed up', max_length=255, choices=[(b'POLLINATORS', b'Pollinators'), (b'BEEKEEPERS', b'Beekeepers')])),
                 ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
             ],
         )

--- a/src/icp/apps/user/migrations/0001_initial.py
+++ b/src/icp/apps/user/migrations/0001_initial.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.contrib.postgres.fields
+from django.conf import settings
+ 
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='UserProfile',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('app', django.contrib.postgres.fields.ArrayField(default=[(b'POLL', b'Pollinator')], size=None, base_field=models.CharField(max_length=255, choices=[(b'POLL', b'Pollinator'), (b'BEEK', b'Beekeepers')]), blank=True)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
+            ],
+        )
+    ]

--- a/src/icp/apps/user/migrations/0002_add_userprofiles_to_existing_users.py
+++ b/src/icp/apps/user/migrations/0002_add_userprofiles_to_existing_users.py
@@ -16,7 +16,7 @@ def create_user_profiles_for_existing_users(apps, schema_editor):
 class Migration(migrations.Migration):
     
     dependencies = [
-        ('user', '0001_initial')
+        ('user', '0001_create_user_profile_model')
     ]
 
     operations = [

--- a/src/icp/apps/user/migrations/0002_add_userprofiles_to_existing_users.py
+++ b/src/icp/apps/user/migrations/0002_add_userprofiles_to_existing_users.py
@@ -4,13 +4,13 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 import django.contrib.postgres.fields
 from django.conf import settings
+from django.contrib.auth.models import User
+
+from apps.user.models import UserProfile
 
 def create_user_profiles_for_existing_users(apps, schema_editor):
-    User = apps.get_model('auth', 'User')
-    UserProfile = apps.get_model('user', 'UserProfile')
-
     for user in User.objects.all():
-        UserProfile.objects.create(user=user)
+        UserProfile.objects.get_or_create(user=user, origin_app=UserProfile.POLLINATION)
  
 
 class Migration(migrations.Migration):

--- a/src/icp/apps/user/migrations/0002_add_userprofiles_to_existing_users.py
+++ b/src/icp/apps/user/migrations/0002_add_userprofiles_to_existing_users.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.contrib.postgres.fields
+from django.conf import settings
+
+def create_user_profiles_for_existing_users(apps, schema_editor):
+    User = apps.get_model('auth', 'User')
+    UserProfile = apps.get_model('user', 'UserProfile')
+
+    for user in User.objects.all():
+        UserProfile.objects.create(user=user)
+ 
+
+class Migration(migrations.Migration):
+    
+    dependencies = [
+        ('user', '0001_initial')
+    ]
+
+    operations = [
+        migrations.RunPython(create_user_profiles_for_existing_users)
+    ]

--- a/src/icp/apps/user/models.py
+++ b/src/icp/apps/user/models.py
@@ -1,1 +1,25 @@
 # -*- coding: utf-8 -*-
+from django.db import models
+from django.contrib.postgres.fields import ArrayField
+from django.conf import settings
+
+AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
+
+
+class UserProfile(models.Model):
+    """For additional user properties."""
+
+    # App options
+    POLL = ('POLL', 'Pollinator')
+    BEEK = ('BEEK', 'Beekeepers')
+    APP_CHOICES = (POLL, BEEK)
+
+    user = models.OneToOneField(AUTH_USER_MODEL)
+    app = ArrayField(
+        models.CharField(
+            max_length=255,
+            choices=APP_CHOICES,
+        ),
+        default=[POLL],
+        blank=True,
+    )

--- a/src/icp/apps/user/models.py
+++ b/src/icp/apps/user/models.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from django.db import models
-from django.contrib.postgres.fields import ArrayField
 from django.conf import settings
 
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
@@ -9,15 +8,19 @@ AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 class UserProfile(models.Model):
     """For additional user properties."""
 
-    POLLINATORS = ('POLLINATORS', 'Pollinators')
-    BEEKEEPERS = ('BEEKEEPERS', 'Beekeepers')
-    APP_CHOICES = (POLLINATORS, BEEKEEPERS,)
+    POLLINATION = 'Pollination'
+    BEEKEEPERS = 'Beekeepers'
+
+    APP_CHOICES = (
+        (POLLINATION, POLLINATION),
+        (BEEKEEPERS, BEEKEEPERS),
+    )
 
     user = models.OneToOneField(AUTH_USER_MODEL)
     origin_app = models.CharField(
         max_length=255,
         choices=APP_CHOICES,
-        default=POLLINATORS,
+        null=False,
         help_text="Record on which app the user signed up"
     )
 

--- a/src/icp/apps/user/models.py
+++ b/src/icp/apps/user/models.py
@@ -9,17 +9,17 @@ AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 class UserProfile(models.Model):
     """For additional user properties."""
 
-    # App options
-    POLL = ('POLL', 'Pollinator')
-    BEEK = ('BEEK', 'Beekeepers')
-    APP_CHOICES = (POLL, BEEK)
+    POLLINATORS = ('POLLINATORS', 'Pollinators')
+    BEEKEEPERS = ('BEEKEEPERS', 'Beekeepers')
+    APP_CHOICES = (POLLINATORS, BEEKEEPERS,)
 
     user = models.OneToOneField(AUTH_USER_MODEL)
-    app = ArrayField(
-        models.CharField(
-            max_length=255,
-            choices=APP_CHOICES,
-        ),
-        default=[POLL],
-        blank=True,
+    origin_app = models.CharField(
+        max_length=255,
+        choices=APP_CHOICES,
+        default=POLLINATORS,
+        help_text="Record on which app the user signed up"
     )
+
+    def __unicode__(self):
+        return self.user.username

--- a/src/icp/apps/user/views.py
+++ b/src/icp/apps/user/views.py
@@ -18,6 +18,7 @@ from rest_framework.permissions import AllowAny
 
 from apps.user.models import UserProfile
 
+
 @decorators.api_view(['POST', 'GET'])
 @decorators.permission_classes((AllowAny, ))
 def login(request):
@@ -122,9 +123,15 @@ def sign_up(request):
         # Create a user profile with correct origin app
         # TODO: Correct the check for the beekeepers app
         if request.META['HTTP_REFERER'] is 'http://localhost:8000/?beekeepers':
-            UserProfile.objects.create(user=user, app=[UserProfile.BEEKEEPERS])
+            UserProfile.objects.create(
+                user=user,
+                origin_app=UserProfile.BEEKEEPERS
+            )
         else:
-            UserProfile.objects.create(user=user)
+            UserProfile.objects.create(
+                user=user,
+                origin_app=UserProfile.POLLINATION
+            )
 
         response_data = {'result': 'success',
                          'username': user.username,

--- a/src/icp/apps/user/views.py
+++ b/src/icp/apps/user/views.py
@@ -16,6 +16,7 @@ from rest_framework import decorators, status
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny
 
+from apps.user.models import UserProfile
 
 @decorators.api_view(['POST', 'GET'])
 @decorators.permission_classes((AllowAny, ))
@@ -117,6 +118,14 @@ def sign_up(request):
 
     if form.is_valid():
         user = view.register(request, form)
+
+        # Create a user profile with correct origin app
+        # TODO: Correct the check for the beekeepers app
+        if request.META['HTTP_REFERER'] is 'http://localhost:8000/?beekeepers':
+            UserProfile.objects.create(user=user, app=[UserProfile.BEEKEEPERS])
+        else:
+            UserProfile.objects.create(user=user)
+
         response_data = {'result': 'success',
                          'username': user.username,
                          'guest': False}


### PR DESCRIPTION
## Overview

The project already has Users for the Pollination Mapper app. Users from PM and Beekeepers will use the same User table, but we want to record from which app the User signed up. This PR adds a UserProfile attached to the User that can be extended to store other info (such as the future Beekeeper account profile).

This was done in place of moving to a custom `User` model. Django is protective of its User class and adding a custom User model would require copying all data to the new table (can't just add a new column to User). Since Bees is already in production, we want to preserve data / touch it as little as possible. We also gain flexibility to add user info later.

Connects #290

### Demo

After creating a user via the Pollination Mapper sign up modal/workflow:

<img width="415" alt="screen shot 2018-11-28 at 3 52 43 pm" src="https://user-images.githubusercontent.com/10568752/49181571-bcb33200-f325-11e8-9d79-2f231e6aa89d.png">
<img width="739" alt="screen shot 2018-11-28 at 3 52 56 pm" src="https://user-images.githubusercontent.com/10568752/49181572-bcb33200-f325-11e8-86c4-075c93aa8267.png">


## Testing Instructions

Apply migrations `./scripts/manage.py migrate`
Check that your existing users were given userprofiles marked with Pollination as their origin app (all users to this point should originate from there) http://localhost:8000/admin
Create a user via the sign up work flow on http://localhost:8000/ and see that it too assigned a user profile either checking via shell or the admin
