### PR TITLE
Implement logging in in Beekeepers UI

### DIFF
--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -124,7 +124,7 @@ export function login(form) {
                 dispatch(setAuthState({
                     username: '',
                     authError: error.response.data.errors[0],
-                    userId: NaN,
+                    userId: null,
                 }));
             });
     };

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -17,6 +17,7 @@ export const closeLoginModal = createAction('Close log in modal');
 export const openParticipateModal = createAction('Open participate modal');
 export const closeParticipateModal = createAction('Close participate modal');
 export const setAuthState = createAction('Set auth information to the state');
+export const clearAuthError = createAction('Clear saved auth error');
 
 
 export function fetchApiaryScores(apiaryList, forageRange) {
@@ -114,7 +115,7 @@ export function login(form) {
             .then(({ data }) => {
                 dispatch(setAuthState({
                     username: data.username,
-                    error: '',
+                    authError: '',
                     userId: data.id,
                 }));
                 dispatch(closeLoginModal());
@@ -122,7 +123,7 @@ export function login(form) {
             .catch((error) => {
                 dispatch(setAuthState({
                     username: '',
-                    error,
+                    authError: error.response.data.errors[0],
                     userId: NaN,
                 }));
             });

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -1,7 +1,7 @@
 import { createAction } from 'redux-act';
 import update from 'immutability-helper';
-import axios from 'axios';
 
+import csrfRequest from './csrfRequest';
 import { INDICATORS } from './constants';
 
 export const setSort = createAction('Set apiary sort');
@@ -16,6 +16,7 @@ export const openLoginModal = createAction('Open log in modal');
 export const closeLoginModal = createAction('Close log in modal');
 export const openParticipateModal = createAction('Open participate modal');
 export const closeParticipateModal = createAction('Close participate modal');
+
 
 export function fetchApiaryScores(apiaryList, forageRange) {
     return (dispatch, getState) => {
@@ -61,7 +62,7 @@ export function fetchApiaryScores(apiaryList, forageRange) {
             lng: apiary.lng,
         }));
 
-        return axios
+        return csrfRequest
             .post('/beekeepers/fetch/', {
                 locations: locationList,
                 forage_range: forageRange,
@@ -101,6 +102,20 @@ export function fetchApiaryScores(apiaryList, forageRange) {
                 window.console.warn(error);
                 dispatch(failFetchApiaryScores(error));
                 dispatch(setApiaryList(newList));
+            });
+    };
+}
+
+export function login(form) {
+    return (dispatch) => {
+        csrfRequest
+            .post('/user/login', form)
+            .then(({ data }) => {
+                window.console.log(data);
+                dispatch(closeLoginModal());
+            })
+            .catch((error) => {
+                window.console.warn(error);
             });
     };
 }

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -16,6 +16,7 @@ export const openLoginModal = createAction('Open log in modal');
 export const closeLoginModal = createAction('Close log in modal');
 export const openParticipateModal = createAction('Open participate modal');
 export const closeParticipateModal = createAction('Close participate modal');
+export const setAuthState = createAction('Set auth information to the state');
 
 
 export function fetchApiaryScores(apiaryList, forageRange) {
@@ -111,11 +112,19 @@ export function login(form) {
         csrfRequest
             .post('/user/login', form)
             .then(({ data }) => {
-                window.console.log(data);
+                dispatch(setAuthState({
+                    username: data.username,
+                    error: '',
+                    userId: data.id,
+                }));
                 dispatch(closeLoginModal());
             })
             .catch((error) => {
-                window.console.warn(error);
+                dispatch(setAuthState({
+                    username: '',
+                    error,
+                    userId: NaN,
+                }));
             });
     };
 }

--- a/src/icp/apps/beekeepers/js/src/components/Header.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Header.jsx
@@ -1,24 +1,30 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { func } from 'prop-types';
+import { func, string } from 'prop-types';
 
-import { openParticipateModal } from '../actions';
+import { openParticipateModal, openLoginModal } from '../actions';
 
-const Header = ({ dispatch }) => (
-    <header className="header">
-        <div className="navbar">
-            <div className="navbar__logo">
-                Landscape4Bees
-            </div>
-            <ul className="navbar__items">
+const Header = ({ dispatch, username }) => {
+    const authButtons = username
+        ? (
+            <li className="navbar__item">
+                <button
+                    type="button"
+                    className="navbar__button"
+                >
+                    {username}
+                </button>
+            </li>
+        )
+        : (
+            <>
                 <li className="navbar__item">
-                    <button type="button" className="navbar__button">
-                        About
-                    </button>
-                </li>
-                <li className="navbar__item">
-                    <button type="button" className="navbar__button">
-                        Methodology
+                    <button
+                        type="button"
+                        className="navbar__button"
+                        onClick={() => dispatch(openLoginModal())}
+                    >
+                        Log in
                     </button>
                 </li>
                 <li className="navbar__item">
@@ -30,17 +36,39 @@ const Header = ({ dispatch }) => (
                             Participate in study
                     </button>
                 </li>
-            </ul>
-        </div>
-    </header>
-);
+            </>
+        );
+    return (
+        <header className="header">
+            <div className="navbar">
+                <div className="navbar__logo">
+                    Landscape4Bees
+                </div>
+                <ul className="navbar__items">
+                    <li className="navbar__item">
+                        <button type="button" className="navbar__button">
+                            About
+                        </button>
+                    </li>
+                    <li className="navbar__item">
+                        <button type="button" className="navbar__button">
+                            Methodology
+                        </button>
+                    </li>
+                    {authButtons}
+                </ul>
+            </div>
+        </header>
+    );
+};
 
 function mapStateToProps(state) {
-    return state.main;
+    return state.auth;
 }
 
 Header.propTypes = {
     dispatch: func.isRequired,
+    username: string.isRequired,
 };
 
 export default connect(mapStateToProps)(Header);

--- a/src/icp/apps/beekeepers/js/src/components/LoginModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/LoginModal.jsx
@@ -4,19 +4,13 @@ import Popup from 'reactjs-popup';
 import { connect } from 'react-redux';
 
 import { closeLoginModal, openSignUpModal, login } from '../actions';
+import { parseFormToObject } from '../utils';
 
 
 const LoginModal = ({ isLoginModalOpen, dispatch }) => {
     const submitForm = (event) => {
-        let form = {};
-        let i;
-        for (i = 0; i < event.currentTarget.elements.length; i += 1) {
-            const inputValue = event.currentTarget.elements[i].value;
-            const inputName = event.currentTarget.elements[i].name;
-            const newElement = { [inputName]: inputValue };
-            form = Object.assign(newElement, form);
-        }
-        dispatch(login(form));
+        // Send form data to backend for validation and prevent modal from closing
+        dispatch(login(parseFormToObject(event)));
         event.preventDefault();
     };
 

--- a/src/icp/apps/beekeepers/js/src/components/LoginModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/LoginModal.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { bool, func, string } from 'prop-types';
 import Popup from 'reactjs-popup';
 import { connect } from 'react-redux';
@@ -9,95 +9,129 @@ import {
     login,
     clearAuthError,
 } from '../actions';
-import { parseFormToObject } from '../utils';
 
 
-const LoginModal = ({ isLoginModalOpen, dispatch, authError }) => {
-    const submitForm = (event) => {
+class LoginModal extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            // each form input corresponds to a state var
+            username: '',
+            password: '',
+        };
+        this.handleChange = this.handleChange.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+    }
+
+    handleChange(event) {
+        this.setState({ [event.currentTarget.name]: event.currentTarget.value });
+    }
+
+    handleSubmit(event) {
         // Send form data to backend for validation and prevent modal from closing
-        dispatch(login(parseFormToObject(event)));
+        const {
+            dispatch,
+        } = this.props;
+        dispatch(login(this.state));
         event.preventDefault();
-    };
+    }
 
-    const errorWarning = authError ? (
-        <div className="form__group--error">
-            {authError}
-        </div>
-    ) : null;
+    render() {
+        const {
+            authError,
+            isLoginModalOpen,
+            dispatch,
+        } = this.props;
 
-    return (
-        <Popup
-            open={isLoginModalOpen}
-            onClose={() => {
-                dispatch(clearAuthError());
-                dispatch(closeLoginModal());
-            }}
-            modal
-        >
-            {close => (
-                <div className="authModal">
-                    <div className="authModal__header">
-                        <div>Log in</div>
-                        <button type="button" className="button" onClick={close}>
-                            &times;
-                        </button>
-                    </div>
-                    <div className="authModal__content">
-                        <div className="title">Log in to your account</div>
-                        <form className="form" onSubmit={submitForm}>
-                            {errorWarning}
-                            <div className="form__group">
-                                <label htmlFor="username">Username</label>
-                                <input
-                                    type="username"
-                                    name="username"
-                                    className="form__control"
-                                />
-                            </div>
-                            <div className="form__group">
-                                <label htmlFor="password">Password</label>
-                                <input
-                                    type="password"
-                                    className="form__control"
-                                    name="password"
-                                />
-                            </div>
-                            <button
-                                type="submit"
-                                value="Submit"
-                                className="button--long"
-                            >
-                                Log in
+        const {
+            username,
+            password,
+        } = this.state;
+
+        const errorWarning = authError ? (
+            <div className="form__group--error">
+                {authError}
+            </div>
+        ) : null;
+
+        return (
+            <Popup
+                open={isLoginModalOpen}
+                onClose={() => {
+                    dispatch(clearAuthError());
+                    dispatch(closeLoginModal());
+                }}
+                modal
+            >
+                {close => (
+                    <div className="authModal">
+                        <div className="authModal__header">
+                            <div>Log in</div>
+                            <button type="button" className="button" onClick={close}>
+                                &times;
                             </button>
-                        </form>
+                        </div>
+                        <div className="authModal__content">
+                            <div className="title">Log in to your account</div>
+                            <form className="form" onSubmit={this.handleSubmit}>
+                                {errorWarning}
+                                <div className="form__group">
+                                    <label htmlFor="username">Username</label>
+                                    <input
+                                        type="text"
+                                        name="username"
+                                        value={username}
+                                        onChange={this.handleChange}
+                                        className="form__control"
+                                    />
+                                </div>
+                                <div className="form__group">
+                                    <label htmlFor="password">Password</label>
+                                    <input
+                                        type="password"
+                                        className="form__control"
+                                        name="password"
+                                        value={password}
+                                        onChange={this.handleChange}
+                                    />
+                                </div>
+                                <button
+                                    type="submit"
+                                    value="Submit"
+                                    className="button--long"
+                                >
+                                    Log in
+                                </button>
+                            </form>
+                        </div>
+                        <div className="authModal__footer">
+                            <span>
+                                <button
+                                    type="button"
+                                    className="button"
+                                    onClick={close}
+                                >
+                                    I forgot my password
+                                </button>
+                                &#9900;
+                                <button
+                                    type="button"
+                                    className="button"
+                                    onClick={() => {
+                                        close();
+                                        dispatch(openSignUpModal());
+                                    }}
+                                >
+                                    I need to sign up
+                                </button>
+                            </span>
+                        </div>
                     </div>
-                    <div className="authModal__footer">
-                        <span>
-                            <button
-                                type="button"
-                                className="button"
-                                onClick={close}
-                            >
-                                I forgot my password
-                            </button>
-                            &#9900;
-                            <button
-                                type="button"
-                                className="button"
-                                onClick={() => {
-                                    close();
-                                    dispatch(openSignUpModal());
-                                }}
-                            >
-                                I need to sign up
-                            </button>
-                        </span>
-                    </div>
-                </div>
-            )}
-        </Popup>
-    );
-};
+                )}
+            </Popup>
+        );
+    }
+}
 
 function mapStateToProps(state) {
     return {

--- a/src/icp/apps/beekeepers/js/src/components/LoginModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/LoginModal.jsx
@@ -1,21 +1,39 @@
 import React from 'react';
-import { bool, func } from 'prop-types';
+import { bool, func, string } from 'prop-types';
 import Popup from 'reactjs-popup';
 import { connect } from 'react-redux';
 
-import { closeLoginModal, openSignUpModal, login } from '../actions';
+import {
+    closeLoginModal,
+    openSignUpModal,
+    login,
+    clearAuthError,
+} from '../actions';
 import { parseFormToObject } from '../utils';
 
 
-const LoginModal = ({ isLoginModalOpen, dispatch }) => {
+const LoginModal = ({ isLoginModalOpen, dispatch, authError }) => {
     const submitForm = (event) => {
         // Send form data to backend for validation and prevent modal from closing
         dispatch(login(parseFormToObject(event)));
         event.preventDefault();
     };
 
+    const errorWarning = authError ? (
+        <div className="form__group--error">
+            {authError}
+        </div>
+    ) : null;
+
     return (
-        <Popup open={isLoginModalOpen} onClose={() => dispatch(closeLoginModal())} modal>
+        <Popup
+            open={isLoginModalOpen}
+            onClose={() => {
+                dispatch(clearAuthError());
+                dispatch(closeLoginModal());
+            }}
+            modal
+        >
             {close => (
                 <div className="authModal">
                     <div className="authModal__header">
@@ -27,6 +45,7 @@ const LoginModal = ({ isLoginModalOpen, dispatch }) => {
                     <div className="authModal__content">
                         <div className="title">Log in to your account</div>
                         <form className="form" onSubmit={submitForm}>
+                            {errorWarning}
                             <div className="form__group">
                                 <label htmlFor="username">Username</label>
                                 <input
@@ -81,12 +100,17 @@ const LoginModal = ({ isLoginModalOpen, dispatch }) => {
 };
 
 function mapStateToProps(state) {
-    return state.main;
+    return {
+        isLoginModalOpen: state.main.isLoginModalOpen,
+        dispatch: state.main.dispatch,
+        authError: state.auth.authError,
+    };
 }
 
 LoginModal.propTypes = {
     isLoginModalOpen: bool.isRequired,
     dispatch: func.isRequired,
+    authError: string.isRequired,
 };
 
 export default connect(mapStateToProps)(LoginModal);

--- a/src/icp/apps/beekeepers/js/src/components/LoginModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/LoginModal.jsx
@@ -3,55 +3,88 @@ import { bool, func } from 'prop-types';
 import Popup from 'reactjs-popup';
 import { connect } from 'react-redux';
 
-import { closeLoginModal, openSignUpModal } from '../actions';
+import { closeLoginModal, openSignUpModal, login } from '../actions';
 
 
-const LoginModal = ({ isLoginModalOpen, dispatch }) => (
-    <Popup open={isLoginModalOpen} onClose={() => dispatch(closeLoginModal())} modal>
-        {close => (
-            <div className="authModal">
-                <div className="authModal__header">
-                    <div>Log in</div>
-                    <button type="button" className="button" onClick={close}>
-                        &times;
-                    </button>
-                </div>
-                <div className="authModal__content">
-                    <div className="title">Log in to your account</div>
-                </div>
-                <div className="authModal__footer">
-                    <button
-                        type="button"
-                        className="button--long"
-                        onClick={close}
-                    >
-                        Log in
-                    </button>
-                    <span>
-                        <button
-                            type="button"
-                            className="button"
-                            onClick={close}
-                        >
-                            I forgot my password
+const LoginModal = ({ isLoginModalOpen, dispatch }) => {
+    const submitForm = (event) => {
+        let form = {};
+        let i;
+        for (i = 0; i < event.currentTarget.elements.length; i += 1) {
+            const inputValue = event.currentTarget.elements[i].value;
+            const inputName = event.currentTarget.elements[i].name;
+            const newElement = { [inputName]: inputValue };
+            form = Object.assign(newElement, form);
+        }
+        dispatch(login(form));
+        event.preventDefault();
+    };
+
+    return (
+        <Popup open={isLoginModalOpen} onClose={() => dispatch(closeLoginModal())} modal>
+            {close => (
+                <div className="authModal">
+                    <div className="authModal__header">
+                        <div>Log in</div>
+                        <button type="button" className="button" onClick={close}>
+                            &times;
                         </button>
-                        &#9900;
-                        <button
-                            type="button"
-                            className="button"
-                            onClick={() => {
-                                close();
-                                dispatch(openSignUpModal());
-                            }}
-                        >
-                            I need to sign up
-                        </button>
-                    </span>
+                    </div>
+                    <div className="authModal__content">
+                        <div className="title">Log in to your account</div>
+                        <form className="form" onSubmit={submitForm}>
+                            <div className="form__group">
+                                <label htmlFor="username">Username</label>
+                                <input
+                                    type="username"
+                                    name="username"
+                                    className="form__control"
+                                />
+                            </div>
+                            <div className="form__group">
+                                <label htmlFor="password">Password</label>
+                                <input
+                                    type="password"
+                                    className="form__control"
+                                    name="password"
+                                />
+                            </div>
+                            <button
+                                type="submit"
+                                value="Submit"
+                                className="button--long"
+                            >
+                                Log in
+                            </button>
+                        </form>
+                    </div>
+                    <div className="authModal__footer">
+                        <span>
+                            <button
+                                type="button"
+                                className="button"
+                                onClick={close}
+                            >
+                                I forgot my password
+                            </button>
+                            &#9900;
+                            <button
+                                type="button"
+                                className="button"
+                                onClick={() => {
+                                    close();
+                                    dispatch(openSignUpModal());
+                                }}
+                            >
+                                I need to sign up
+                            </button>
+                        </span>
+                    </div>
                 </div>
-            </div>
-        )}
-    </Popup>
-);
+            )}
+        </Popup>
+    );
+};
 
 function mapStateToProps(state) {
     return state.main;

--- a/src/icp/apps/beekeepers/js/src/csrfRequest.js
+++ b/src/icp/apps/beekeepers/js/src/csrfRequest.js
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+// Used to make an authenticated HTTP requests to Django
+axios.defaults.xsrfHeaderName = 'X-CSRFToken';
+axios.defaults.xsrfCookieName = 'csrftoken';
+const csrfRequest = axios.create({
+    headers: {
+        credentials: 'same-origin',
+    },
+});
+
+export default csrfRequest;

--- a/src/icp/apps/beekeepers/js/src/reducers.js
+++ b/src/icp/apps/beekeepers/js/src/reducers.js
@@ -15,6 +15,7 @@ import {
     closeLoginModal,
     openParticipateModal,
     closeParticipateModal,
+    setAuthState,
 } from './actions';
 
 const initialState = {
@@ -50,7 +51,19 @@ const mainReducer = createReducer({
 // Placeholder reducer for parts of state that will be persisted to localStorage
 const savedReducer = createReducer({}, {});
 
+const initialAuthState = {
+    username: '',
+    userId: NaN,
+    error: '',
+};
+
+const authReducer = createReducer({
+    [setAuthState]:
+        (state, payload) => update(state, { $set: payload }),
+}, initialAuthState);
+
 export default {
     main: mainReducer,
     saved: savedReducer,
+    auth: authReducer,
 };

--- a/src/icp/apps/beekeepers/js/src/reducers.js
+++ b/src/icp/apps/beekeepers/js/src/reducers.js
@@ -16,6 +16,7 @@ import {
     openParticipateModal,
     closeParticipateModal,
     setAuthState,
+    clearAuthError,
 } from './actions';
 
 const initialState = {
@@ -54,12 +55,14 @@ const savedReducer = createReducer({}, {});
 const initialAuthState = {
     username: '',
     userId: NaN,
-    error: '',
+    authError: '',
 };
 
 const authReducer = createReducer({
     [setAuthState]:
         (state, payload) => update(state, { $set: payload }),
+    [clearAuthError]:
+        state => update(state, { authError: { $set: '' } }),
 }, initialAuthState);
 
 export default {

--- a/src/icp/apps/beekeepers/js/src/reducers.js
+++ b/src/icp/apps/beekeepers/js/src/reducers.js
@@ -54,7 +54,7 @@ const savedReducer = createReducer({}, {});
 
 const initialAuthState = {
     username: '',
-    userId: NaN,
+    userId: null,
     authError: '',
 };
 

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -12,15 +12,3 @@ export function toTitleCase(value) {
         .map(word => word.charAt(0).toUpperCase() + word.slice(1))
         .join('');
 }
-
-export function parseFormToObject(submitEvent) {
-    let form = {};
-    let i;
-    for (i = 0; i < submitEvent.currentTarget.elements.length; i += 1) {
-        const inputValue = submitEvent.currentTarget.elements[i].value;
-        const inputName = submitEvent.currentTarget.elements[i].name;
-        const newElement = { [inputName]: inputValue };
-        form = Object.assign(newElement, form);
-    }
-    return form;
-}

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -12,3 +12,15 @@ export function toTitleCase(value) {
         .map(word => word.charAt(0).toUpperCase() + word.slice(1))
         .join('');
 }
+
+export function parseFormToObject(submitEvent) {
+    let form = {};
+    let i;
+    for (i = 0; i < submitEvent.currentTarget.elements.length; i += 1) {
+        const inputValue = submitEvent.currentTarget.elements[i].value;
+        const inputName = submitEvent.currentTarget.elements[i].name;
+        const newElement = { [inputName]: inputValue };
+        form = Object.assign(newElement, form);
+    }
+    return form;
+}

--- a/src/icp/apps/beekeepers/sass/06_components/_modal.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_modal.scss
@@ -67,6 +67,10 @@
         width: 100%;
         font: $font-size-base;
         font-weight: $font-weight-bold;
+
+        &--error {
+            color: $color-starred;
+        }
     }
 
     &__control {

--- a/src/icp/apps/beekeepers/sass/06_components/_modal.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_modal.scss
@@ -9,6 +9,19 @@
 }
 
 .authModal {
+    .button {
+        color: $color-primary;
+        border: none;
+
+        &--long {
+            width: 100%;
+            margin-top: 20px;
+            padding: 15px;
+            color: $color-white;
+            background: $color-primary;
+        }
+    }
+
     &__header {
         display: flex;
         justify-content: space-between;
@@ -20,6 +33,7 @@
 
         > .button {
             padding: 0;
+            color: $color-black;
             font: $font-xl;
             border: none;
         }
@@ -38,20 +52,26 @@
         display: flex;
         flex-direction: column;
         align-items: center;
-        margin-top: 20px;
         padding: 15px;
+    }
+}
 
-        .button {
-            margin-top: 20px;
-            color: $color-primary;
-            border: none;
+.form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 
-            &--long {
-                width: 100%;
-                padding: 15px;
-                color: $color-white;
-                background: $color-primary;
-            }
-        }
+    &__group {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        font: $font-size-base;
+        font-weight: $font-weight-bold;
+    }
+
+    &__control {
+        padding: 8px;
+        font: $font-med;
+        border: $color-grey-3 solid 0.1px;
     }
 }

--- a/src/icp/apps/user/views.py
+++ b/src/icp/apps/user/views.py
@@ -26,8 +26,10 @@ def login(request):
     status_code = status.HTTP_200_OK
 
     if request.method == 'POST':
-        user = authenticate(username=request.REQUEST.get('username'),
-                            password=request.REQUEST.get('password'))
+        username = request.REQUEST.get('username') or request.DATA.get('username')
+        password = request.REQUEST.get('password') or request.DATA.get('password')
+        user = authenticate(username=username,
+                            password=password)
 
         if user is not None:
             if user.is_active:

--- a/src/icp/apps/user/views.py
+++ b/src/icp/apps/user/views.py
@@ -26,8 +26,10 @@ def login(request):
     status_code = status.HTTP_200_OK
 
     if request.method == 'POST':
-        username = request.REQUEST.get('username') or request.DATA.get('username')
-        password = request.REQUEST.get('password') or request.DATA.get('password')
+        username = (request.REQUEST.get('username') or
+                    request.DATA.get('username'))
+        password = (request.REQUEST.get('password') or
+                    request.DATA.get('password'))
         user = authenticate(username=username,
                             password=password)
 


### PR DESCRIPTION
## Overview

This PR officially hooks up the beekeepers UI and Django user management. Users registered to either app will be able to sign in.

I added some basic error handling to show the user the error message from the server.

I had to loop in #358 to make a the POST request to `/user/login`. I spent a solid chunk of time solving it then realized GARP had to deal with the same issue, so I lifted that project's solution which is just `axios` set up to recognize available CSRF info.

Connects #358, #327

### Demo

<img width="547" alt="screen shot 2018-12-07 at 12 09 32 pm" src="https://user-images.githubusercontent.com/10568752/49662180-249a0480-fa19-11e8-948e-ea83d7e0d9a2.png">

sucessfully logged in -->
<img width="174" alt="screen shot 2018-12-07 at 12 09 13 pm" src="https://user-images.githubusercontent.com/10568752/49662179-249a0480-fa19-11e8-93d0-6170014363b8.png">

### Notes

As with the other actions fired by the modal's `close` method, clearing the auth error fires twice in most cases too.

I added a reducer set for storing user information. The fields we save are flexible. `username`, `userId`, and `authError` seemed like a good starting set.

My gut tells me using an observable/ listening to the dispatched `login` action is how I really do want to receive any login error but I thought this solution was simple and self-contained enough to prefer the time savings over learning how to do the former. 

Again, BEM... I'm learning 🤷‍♀️ 

## Testing Instructions

You must have a valid user (either thru the django shell or through the pollinators app).
Click "login" and submit your information *incorrectly*. See the error message shows, and doesn't reappear if you exit/reopen the login modal.
Click "login" and submit your info *correctly* and see that login works
