### PR TITLE
Match Marker to Sidebar Apiaries

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { Apiary } from '../propTypes';
 import { INDICATORS } from '../constants';
 import { setApiaryStar, setApiarySurvey, deleteApiary } from '../actions';
+import { getMarkerClass } from '../utils';
 
 import CardButton from './CardButton';
 import ScoresLabel from './ScoresLabel';
@@ -13,7 +14,6 @@ const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
     const {
         marker,
         name,
-        selected,
         starred,
         surveyed,
         scores,
@@ -21,21 +21,7 @@ const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
 
     const values = scores[forageRange];
 
-    const markerMod = (() => {
-        if (surveyed) {
-            return 'marker--starred-survey';
-        }
-
-        if (starred) {
-            return 'marker--starred';
-        }
-
-        if (selected) {
-            return 'marker--selected';
-        }
-
-        return '';
-    })();
+    const markerClass = getMarkerClass(apiary);
 
     const scoresBody = !Object.keys(apiary.scores[forageRange]).length
         ? <div className="spinner" />
@@ -68,7 +54,7 @@ const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
         <li className="card">
             <div className="card__top">
                 <div className="card__identification">
-                    <div className={`marker ${markerMod}`}>{marker}</div>
+                    <div className={`marker ${markerClass}`}>{marker}</div>
                     <div className="card__name">{name}</div>
                 </div>
                 <div className="card__buttons">

--- a/src/icp/apps/beekeepers/js/src/components/ApiaryMarker.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryMarker.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { Apiary } from '../propTypes';
+import { getMarkerClass } from '../utils';
+
+const ApiaryMarker = ({ apiary }) => {
+    const markerClass = getMarkerClass(apiary);
+
+    return (
+        <div className={`marker map-marker ${markerClass}`}>
+            {apiary.marker}
+        </div>
+    );
+};
+
+ApiaryMarker.propTypes = {
+    apiary: Apiary.isRequired,
+};
+
+export default ApiaryMarker;

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -1,4 +1,5 @@
 import React, { Component, createRef } from 'react';
+import { renderToString } from 'react-dom/server';
 import * as esri from 'esri-leaflet-geocoder';
 import update from 'immutability-helper';
 import {
@@ -20,6 +21,8 @@ import {
     FORAGE_RANGE_5KM,
 } from '../constants';
 import { getNextInSequence, isSameLocation } from '../utils';
+
+import ApiaryMarker from './ApiaryMarker';
 
 class Map extends Component {
     constructor() {
@@ -145,10 +148,15 @@ class Map extends Component {
             // TODO: Replace unique key generator once app uses real, complete data
             // Currently solution appeases React unique key error
             const key = apiary.name + String.fromCharCode(idx);
+            const icon = L.divIcon({
+                className: 'custom icon',
+                html: renderToString(<ApiaryMarker apiary={apiary} />),
+            });
             return (
                 <Marker
                     key={key}
                     position={[apiary.lat, apiary.lng]}
+                    icon={icon}
                 />
             );
         });

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -57,3 +57,19 @@ export function getNextInSequence(s) {
 
     return prefix + getNextLetter(final);
 }
+
+export function getMarkerClass({ selected, starred, surveyed }) {
+    if (surveyed) {
+        return 'marker--starred-survey';
+    }
+
+    if (starred) {
+        return 'marker--starred';
+    }
+
+    if (selected) {
+        return 'marker--selected';
+    }
+
+    return '';
+}

--- a/src/icp/apps/beekeepers/sass/06_components/_marker.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_marker.scss
@@ -20,3 +20,7 @@
         background-color: $color-starred-survey;
     }
 }
+
+.map-marker {
+    transform: translate(-25%, -25%);
+}


### PR DESCRIPTION
## Overview

Adjusts the visual markers on the map to make them match the apiaries the correspond to and their state.

Connects #369 

### Demo

![2018-12-20 15 57 00](https://user-images.githubusercontent.com/1430060/50310612-85412c80-0470-11e9-977f-149e1ffe1d95.gif)

### Notes

The text on the map markers is slightly blurrier than on the sidebar. I believe this is because of the `transform3d` which is applied to all Leaflet elements. I don't think there is anything we can easily do about that.

## Testing Instructions

* Check out this branch and `beekeepers start`
* Go to [:8000/?beekeepers](http://localhost:8000/?beekeepers) and add some apiaries
* Ensure they are added where you clicked them, that they match the marker of the apiary, and their color corresponds to the starred / surveyed state.