### PR TITLE
Implement modals for auth in the UI

### DIFF
--- a/src/icp/apps/beekeepers/js/src/App.jsx
+++ b/src/icp/apps/beekeepers/js/src/App.jsx
@@ -4,11 +4,15 @@ import { hot } from 'react-hot-loader';
 import Header from './components/Header';
 import Map from './components/Map';
 import Sidebar from './components/Sidebar';
+import SignUpModal from './components/SignUpModal';
+import LoginModal from './components/LoginModal';
 
 const App = () => (
     <>
         <Header />
         <main>
+            <SignUpModal />
+            <LoginModal />
             <Map />
             <Sidebar />
         </main>

--- a/src/icp/apps/beekeepers/js/src/App.jsx
+++ b/src/icp/apps/beekeepers/js/src/App.jsx
@@ -6,11 +6,13 @@ import Map from './components/Map';
 import Sidebar from './components/Sidebar';
 import SignUpModal from './components/SignUpModal';
 import LoginModal from './components/LoginModal';
+import ParticipateModal from './components/ParticipateModal';
 
 const App = () => (
     <>
         <Header />
         <main>
+            <ParticipateModal />
             <SignUpModal />
             <LoginModal />
             <Map />

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -14,6 +14,8 @@ export const openSignUpModal = createAction('Open sign up modal');
 export const closeSignUpModal = createAction('Close sign up modal');
 export const openLoginModal = createAction('Open log in modal');
 export const closeLoginModal = createAction('Close log in modal');
+export const openParticipateModal = createAction('Open participate modal');
+export const closeParticipateModal = createAction('Close participate modal');
 
 export function fetchApiaryScores(apiaryList, forageRange) {
     return (dispatch, getState) => {

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -10,6 +10,10 @@ export const setApiaryList = createAction('Set the apiary list');
 export const startFetchApiaryScores = createAction('Start fetching apiary scores');
 export const failFetchApiaryScores = createAction('Failed to fetch apiary scores');
 export const completeFetchApiaryScores = createAction('Completed fetching apiary scores');
+export const openSignUpModal = createAction('Open sign up modal');
+export const closeSignUpModal = createAction('Close sign up modal');
+export const openLoginModal = createAction('Open log in modal');
+export const closeLoginModal = createAction('Close log in modal');
 
 export function fetchApiaryScores(apiaryList, forageRange) {
     return (dispatch, getState) => {

--- a/src/icp/apps/beekeepers/js/src/components/Header.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Header.jsx
@@ -18,8 +18,8 @@ export default () => (
                     </button>
                 </li>
                 <li className="navbar__item">
-                    <button type="button" className="navbar__button">
-                        Account
+                    <button type="button" className="navbar__button--auth">
+                        Participate in study
                     </button>
                 </li>
             </ul>

--- a/src/icp/apps/beekeepers/js/src/components/Header.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Header.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import { func } from 'prop-types';
 
-export default () => (
+import { openSignUpModal } from '../actions';
+
+const Header = ({ dispatch }) => (
     <header className="header">
         <div className="navbar">
             <div className="navbar__logo">
@@ -18,11 +22,25 @@ export default () => (
                     </button>
                 </li>
                 <li className="navbar__item">
-                    <button type="button" className="navbar__button--auth">
-                        Participate in study
+                    <button
+                        type="button"
+                        className="navbar__button--auth"
+                        onClick={() => dispatch(openSignUpModal())}
+                    >
+                            Participate in study
                     </button>
                 </li>
             </ul>
         </div>
     </header>
 );
+
+function mapStateToProps(state) {
+    return state.main;
+}
+
+Header.propTypes = {
+    dispatch: func.isRequired,
+};
+
+export default connect(mapStateToProps)(Header);

--- a/src/icp/apps/beekeepers/js/src/components/Header.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Header.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { func } from 'prop-types';
 
-import { openSignUpModal } from '../actions';
+import { openParticipateModal } from '../actions';
 
 const Header = ({ dispatch }) => (
     <header className="header">
@@ -25,7 +25,7 @@ const Header = ({ dispatch }) => (
                     <button
                         type="button"
                         className="navbar__button--auth"
-                        onClick={() => dispatch(openSignUpModal())}
+                        onClick={() => dispatch(openParticipateModal())}
                     >
                             Participate in study
                     </button>

--- a/src/icp/apps/beekeepers/js/src/components/LoginModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/LoginModal.jsx
@@ -11,31 +11,43 @@ const LoginModal = ({ isLoginModalOpen, dispatch }) => (
         {close => (
             <div className="authModal">
                 <div className="authModal__header">
-                    <div>Log in to your account</div>
-                    <button type="button" onClick={close}>
+                    <div>Log in</div>
+                    <button type="button" className="button" onClick={close}>
                         &times;
                     </button>
                 </div>
                 <div className="authModal__content">
-                    <div className="title">Sign up for the study</div>
+                    <div className="title">Log in to your account</div>
                 </div>
-                <button
-                    type="button"
-                    className="button"
-                    onClick={close}
-                >
-                    I forgot my password
-                </button>
-                <button
-                    type="button"
-                    className="button"
-                    onClick={() => {
-                        close();
-                        dispatch(openSignUpModal());
-                    }}
-                >
-                    I need to sign up
-                </button>
+                <div className="authModal__footer">
+                    <button
+                        type="button"
+                        className="button--long"
+                        onClick={close}
+                    >
+                        Log in
+                    </button>
+                    <span>
+                        <button
+                            type="button"
+                            className="button"
+                            onClick={close}
+                        >
+                            I forgot my password
+                        </button>
+                        &#9900;
+                        <button
+                            type="button"
+                            className="button"
+                            onClick={() => {
+                                close();
+                                dispatch(openSignUpModal());
+                            }}
+                        >
+                            I need to sign up
+                        </button>
+                    </span>
+                </div>
             </div>
         )}
     </Popup>

--- a/src/icp/apps/beekeepers/js/src/components/LoginModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/LoginModal.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { bool, func } from 'prop-types';
+import Popup from 'reactjs-popup';
+import { connect } from 'react-redux';
+
+import { closeLoginModal, openSignUpModal } from '../actions';
+
+
+const LoginModal = ({ isLoginModalOpen, dispatch }) => (
+    <Popup open={isLoginModalOpen} onClose={() => dispatch(closeLoginModal())} modal>
+        {close => (
+            <div className="authModal">
+                <div className="authModal__header">
+                    <div>Log in to your account</div>
+                    <button type="button" onClick={close}>
+                        &times;
+                    </button>
+                </div>
+                <div className="authModal__content">
+                    <div className="title">Sign up for the study</div>
+                </div>
+                <button
+                    type="button"
+                    className="button"
+                    onClick={close}
+                >
+                    I forgot my password
+                </button>
+                <button
+                    type="button"
+                    className="button"
+                    onClick={() => {
+                        close();
+                        dispatch(openSignUpModal());
+                    }}
+                >
+                    I need to sign up
+                </button>
+            </div>
+        )}
+    </Popup>
+);
+
+function mapStateToProps(state) {
+    return state.main;
+}
+
+LoginModal.propTypes = {
+    isLoginModalOpen: bool.isRequired,
+    dispatch: func.isRequired,
+};
+
+export default connect(mapStateToProps)(LoginModal);

--- a/src/icp/apps/beekeepers/js/src/components/ParticipateModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ParticipateModal.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { bool, func } from 'prop-types';
+import Popup from 'reactjs-popup';
+import { connect } from 'react-redux';
+
+import { closeParticipateModal, openSignUpModal, openLoginModal } from '../actions';
+
+
+const ParticipateModal = ({ isParticipateModalOpen, dispatch }) => (
+    <Popup open={isParticipateModalOpen} onClose={() => dispatch(closeParticipateModal())} modal>
+        {close => (
+            <div className="authModal">
+                <div className="authModal__header">
+                    <div>Participate in study</div>
+                    <button type="button" className="button" onClick={close}>
+                        &times;
+                    </button>
+                </div>
+                <div className="authModal__content">
+                    <div className="title">
+                        Help give the beekeeping community better data!
+                    </div>
+                    Lorem ipsum
+                </div>
+                <div className="authModal__footer">
+                    <button
+                        type="button"
+                        className="button--long"
+                        onClick={() => {
+                            close();
+                            dispatch(openSignUpModal());
+                        }}
+                    >
+                        I want to participate
+                    </button>
+                    <span>
+                        Already a participant?
+                        <button
+                            type="button"
+                            className="button"
+                            onClick={() => {
+                                close();
+                                dispatch(openLoginModal());
+                            }}
+                        >
+                            Log in
+                        </button>
+                    </span>
+                </div>
+            </div>
+        )}
+    </Popup>
+);
+
+function mapStateToProps(state) {
+    return state.main;
+}
+
+ParticipateModal.propTypes = {
+    isParticipateModalOpen: bool.isRequired,
+    dispatch: func.isRequired,
+};
+
+export default connect(mapStateToProps)(ParticipateModal);

--- a/src/icp/apps/beekeepers/js/src/components/SignUpModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SignUpModal.jsx
@@ -12,31 +12,35 @@ const SignUpModal = ({ isSignUpModalOpen, dispatch }) => (
             <div className="authModal">
                 <div className="authModal__header">
                     <div>Participate in study</div>
-                    <button type="button" onClick={close}>
+                    <button type="button" className="button" onClick={close}>
                         &times;
                     </button>
                 </div>
                 <div className="authModal__content">
                     <div className="title">Sign up for the study</div>
                 </div>
-                <button
-                    type="button"
-                    className="button"
-                    onClick={close}
-                >
-                    Sign up
-                </button>
-                Already a participant?
-                <button
-                    type="button"
-                    className="button"
-                    onClick={() => {
-                        close();
-                        dispatch(openLoginModal());
-                    }}
-                >
-                    Log in
-                </button>
+                <div className="authModal__footer">
+                    <button
+                        type="button"
+                        className="button--long"
+                        onClick={close}
+                    >
+                        Sign up
+                    </button>
+                    <span>
+                        Already a participant?
+                        <button
+                            type="button"
+                            className="button"
+                            onClick={() => {
+                                close();
+                                dispatch(openLoginModal());
+                            }}
+                        >
+                            Log in
+                        </button>
+                    </span>
+                </div>
             </div>
         )}
     </Popup>

--- a/src/icp/apps/beekeepers/js/src/components/SignUpModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SignUpModal.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { bool, func } from 'prop-types';
+import Popup from 'reactjs-popup';
+import { connect } from 'react-redux';
+
+import { closeSignUpModal, openLoginModal } from '../actions';
+
+
+const SignUpModal = ({ isSignUpModalOpen, dispatch }) => (
+    <Popup open={isSignUpModalOpen} onClose={() => dispatch(closeSignUpModal())} modal>
+        {close => (
+            <div className="authModal">
+                <div className="authModal__header">
+                    <div>Participate in study</div>
+                    <button type="button" onClick={close}>
+                        &times;
+                    </button>
+                </div>
+                <div className="authModal__content">
+                    <div className="title">Sign up for the study</div>
+                </div>
+                <button
+                    type="button"
+                    className="button"
+                    onClick={close}
+                >
+                    Sign up
+                </button>
+                Already a participant?
+                <button
+                    type="button"
+                    className="button"
+                    onClick={() => {
+                        close();
+                        dispatch(openLoginModal());
+                    }}
+                >
+                    Log in
+                </button>
+            </div>
+        )}
+    </Popup>
+);
+
+function mapStateToProps(state) {
+    return state.main;
+}
+
+SignUpModal.propTypes = {
+    isSignUpModalOpen: bool.isRequired,
+    dispatch: func.isRequired,
+};
+
+export default connect(mapStateToProps)(SignUpModal);

--- a/src/icp/apps/beekeepers/js/src/reducers.js
+++ b/src/icp/apps/beekeepers/js/src/reducers.js
@@ -9,12 +9,18 @@ import {
     setSort,
     setForageRange,
     setApiaryList,
+    openSignUpModal,
+    closeSignUpModal,
+    openLoginModal,
+    closeLoginModal,
 } from './actions';
 
 const initialState = {
     sortBy: DEFAULT_SORT,
     forageRange: FORAGE_RANGE_3KM,
     apiaries: [],
+    isSignUpModalOpen: false,
+    isLoginModalOpen: false,
 };
 
 const mainReducer = createReducer({
@@ -24,6 +30,14 @@ const mainReducer = createReducer({
         (state, payload) => update(state, { forageRange: { $set: payload } }),
     [setApiaryList]:
         (state, payload) => update(state, { apiaries: { $set: payload } }),
+    [openSignUpModal]:
+        state => update(state, { isSignUpModalOpen: { $set: true } }),
+    [closeSignUpModal]:
+        state => update(state, { isSignUpModalOpen: { $set: false } }),
+    [openLoginModal]:
+        state => update(state, { isLoginModalOpen: { $set: true } }),
+    [closeLoginModal]:
+        state => update(state, { isLoginModalOpen: { $set: false } }),
 }, initialState);
 
 // Placeholder reducer for parts of state that will be persisted to localStorage

--- a/src/icp/apps/beekeepers/js/src/reducers.js
+++ b/src/icp/apps/beekeepers/js/src/reducers.js
@@ -13,6 +13,8 @@ import {
     closeSignUpModal,
     openLoginModal,
     closeLoginModal,
+    openParticipateModal,
+    closeParticipateModal,
 } from './actions';
 
 const initialState = {
@@ -21,6 +23,7 @@ const initialState = {
     apiaries: [],
     isSignUpModalOpen: false,
     isLoginModalOpen: false,
+    isParticipateModalOpen: false,
 };
 
 const mainReducer = createReducer({
@@ -38,6 +41,10 @@ const mainReducer = createReducer({
         state => update(state, { isLoginModalOpen: { $set: true } }),
     [closeLoginModal]:
         state => update(state, { isLoginModalOpen: { $set: false } }),
+    [openParticipateModal]:
+        state => update(state, { isParticipateModalOpen: { $set: true } }),
+    [closeParticipateModal]:
+        state => update(state, { isParticipateModalOpen: { $set: false } }),
 }, initialState);
 
 // Placeholder reducer for parts of state that will be persisted to localStorage

--- a/src/icp/apps/beekeepers/package.json
+++ b/src/icp/apps/beekeepers/package.json
@@ -33,6 +33,7 @@
     "react-redux": "~5.0.7",
     "react-router": "~4.2.0",
     "react-router-dom": "~4.2.2",
+    "reactjs-popup": "~1.3.1",
     "redux": "~3.7.2",
     "redux-act": "~1.7.4",
     "redux-logger": "~3.0.6",

--- a/src/icp/apps/beekeepers/sass/06_components/_modal.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_modal.scss
@@ -1,0 +1,57 @@
+.popup-overlay {
+    z-index: 1001 !important;
+}
+
+.popup-content {
+    top: -15%;
+    width: 380px !important;
+    padding: 0 !important;
+}
+
+.authModal {
+    &__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 8px 15px;
+        font: $font-med;
+        font-weight: $font-weight-bold;
+        border-bottom: 1px solid $color-grey-4;
+
+        > .button {
+            padding: 0;
+            font: $font-xl;
+            border: none;
+        }
+    }
+
+    &__content {
+        padding: 15px;
+
+        .title {
+            font: $font-xxl;
+            font-weight: $font-weight-bold;
+        }
+    }
+
+    &__footer {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin-top: 20px;
+        padding: 15px;
+
+        .button {
+            margin-top: 20px;
+            color: $color-primary;
+            border: none;
+
+            &--long {
+                width: 100%;
+                padding: 15px;
+                color: $color-white;
+                background: $color-primary;
+            }
+        }
+    }
+}

--- a/src/icp/apps/beekeepers/sass/06_components/_navbar.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_navbar.scss
@@ -22,5 +22,11 @@
         font-size: 14px;
         background: none;
         border: none;
+
+        &--auth {
+            padding: 9px;
+            color: $color-white;
+            background: $color-primary;
+        }
     }
 }

--- a/src/icp/apps/beekeepers/webpack.config.js
+++ b/src/icp/apps/beekeepers/webpack.config.js
@@ -21,6 +21,7 @@ module.exports = ({ production }) => {
                 'react',
                 'react-dom',
                 'react-leaflet',
+                'reactjs-popup',
                 'react-redux',
                 'react-router',
                 'react-router-dom',

--- a/src/icp/apps/beekeepers/yarn.lock
+++ b/src/icp/apps/beekeepers/yarn.lock
@@ -6985,6 +6985,10 @@ react@~16.6.0:
     prop-types "^15.6.2"
     scheduler "^0.10.0"
 
+reactjs-popup@~1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/reactjs-popup/-/reactjs-popup-1.3.1.tgz#a5440612f7b564acad90bc06ee8f01b0f75e7477"
+
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"


### PR DESCRIPTION
## Overview

We've started working on the user management feature for Beekeepers as of #290 and this PR is the first of many for the UI. Set up the 3 types of auth modals and moving between them as per the wireframes, see issue for screen caps.

Note and pardon the `=` in the branch name, sloppy typing 😬 

Connects #325

### Demo
![screen shot 2018-12-03 at 4 07 00 pm](https://user-images.githubusercontent.com/10568752/49401585-9a4e5980-f715-11e8-9f93-6e85dba85e2c.png)

![screen shot 2018-12-03 at 4 08 04 pm](https://user-images.githubusercontent.com/10568752/49401605-a9cda280-f715-11e8-90fa-eb1f7185beab.png)

![screen shot 2018-12-03 at 4 08 13 pm](https://user-images.githubusercontent.com/10568752/49401606-a9cda280-f715-11e8-8b05-f3cb2742ec83.png)


### Notes

The dispatched action from the modal closing is called twice, which is non-breaking and seems out of my control using the lib's close methods 🤔 -- reactjs-popup appears to be doing that. 

Unsure about my BEM implementation 😬 

## Testing Instructions

Install the new npm lib with `./scripts/beekeepers.sh install`
`./scripts/beekeepers.sh start` 
Click "participate in study" in the top right and cycle through making sure things are as you expect. Some buttons that will eventually have functionality are set up to close their modal at the moment.
