### PR TITLE
Add survey route and navigation tabs

### DIFF
--- a/src/icp/apps/beekeepers/js/src/App.jsx
+++ b/src/icp/apps/beekeepers/js/src/App.jsx
@@ -1,14 +1,21 @@
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
 import { func, number } from 'prop-types';
 import { hot } from 'react-hot-loader';
+import {
+    Switch,
+    Route,
+} from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import Map from './components/Map';
+import Header from './components/Header';
 import Sidebar from './components/Sidebar';
+import Survey from './Survey';
+import SignUpModal from './components/SignUpModal';
+import LoginModal from './components/LoginModal';
+import ParticipateModal from './components/ParticipateModal';
 
 import { login, fetchUserApiaries } from './actions';
-import Survey from './Survey';
 
 class App extends React.Component {
     componentDidMount() {
@@ -33,10 +40,18 @@ class App extends React.Component {
             </>
         );
         return (
-            <Switch>
-                <Route exact path="/" component={locationFinder} />
-                <Route path="/survey" component={Survey} />
-            </Switch>
+            <>
+                <Header />
+                <main>
+                    <ParticipateModal />
+                    <SignUpModal />
+                    <LoginModal />
+                    <Switch>
+                        <Route path="/survey" component={Survey} />
+                        <Route render={locationFinder} />
+                    </Switch>
+                </main>
+            </>
         );
     }
 }

--- a/src/icp/apps/beekeepers/js/src/App.jsx
+++ b/src/icp/apps/beekeepers/js/src/App.jsx
@@ -1,16 +1,14 @@
 import React from 'react';
+import { Route, Switch } from 'react-router-dom';
 import { func, number } from 'prop-types';
 import { hot } from 'react-hot-loader';
 import { connect } from 'react-redux';
 
-import Header from './components/Header';
 import Map from './components/Map';
 import Sidebar from './components/Sidebar';
-import SignUpModal from './components/SignUpModal';
-import LoginModal from './components/LoginModal';
-import ParticipateModal from './components/ParticipateModal';
 
 import { login, fetchUserApiaries } from './actions';
+import Survey from './Survey';
 
 class App extends React.Component {
     componentDidMount() {
@@ -28,17 +26,17 @@ class App extends React.Component {
     }
 
     render() {
-        return (
+        const locationFinder = () => (
             <>
-                <Header />
-                <main>
-                    <ParticipateModal />
-                    <SignUpModal />
-                    <LoginModal />
-                    <Map />
-                    <Sidebar />
-                </main>
+                <Map />
+                <Sidebar />
             </>
+        );
+        return (
+            <Switch>
+                <Route exact path="/" component={locationFinder} />
+                <Route path="/survey" component={Survey} />
+            </Switch>
         );
     }
 }

--- a/src/icp/apps/beekeepers/js/src/Survey.jsx
+++ b/src/icp/apps/beekeepers/js/src/Survey.jsx
@@ -1,20 +1,10 @@
 import React from 'react';
 import { hot } from 'react-hot-loader';
 
-import Header from './components/Header';
-import SignUpModal from './components/SignUpModal';
-import LoginModal from './components/LoginModal';
-import ParticipateModal from './components/ParticipateModal';
-
 const Survey = () => (
-    <>
-        <Header />
-        <main>
-            <ParticipateModal />
-            <SignUpModal />
-            <LoginModal />
-        </main>
-    </>
+    <div>
+        Survey component
+    </div>
 );
 
 export default hot(module)(Survey);

--- a/src/icp/apps/beekeepers/js/src/Survey.jsx
+++ b/src/icp/apps/beekeepers/js/src/Survey.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
-import { hot } from 'react-hot-loader';
 
 const Survey = () => (
-    <div>
-        Survey component
-    </div>
+    <div>Survey</div>
 );
 
-export default hot(module)(Survey);
+export default Survey;

--- a/src/icp/apps/beekeepers/js/src/Survey.jsx
+++ b/src/icp/apps/beekeepers/js/src/Survey.jsx
@@ -6,7 +6,7 @@ import SignUpModal from './components/SignUpModal';
 import LoginModal from './components/LoginModal';
 import ParticipateModal from './components/ParticipateModal';
 
-const Surveys = () => (
+const Survey = () => (
     <>
         <Header />
         <main>
@@ -17,4 +17,4 @@ const Surveys = () => (
     </>
 );
 
-export default hot(module)(Surveys);
+export default hot(module)(Survey);

--- a/src/icp/apps/beekeepers/js/src/Surveys.jsx
+++ b/src/icp/apps/beekeepers/js/src/Surveys.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { hot } from 'react-hot-loader';
+
+import Header from './components/Header';
+import SignUpModal from './components/SignUpModal';
+import LoginModal from './components/LoginModal';
+import ParticipateModal from './components/ParticipateModal';
+
+const Surveys = () => (
+    <>
+        <Header />
+        <main>
+            <ParticipateModal />
+            <SignUpModal />
+            <LoginModal />
+        </main>
+    </>
+);
+
+export default hot(module)(Surveys);

--- a/src/icp/apps/beekeepers/js/src/components/Header.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { NavLink } from 'react-router-dom';
 import { func, string } from 'prop-types';
 
 import { openParticipateModal, openLoginModal } from '../actions';
@@ -43,6 +44,8 @@ const Header = ({ dispatch, username }) => {
             <div className="navbar">
                 <div className="navbar__logo">
                     Landscape4Bees
+                    <NavLink exact to="/" className="navbar__item">Location finder</NavLink>
+                    <NavLink to="/survey" className="navbar__item">Survey</NavLink>
                 </div>
                 <ul className="navbar__items">
                     <li className="navbar__item">

--- a/src/icp/apps/beekeepers/js/src/components/Header.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Header.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { NavLink } from 'react-router-dom';
+import { NavLink, withRouter } from 'react-router-dom';
 import { func, string } from 'prop-types';
 
 import { openParticipateModal, openLoginModal } from '../actions';
@@ -74,4 +74,4 @@ Header.propTypes = {
     username: string.isRequired,
 };
 
-export default connect(mapStateToProps)(Header);
+export default withRouter(connect(mapStateToProps)(Header));

--- a/src/icp/apps/beekeepers/js/src/main.jsx
+++ b/src/icp/apps/beekeepers/js/src/main.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { render } from 'react-dom';
 
-import { BrowserRouter, Route } from 'react-router-dom';
+import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 
 import '../../sass/main.scss';
 import App from './App';
+import Surveys from './Surveys';
 
 import { store, persistor } from './store';
 
@@ -16,7 +17,10 @@ render(
             https://github.com/project-icp/bee-pollinator-app/issues/314 */}
         <PersistGate loading={null} persistor={persistor}>
             <BrowserRouter>
-                <Route exact path="/" component={App} />
+                <Switch>
+                    <Route exact path="/" component={App} />
+                    <Route path="/surveys" component={Surveys} />
+                </Switch>
             </BrowserRouter>
         </PersistGate>
     </Provider>,

--- a/src/icp/apps/beekeepers/js/src/main.jsx
+++ b/src/icp/apps/beekeepers/js/src/main.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { render } from 'react-dom';
 
-import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 
 import '../../sass/main.scss';
 import App from './App';
-import Survey from './Survey';
+import Header from './components/Header';
+import SignUpModal from './components/SignUpModal';
+import LoginModal from './components/LoginModal';
+import ParticipateModal from './components/ParticipateModal';
 
 import { store, persistor } from './store';
 
@@ -17,10 +20,15 @@ render(
             https://github.com/project-icp/bee-pollinator-app/issues/314 */}
         <PersistGate loading={null} persistor={persistor}>
             <BrowserRouter>
-                <Switch>
-                    <Route exact path="/" component={App} />
-                    <Route path="/survey" component={Survey} />
-                </Switch>
+                <>
+                    <Header />
+                    <main>
+                        <ParticipateModal />
+                        <SignUpModal />
+                        <LoginModal />
+                        <App />
+                    </main>
+                </>
             </BrowserRouter>
         </PersistGate>
     </Provider>,

--- a/src/icp/apps/beekeepers/js/src/main.jsx
+++ b/src/icp/apps/beekeepers/js/src/main.jsx
@@ -7,7 +7,7 @@ import { PersistGate } from 'redux-persist/integration/react';
 
 import '../../sass/main.scss';
 import App from './App';
-import Surveys from './Surveys';
+import Survey from './Survey';
 
 import { store, persistor } from './store';
 
@@ -19,7 +19,7 @@ render(
             <BrowserRouter>
                 <Switch>
                     <Route exact path="/" component={App} />
-                    <Route path="/surveys" component={Surveys} />
+                    <Route path="/survey" component={Survey} />
                 </Switch>
             </BrowserRouter>
         </PersistGate>

--- a/src/icp/apps/beekeepers/js/src/main.jsx
+++ b/src/icp/apps/beekeepers/js/src/main.jsx
@@ -1,16 +1,12 @@
 import React from 'react';
 import { render } from 'react-dom';
 
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, Route } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 
 import '../../sass/main.scss';
 import App from './App';
-import Header from './components/Header';
-import SignUpModal from './components/SignUpModal';
-import LoginModal from './components/LoginModal';
-import ParticipateModal from './components/ParticipateModal';
 
 import { store, persistor } from './store';
 
@@ -20,15 +16,7 @@ render(
             https://github.com/project-icp/bee-pollinator-app/issues/314 */}
         <PersistGate loading={null} persistor={persistor}>
             <BrowserRouter>
-                <>
-                    <Header />
-                    <main>
-                        <ParticipateModal />
-                        <SignUpModal />
-                        <LoginModal />
-                        <App />
-                    </main>
-                </>
+                <Route component={App} />
             </BrowserRouter>
         </PersistGate>
     </Provider>,

--- a/src/icp/apps/beekeepers/sass/06_components/_modal.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_modal.scss
@@ -3,7 +3,6 @@
 }
 
 .popup-content {
-    top: -15%;
     width: 380px !important;
     padding: 0 !important;
 }
@@ -11,6 +10,7 @@
 .authModal {
     .button {
         color: $color-primary;
+        background-color: $color-white;
         border: none;
 
         &--long {
@@ -19,6 +19,7 @@
             padding: 15px;
             color: $color-white;
             background: $color-primary;
+            border: none;
         }
     }
 

--- a/src/icp/apps/beekeepers/sass/06_components/_navbar.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_navbar.scss
@@ -18,19 +18,21 @@
 
     &__item {
         margin-left: 1.4rem;
-        color: $color-black;
+        color: $color-grey-2;
         font-weight: normal;
         font-size: 14px;
         text-decoration: none;
         list-style: none;
 
         &.active {
+            color: $color-black;
             text-decoration: underline;
         }
     }
 
     &__button {
         padding: 0;
+        color: $color-grey-2;
         font-size: 14px;
         background: none;
         border: none;
@@ -39,6 +41,7 @@
             padding: 9px;
             color: $color-white;
             background: $color-primary;
+            border: none;
         }
     }
 }

--- a/src/icp/apps/beekeepers/sass/06_components/_navbar.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_navbar.scss
@@ -4,6 +4,9 @@
     height: 100%;
 
     &__logo {
+        display: flex;
+        flex: 1;
+        justify-content: flex-start;
         font-weight: 900;
     }
 
@@ -15,6 +18,15 @@
 
     &__item {
         margin-left: 1.4rem;
+        color: $color-black;
+        font-weight: normal;
+        font-size: 14px;
+        text-decoration: none;
+        list-style: none;
+
+        &.active {
+            text-decoration: underline;
+        }
     }
 
     &__button {

--- a/src/icp/apps/home/urls.py
+++ b/src/icp/apps/home/urls.py
@@ -10,7 +10,7 @@ from apps.home.views import home_page, projects, project, project_clone
 urlpatterns = patterns(
     '',
     url(r'^$', home_page, name='home_page'),
-    url(r'^surveys/$', home_page, name='home_page'),
+    url(r'^survey/$', home_page, name='home_page'),
     url(r'^draw/?$', home_page, name='home_page'),
     url(r'^projects/$', projects, name='projects'),
     url(r'^project/$', project, name='project'),

--- a/src/icp/apps/home/urls.py
+++ b/src/icp/apps/home/urls.py
@@ -10,6 +10,7 @@ from apps.home.views import home_page, projects, project, project_clone
 urlpatterns = patterns(
     '',
     url(r'^$', home_page, name='home_page'),
+    url(r'^surveys/$', home_page, name='home_page'),
     url(r'^draw/?$', home_page, name='home_page'),
     url(r'^projects/$', projects, name='projects'),
     url(r'^project/$', project, name='project'),


### PR DESCRIPTION
## Overview

The survey view will live at its own route / page and this PR sets up the app to accomodate that future work.

Connects #329

### Demo

<img width="951" alt="screen shot 2018-12-11 at 12 10 47 pm" src="https://user-images.githubusercontent.com/10568752/49817314-e1ec6b00-fd3d-11e8-9f98-9830994b9568.png">
<img width="953" alt="screen shot 2018-12-11 at 12 10 54 pm" src="https://user-images.githubusercontent.com/10568752/49817315-e1ec6b00-fd3d-11e8-960d-ae7bfc2dffc9.png">


### Notes

The routes don't include the `?beekeepers` query param, which navigates correctly and eventually for staging/production when rather than check for that flag django routes to Beekeepers by the host path (whatever becomes the beekeepers domains). However, for development it is maybe a little annoying because if one refreshes the page they get rerouted to Pollination Mapper.

## Testing Instructions

`./scripts/beekeepers.sh start` and navigate the tabs in the header
Routes at http://localhost:8000/survey/?beekeepers and http://localhost:8000/?beekeepers
