### PR TITLE
Add landing pages for different survey tab states

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/EmptySurveyView.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/EmptySurveyView.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+
+export default function () {
+    return (
+        <div className="survey empty">
+            <div className="survey__header empty">
+                Add locations of interest
+            </div>
+            <div className="survey__body">
+                <div>
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+                    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+                    minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+                    aliquip ex ea commodo consequat.
+                </div>
+                <Link to="/" className="survey__button">Go to location finder</Link>
+            </div>
+        </div>
+    );
+}

--- a/src/icp/apps/beekeepers/js/src/components/GuestSurveyView.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/GuestSurveyView.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { func } from 'prop-types';
+
+import { openSignUpModal } from '../actions';
+
+
+const GuestSurveyView = ({ dispatch }) => (
+    <div className="survey empty">
+        <div className="survey__header empty">
+            Sign up to participate in our study to get better info about hive locations
+        </div>
+        <div className="survey__body">
+            <div>
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+                minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+                aliquip ex ea commodo consequat.
+            </div>
+            <button
+                type="button"
+                className="survey__button"
+                onClick={() => dispatch(openSignUpModal())}
+            >
+                Sign up
+            </button>
+        </div>
+    </div>
+);
+
+function mapStateToProps(state) {
+    return state.main;
+}
+
+GuestSurveyView.propTypes = {
+    dispatch: func.isRequired,
+};
+
+export default connect(mapStateToProps)(GuestSurveyView);

--- a/src/icp/apps/beekeepers/js/src/components/Survey.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Survey.jsx
@@ -5,14 +5,14 @@ import { Link } from 'react-router-dom';
 import { arrayOf, number, func } from 'prop-types';
 import { Apiary } from '../propTypes';
 
-import { openParticipateModal } from '../actions';
+import { openSignUpModal } from '../actions';
 
 const Survey = ({ dispatch, userId, apiaries }) => {
     if (!userId) {
         return (
             <div className="survey empty">
                 <div className="survey__header empty">
-                    Sign up to participate
+                    Sign up to participate in our study to get better info about hive locations
                 </div>
                 <div className="survey__body">
                     <div>
@@ -24,9 +24,9 @@ const Survey = ({ dispatch, userId, apiaries }) => {
                     <button
                         type="button"
                         className="survey__button"
-                        onClick={() => dispatch(openParticipateModal())}
+                        onClick={() => dispatch(openSignUpModal())}
                     >
-                        Participate in study
+                        Sign up
                     </button>
                 </div>
             </div>

--- a/src/icp/apps/beekeepers/js/src/components/Survey.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Survey.jsx
@@ -1,7 +1,97 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 
-const Survey = () => (
-    <div>Survey</div>
-);
+import { arrayOf, number, func } from 'prop-types';
+import { Apiary } from '../propTypes';
 
-export default Survey;
+import { openParticipateModal } from '../actions';
+
+const Survey = ({ dispatch, userId, apiaries }) => {
+    if (!userId) {
+        return (
+            <div className="survey empty">
+                <div className="survey__header empty">
+                    Sign up to participate
+                </div>
+                <div className="survey__body">
+                    <div>
+                        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+                        eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+                        minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+                        aliquip ex ea commodo consequat.
+                    </div>
+                    <button
+                        type="button"
+                        className="survey__button"
+                        onClick={() => dispatch(openParticipateModal())}
+                    >
+                        Participate in study
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    if (apiaries.length === 0) {
+        return (
+            <div className="survey empty">
+                <div className="survey__header empty">
+                    Add locations of interest
+                </div>
+                <div className="survey__body">
+                    <div>
+                        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+                        eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+                        minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+                        aliquip ex ea commodo consequat.
+                    </div>
+                    <Link to="/" className="survey__button">Go to location finder</Link>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="survey">
+            <div className="survey__header">
+                Survey
+            </div>
+            <div className="survey__body">
+                <div>
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+                    eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                </div>
+                <div className="survey__body--section">
+                    Response needed
+                </div>
+                <div className="survey__body--section">
+                    Up to date
+                </div>
+                <div className="survey__body--section">
+                    This is not in the study
+                </div>
+            </div>
+        </div>
+    );
+};
+
+function mapStateToProps(state) {
+    return {
+        dispatch: state.main.dispatch,
+        userId: state.auth.userId,
+        apiaries: state.main.apiaries,
+    };
+}
+
+Survey.propTypes = {
+    dispatch: func.isRequired,
+    userId: number,
+    apiaries: arrayOf(Apiary).isRequired,
+};
+
+Survey.defaultProps = {
+    userId: null,
+};
+
+export default connect(mapStateToProps)(Survey);

--- a/src/icp/apps/beekeepers/js/src/components/Survey.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Survey.jsx
@@ -1,91 +1,33 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
 
-import { arrayOf, number, func } from 'prop-types';
+import { arrayOf, number } from 'prop-types';
 import { Apiary } from '../propTypes';
 
-import { openSignUpModal } from '../actions';
+import GuestSurveyView from './GuestSurveyView';
+import EmptySurveyView from './EmptySurveyView';
+import SurveyView from './SurveyView';
 
-const Survey = ({ dispatch, userId, apiaries }) => {
+const Survey = ({ userId, apiaries }) => {
     if (!userId) {
-        return (
-            <div className="survey empty">
-                <div className="survey__header empty">
-                    Sign up to participate in our study to get better info about hive locations
-                </div>
-                <div className="survey__body">
-                    <div>
-                        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-                        eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-                        minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-                        aliquip ex ea commodo consequat.
-                    </div>
-                    <button
-                        type="button"
-                        className="survey__button"
-                        onClick={() => dispatch(openSignUpModal())}
-                    >
-                        Sign up
-                    </button>
-                </div>
-            </div>
-        );
+        return <GuestSurveyView />;
     }
 
     if (apiaries.length === 0) {
-        return (
-            <div className="survey empty">
-                <div className="survey__header empty">
-                    Add locations of interest
-                </div>
-                <div className="survey__body">
-                    <div>
-                        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-                        eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-                        minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-                        aliquip ex ea commodo consequat.
-                    </div>
-                    <Link to="/" className="survey__button">Go to location finder</Link>
-                </div>
-            </div>
-        );
+        return <EmptySurveyView />;
     }
 
-    return (
-        <div className="survey">
-            <div className="survey__header">
-                Survey
-            </div>
-            <div className="survey__body">
-                <div>
-                    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-                    eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                </div>
-                <div className="survey__body--section">
-                    Response needed
-                </div>
-                <div className="survey__body--section">
-                    Up to date
-                </div>
-                <div className="survey__body--section">
-                    This is not in the study
-                </div>
-            </div>
-        </div>
-    );
+    return <SurveyView apiaries={apiaries} />;
 };
 
 function mapStateToProps(state) {
     return {
-        dispatch: state.main.dispatch,
         userId: state.auth.userId,
         apiaries: state.main.apiaries,
     };
 }
 
 Survey.propTypes = {
-    dispatch: func.isRequired,
     userId: number,
     apiaries: arrayOf(Apiary).isRequired,
 };

--- a/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { arrayOf } from 'prop-types';
+import { Apiary } from '../propTypes';
+
+
+const SurveyView = ({ apiaries }) => (
+    <div className="survey">
+        <div className="survey__header">
+            Survey
+        </div>
+        <div className="survey__body">
+            <div>
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                {apiaries[0].name}
+            </div>
+            <div className="survey__body--section">
+                Response needed
+            </div>
+            <div className="survey__body--section">
+                Up to date
+            </div>
+            <div className="survey__body--section">
+                This is not in the study
+            </div>
+        </div>
+    </div>
+);
+
+SurveyView.propTypes = {
+    apiaries: arrayOf(Apiary).isRequired,
+};
+
+export default SurveyView;

--- a/src/icp/apps/beekeepers/sass/06_components/_survey.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_survey.scss
@@ -1,0 +1,47 @@
+.survey {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    background-color: $color-grey-5;
+
+    &.empty {
+        align-items: center;
+    }
+
+    &__header {
+        width: 500px;
+        margin-top: 3rem;
+        font: $font-xxl;
+        font-weight: $font-weight-bold;
+
+        &.empty {
+            margin-top: 8rem;
+        }
+    }
+
+    &__body {
+        display: flex;
+        flex-direction: column;
+        width: 500px;
+        margin: 2rem 0;
+        font: $font-med;
+
+        &--section {
+            margin: 2rem 0;
+            font: $font-lg;
+            font-weight: $font-weight-bold;
+        }
+    }
+
+    &__button {
+        max-width: max-content;
+        margin: 2rem 0;
+        padding: 15px;
+        color: $color-white;
+        font-size: 14px;
+        text-decoration: none;
+        background: $color-primary;
+        border: none;
+    }
+}


### PR DESCRIPTION
## Overview

Scaffold sections and states for the survey page. There are 3 states: not logged in; logged in, 0 apiaries; logged in, 1+ apiaries.

Connects #330

### Demo

<img width="873" alt="screen shot 2018-12-21 at 3 26 19 pm" src="https://user-images.githubusercontent.com/10568752/50362466-d9621480-0535-11e9-95c0-0c7e0213ad57.png">

<img width="484" alt="screen shot 2018-12-21 at 3 52 58 pm" src="https://user-images.githubusercontent.com/10568752/50363206-acfbc780-0538-11e9-985f-e654d68b84f7.png">


<img width="865" alt="screen shot 2018-12-21 at 3 27 09 pm" src="https://user-images.githubusercontent.com/10568752/50362468-d9621480-0535-11e9-9846-7b610b2c42ef.png">


### Notes

There's a flash of the 2nd scenario page if you log in with a user that has apiaries on the survey page. Not significant enough to address at the moment.

## Testing Instructions

Hit http://localhost:8000/survey/?beekeepers at various stages of logged in/out and 0-1 apiaries.