### PR TITLE
Update rasters for multi-state support

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,3 +294,23 @@ Now any changes made to the front-end within `src/icp/apps/beekeepers` will be r
 **Note**: After running `start`, `build` must be run again to enable the front-end. This is because the template reads the `apps/beekeepers/.webpack.stats.json` file to decide which JavaScript files to include, which are generated and stored in the static files directory with `build`. However, `start` serves those files from its own port, which is no longer active when it is shut down, so we must run `build` again to generate the static files.
 
 The [`beekeepers.sh`](./scripts/beekeepers.sh) script just SSH's in to the `app` VM and runs [`yarn.sh`](./src/icp/apps/beekeepers/yarn.sh), so it can take any `yarn` parameters.
+
+## Apiary Score raster layers
+The raster data layers read by the application are hosted in the icp-bees AWS account and
+are used by dev, staging and production (there is only read-only access). The data layers
+are provided in pairs, one each at 3km and 5km focal operations. Additionally, each layer
+is provided per state and the file naming scheme represents this as:
+
+`[STATE_ABBR]_[INDICATOR]_[FORAGE_RADIUS].tif`
+
+This results in files named like `PA_pesticide_3km.tif`.
+
+In order to support multiple states that come as discrete files, a VRT per layer/radius pair
+has been created using the following steps:
+
+```bash
+gdalbuildvrt pesticide_3km.vrt PA_pesticide_3km.tif IL_pesticide_3km.tif
+```
+
+Once a VRT has been created for each layer/radius, both VRT and tifs are uploaded
+to the data bucket under a folder indicating 3km or 5km.

--- a/README.md
+++ b/README.md
@@ -312,5 +312,8 @@ has been created using the following steps:
 gdalbuildvrt pesticide_3km.vrt PA_pesticide_3km.tif IL_pesticide_3km.tif
 ```
 
+A convenience script has been added to `scripts/make-vrts.sh` which contains the `gdalbuildvrt`
+commands used to generate the existing IN, IL & PA VRTs.  It can be modified to regenerate
+with additional states in the future.
 Once a VRT has been created for each layer/radius, both VRT and tifs are uploaded
 to the data bucket under a folder indicating 3km or 5km.

--- a/scripts/make-vrts.sh
+++ b/scripts/make-vrts.sh
@@ -1,0 +1,16 @@
+# Build vrts for PA, IL & IN raster files contained in this directory
+
+gdalbuildvrt floral_spring_3km.vrt PA_floral_spring_3km.tif IL_floral_spring_3km.tif IN_floral_spring_3km.tif
+gdalbuildvrt floral_spring_5km.vrt PA_floral_spring_5km.tif IL_floral_spring_5km.tif IN_floral_spring_5km.tif
+
+gdalbuildvrt floral_summer_3km.vrt PA_floral_summer_3km.tif IL_floral_summer_3km.tif IN_floral_summer_3km.tif
+gdalbuildvrt floral_summer_5km.vrt PA_floral_summer_5km.tif IL_floral_summer_5km.tif IN_floral_summer_5km.tif
+
+gdalbuildvrt floral_fall_3km.vrt PA_floral_fall_3km.tif IL_floral_fall_3km.tif IN_floral_fall_3km.tif
+gdalbuildvrt floral_fall_5km.vrt PA_floral_fall_5km.tif IL_floral_fall_5km.tif IN_floral_fall_5km.tif
+
+gdalbuildvrt nesting_3km.vrt PA_nesting_3km.tif IL_nesting_3km.tif IN_nesting_3km.tif
+gdalbuildvrt nesting_5km.vrt PA_nesting_5km.tif IL_nesting_5km.tif IN_nesting_5km.tif
+
+gdalbuildvrt pesticide_3km.vrt PA_pesticide_3km.tif IL_pesticide_3km.tif IN_pesticide_3km.tif
+gdalbuildvrt pesticide_5km.vrt PA_pesticide_5km.tif IL_pesticide_5km.tif IN_pesticide_5km.tif

--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -50,9 +50,9 @@ const ApiaryCard = ({ apiary, forageRange }) => {
                 <ScoresLabel
                     indicator="forage"
                     scores={[
-                        values[INDICATORS.FORAGE_SPRING],
-                        values[INDICATORS.FORAGE_SUMMER],
-                        values[INDICATORS.FORAGE_FALL],
+                        values[INDICATORS.FLORAL_SPRING],
+                        values[INDICATORS.FLORAL_SUMMER],
+                        values[INDICATORS.FLORAL_FALL],
                     ]}
                 />
             </div>

--- a/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
@@ -6,7 +6,12 @@ import { toDashedString, toSpacedString } from '../utils';
 
 
 function generateScore(data, error) {
-    return error ? NaN : Math.round(data);
+    // Handle nodata values by representing as a 'double-dash'
+    if (data < 0) {
+        return '--';
+    }
+
+    return error ? NaN : Math.round(data * 100);
 }
 
 const ScoresLabel = ({ indicator, scores }) => {

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -5,11 +5,11 @@ export const FORAGE_RANGES = [FORAGE_RANGE_3KM, FORAGE_RANGE_5KM];
 export const DEFAULT_SORT = 'default';
 
 export const INDICATORS = {
-    NESTING_QUALITY: 'nesting_quality',
+    NESTING_QUALITY: 'nesting',
     PESTICIDE: 'pesticide',
-    FORAGE_SPRING: 'forage_spring',
-    FORAGE_SUMMER: 'forage_summer',
-    FORAGE_FALL: 'forage_fall',
+    FLORAL_SPRING: 'floral_spring',
+    FLORAL_SUMMER: 'floral_summer',
+    FLORAL_FALL: 'floral_fall',
 };
 
 export const SORT_OPTIONS = [DEFAULT_SORT].concat(Object.values(INDICATORS));

--- a/src/icp/apps/beekeepers/tasks.py
+++ b/src/icp/apps/beekeepers/tasks.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
+import os
 
+import boto3
 import rasterio
 from pyproj import Proj
 
@@ -17,21 +19,69 @@ def sample_at_point(geom, raster_path):
     :type geom: Dict with lat and lon values, like {lat: float, lon: float}
     :type raster_path: String
     """
-    try:
-        with rasterio.open(raster_path, mode='r') as src:
-            # reproject latlon to coords in the same SRS as the target raster
-            to_proj = Proj(src.crs)
-            x, y = to_proj(geom['lng'], geom['lat'])
+    with gdal_configured_credentials():
+        try:
+            with rasterio.open(raster_path, mode='r') as src:
+                # Reproject latlon to coords in the same SRS as the
+                # target raster
+                to_proj = Proj(src.crs)
+                x, y = to_proj(geom['lng'], geom['lat'])
 
-            # Sample the raster at the given coordinates
-            value_gen = src.sample([(x, y)], indexes=[1])
-            value = value_gen.next().item(0)
-    except rasterio.RasterioIOError as e:
-        return ({
-            "data": None,
-            "error": e.message
-        })
+                # Sample the raster at the given coordinates
+                value_gen = src.sample([(x, y)], indexes=[1])
+                value = value_gen.next().item(0)
+        except rasterio.RasterioIOError as e:
+            return ({
+                "data": None,
+                "error": e.message
+            })
+
     return ({
         "data": value,
         "error": None
     })
+
+
+class gdal_configured_credentials():
+    """
+    A context manager which ensures any environment variables containing AWS
+    credentials are cleared after the context is closed.
+    These must be set again in order for GDAL vsis3 file handlers to work, but
+    when running in production, their presence affects how boto will acquire
+    new credentials.
+    """
+
+    def remove_env_vars(self):
+        """Clear all AWS environment variables"""
+
+        if 'AWS_ACCESS_KEY_ID' in os.environ:
+            del os.environ['AWS_ACCESS_KEY_ID']
+
+        if 'AWS_SECRET_ACCESS_KEY' in os.environ:
+            del os.environ['AWS_SECRET_ACCESS_KEY']
+
+        if 'AWS_SESSION_TOKEN' in os.environ:
+            del os.environ['AWS_SESSION_TOKEN']
+
+    def create_new_env_vars(self):
+        """
+        Fetch new AWS credentials and supply them to the environment variables
+        which GDAL will use for vsis3 requests
+        """
+        credentials = boto3.Session().get_credentials()
+        os.environ['AWS_ACCESS_KEY_ID'] = credentials.access_key
+        os.environ['AWS_SECRET_ACCESS_KEY'] = credentials.secret_key
+
+        # In dev, the token won't be available. In prod, this should be
+        # provided via the instance metadata
+        if credentials.token:
+            os.environ['AWS_SESSION_TOKEN'] = credentials.token
+
+    def __enter__(self):
+        """Context manager start"""
+        self.remove_env_vars()
+        self.create_new_env_vars()
+
+    def __exit__(self, *args):
+        """Context manager close"""
+        self.remove_env_vars()

--- a/src/icp/apps/beekeepers/views.py
+++ b/src/icp/apps/beekeepers/views.py
@@ -39,7 +39,7 @@ def fetch_data(request):
     for location in locations:
         all_location_data = {}
         for indicator in indicators:
-            s3_filename = '{}_{}.tif'.format(indicator, forage_range)
+            s3_filename = '{}_{}.vrt'.format(indicator, forage_range)
             s3_url = 's3://{}/{}/{}'.format(
                 DATA_BUCKET,
                 forage_range,


### PR DESCRIPTION
## Overview

Rasters are now provided as discrete files representing single states.
In order to mosaic them on the fly and read from the correct file, VRTs
have been created which reference adjacent raw geotiffs. Since rasterio
delegates vsis3 calls directly to gdal for the path, additional work
must be done to provide AWS credentials via environment variables as
rasterio will only continue to read the initial VRT read with it's own
configured credentials.

Connects #342 

### Demo

VRTs and tifs together in a temporary s3 bucket:

![screenshot from 2018-12-11 17 29 16](https://user-images.githubusercontent.com/1014341/49834410-50472280-fd6a-11e8-98df-57a9c53bdc6e.png)

![screenshot from 2018-12-11 17 35 12](https://user-images.githubusercontent.com/1014341/49834732-24786c80-fd6b-11e8-853d-43b9d110117c.png)
![screenshot from 2018-12-11 17 34 45](https://user-images.githubusercontent.com/1014341/49834733-24786c80-fd6b-11e8-9944-fddb192195ad.png)
![screenshot from 2018-12-11 17 33 50](https://user-images.githubusercontent.com/1014341/49834734-24786c80-fd6b-11e8-96cf-d25d1a1ef983.png)


### Notes

Since other devs are currently using the tifs in the real staging bucket, I've created a temp bucket to hold these values until it's ready to be merged.  I'll then copy between buckets.  The bit of code around GDAL credentials was learned the hard way around previous work on USACE doing essentially the same task.


## Testing Instructions
* Rebundle and build
* Place apiary markers in PA, IL and non-supported states/areas
* Verify that data is returned (or nodata) for the appropriate selection and that it renders correctly on the card.
* Test that both 3km and 5km options are working