### PR TITLE
Add spinner to apiary cards

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -36,7 +36,7 @@ const ApiaryCard = ({ apiary, forageRange }) => {
     })();
 
     const scoresBody = !Object.keys(apiary.scores[forageRange]).length
-        ? 'TODO: Insert spinner'
+        ? <div className="spinner" />
         : (
             <div className="indicator-container">
                 <ScoresLabel

--- a/src/icp/apps/beekeepers/sass/06_components/_card.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_card.scss
@@ -21,6 +21,7 @@
         width: 100%;
         height: 3.6rem;
         padding: 0.9rem 0.4rem;
+        text-align: center;
     }
 
     &__identification {

--- a/src/icp/apps/beekeepers/sass/06_components/_spinner.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_spinner.scss
@@ -1,0 +1,17 @@
+.spinner::after {
+    position: absolute;
+    box-sizing: border-box;
+    width: 20px;
+    height: 20px;
+    border: 2px solid #ccc;
+    border-top-color: #333;
+    border-radius: 50%;
+    animation: spinner-animation 0.6s linear infinite;
+    content: '';
+}
+
+@keyframes spinner-animation {
+    to {
+        transform: rotate(360deg);
+    }
+}


### PR DESCRIPTION
## Overview

Replace the TODO text in the apiary card with a spinner. The user sees the spinner when the data is fetching. I lifted the spinner CSS from MMW.

Connects #351 

### Demo

![spinner](https://user-images.githubusercontent.com/10568752/49465317-4aca6500-f7cb-11e8-865d-24f48f7e8ff5.gif)

## Notes
FYI if you’re logged into the pollination front end, beekeepers requests to the backend will fail with a 403 due to CSRF protection. The underlying error: `CSRF Failed: CSRF token missing or incorrect.` It's ok for now, but we will want to fix that after login is implemented #327 . I've created #358

## Testing Instructions
`./scripts/beekeepers.sh start`
Click on the map, and see the spinner go on the apiary card ~