### PR TITLE
Add imagery basemap

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -106,6 +106,7 @@ class Map extends Component {
                     zoomControl={false}
                     onClick={this.onClickAddMarker}
                     ref={this.mapRef}
+                    maxZoom={18}
                 >
                     <TileLayer
                         attribution="Tiles &copy; Esri"

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -108,8 +108,13 @@ class Map extends Component {
                     ref={this.mapRef}
                 >
                     <TileLayer
-                        attribution="&amp;copy <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
-                        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                        attribution="Tiles &copy; Esri"
+                        url="https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+                    />
+                    <TileLayer
+                        attribution='&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
+                        url="https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}{r}.png"
+                        subdomains="abcd"
                     />
                     <ZoomControl position="bottomleft" />
                     {markers}


### PR DESCRIPTION
## Overview

Adds an esri imagery basemap with a carto label-only overlay for context.  Limits the map zooming based on the availability of the overlays.

Connects #299 

### Demo
Here's how it looks at different zoom levels:

![screenshot from 2018-12-07 13 47 37](https://user-images.githubusercontent.com/1014341/49666640-ba885c00-fa26-11e8-8fcb-1e27d0ed9102.png)

![screenshot from 2018-12-07 13 47 23](https://user-images.githubusercontent.com/1014341/49666641-bb20f280-fa26-11e8-971b-0dd48c01dc66.png)

![screenshot from 2018-12-07 13 46 48](https://user-images.githubusercontent.com/1014341/49666642-bb20f280-fa26-11e8-91a8-3632cc9b643b.png)


### Notes

The labels don't provide amazing contrast and are challenging to read over some types of land cover, however, out of what's available, this was the best I could produce.

## Testing Instructions

 * Ensure map layers are displayed
