### PR TITLE
Initialize new Apiaries with Marker and Address

### DIFF
--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -3,6 +3,7 @@ import update from 'immutability-helper';
 
 import csrfRequest from './csrfRequest';
 import { INDICATORS } from './constants';
+import { isSameLocation } from './utils';
 
 export const setSort = createAction('Set apiary sort');
 export const setForageRange = createAction('Set forage range');
@@ -65,7 +66,7 @@ export function fetchApiaryScores(apiaryList, forageRange) {
 
         // mark apiaries from input list as fetching data
         const fetchingApiaries = apiaries.map((apiary) => {
-            if (apiaryList.find(a => a.lat === apiary.lat && a.lng === apiary.lng)) {
+            if (apiaryList.find(a => isSameLocation(a, apiary))) {
                 return update(apiary, {
                     fetching: { $set: true },
                 });
@@ -199,7 +200,7 @@ function toggleApiaryFlag(flag) {
         } = getState();
 
         const newList = apiaries.map((a) => {
-            if (a.lat === apiary.lat && a.lng === apiary.lng) {
+            if (isSameLocation(a, apiary)) {
                 return update(apiary, {
                     [flag]: { $set: !apiary[flag] },
                 });
@@ -237,7 +238,7 @@ export function deleteApiary(apiary) {
             },
         } = getState();
 
-        const newList = apiaries.filter(a => a.lat !== apiary.lat || a.lng !== apiary.lng);
+        const newList = apiaries.filter(a => !isSameLocation(a, apiary));
 
         dispatch(setApiaryList(newList));
 

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -188,8 +188,8 @@ export function fetchUserApiaries() {
     };
 }
 
-function toggleApiaryFlag(flag) {
-    return apiary => (dispatch, getState) => {
+export function updateApiary(apiary) {
+    return (dispatch, getState) => {
         const {
             main: {
                 apiaries,
@@ -201,9 +201,7 @@ function toggleApiaryFlag(flag) {
 
         const newList = apiaries.map((a) => {
             if (isSameLocation(a, apiary)) {
-                return update(apiary, {
-                    [flag]: { $set: !apiary[flag] },
-                });
+                return apiary;
             }
 
             return a;
@@ -215,12 +213,22 @@ function toggleApiaryFlag(flag) {
             dispatch(startUpdatingApiary());
 
             csrfRequest
-                .patch(`/beekeepers/apiary/${apiary.id}/`, {
-                    [flag]: !apiary[flag],
-                })
+                .patch(`/beekeepers/apiary/${apiary.id}/`, apiary)
                 .then(() => dispatch(completeUpdatingApiary()))
                 .catch(error => dispatch(failUpdatingApiary(error)));
         }
+    };
+}
+
+function toggleApiaryFlag(flag) {
+    return apiary => (dispatch) => {
+        const toggled = update(apiary, {
+            [flag]: {
+                $set: !apiary[flag],
+            },
+        });
+
+        dispatch(updateApiary(toggled));
     };
 }
 

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -19,7 +19,7 @@ import {
     FORAGE_RANGE_3KM,
     FORAGE_RANGE_5KM,
 } from '../constants';
-import { isSameLocation } from '../utils';
+import { getNextInSequence, isSameLocation } from '../utils';
 
 class Map extends Component {
     constructor() {
@@ -94,9 +94,19 @@ class Map extends Component {
                     return;
                 }
 
+                const marker = (() => {
+                    if (apiaries.length === 0) {
+                        return 'A';
+                    }
+
+                    const lastMarker = apiaries[apiaries.length - 1].marker;
+
+                    return getNextInSequence(lastMarker);
+                })();
+
                 const newApiary = {
                     name: 'Apiary',
-                    marker: 'F',
+                    marker,
                     lat: event.latlng.lat,
                     lng: event.latlng.lng,
                     scores: {

--- a/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
@@ -40,9 +40,13 @@ class Sidebar extends Component {
 
         if (sortBy === DEFAULT_SORT) {
             apiaries.sort((a, b) => {
-                if (a.marker < b.marker) { return -1; }
-                if (a.marker > b.marker) { return 1; }
-                return 0;
+                if (a.marker.length === b.marker.length) {
+                    if (a.marker < b.marker) { return -1; }
+                    if (a.marker > b.marker) { return 1; }
+                    return 0;
+                }
+
+                return a.marker.length - b.marker.length;
             });
         } else {
             apiaries.sort((a, b) => {

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -16,3 +16,44 @@ export function toTitleCase(value) {
 export function isSameLocation(a, b) {
     return a.lat === b.lat && a.lng === b.lng;
 }
+
+function isLastInSequence(s) {
+    let isLast = true;
+
+    [...s].forEach((c) => {
+        if (c !== 'Z') {
+            isLast = false;
+        }
+    });
+
+    return isLast;
+}
+
+function getNextLetter(c) {
+    const cc = c.charCodeAt(0);
+
+    if (cc < 90) {
+        return String.fromCharCode(cc + 1);
+    }
+
+    return 'A';
+}
+
+// Adapted from https://stackoverflow.com/a/34483399/6995854
+export function getNextInSequence(s) {
+    if (isLastInSequence(s)) {
+        return 'A'.repeat(s.length + 1);
+    }
+
+    const prefix = s.slice(0, -1);
+    const penultimate = prefix.slice(-1);
+    const final = s.slice(-1);
+
+    if (final === 'Z') {
+        return prefix.slice(0, -1)
+            + getNextLetter(penultimate)
+            + getNextLetter(final);
+    }
+
+    return prefix + getNextLetter(final);
+}

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -12,3 +12,7 @@ export function toTitleCase(value) {
         .map(word => word.charAt(0).toUpperCase() + word.slice(1))
         .join('');
 }
+
+export function isSameLocation(a, b) {
+    return a.lat === b.lat && a.lng === b.lng;
+}


### PR DESCRIPTION
## Overview

Initializes new apiaries with a reverse geocoded address for the point on which they were clicked, and a marker label which is next in the sequence. The marker is always one after the last Apairy's marker, in an Excel-style alphabetic sequence: A, B, ... Z, AA, AB, ... AZ, BA, ... ZZ, AAA, AAB, ...

Connects #370 

### Demo

![2018-12-19 17 06 32](https://user-images.githubusercontent.com/1430060/50251128-d5f15080-03b0-11e9-8dec-5e927ee8a4f9.gif)

### Notes

In some cases when the address is too long, it spills over into the next line. I'm leaving this until a design pass to fix. Will make a design pass card and highlight this there.

There is a slight flicker when adding a a new apiary on the map, as it is set once with a default name, then updated with the reverse geocoded name, then updated with the scores. I wasn't able to get to the bottom of this, but given 🚀🐦 I thought it was tolerable.

## Testing Instructions

* Check out this branch and `beekeepers start`
* Go to [:8000/?beekeepers](http://localhost:8000/?beekeepers) and add a few apiaries. Ensure they have reverse geocoded names and appropriate markers.
* Delete some apiaries in between. Add new ones. Ensure they are given appropriate markers.
* Delete some apiaries at the end. Add new ones. Ensure they are given appropriate markers.