### PR TITLE
Add survey cards and sort them correctly

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -144,17 +144,14 @@ class Map extends Component {
 
     render() {
         const { apiaries } = this.props;
-        const markers = apiaries.map((apiary, idx) => {
-            // TODO: Replace unique key generator once app uses real, complete data
-            // Currently solution appeases React unique key error
-            const key = apiary.name + String.fromCharCode(idx);
+        const markers = apiaries.map((apiary) => {
             const icon = L.divIcon({
                 className: 'custom icon',
                 html: renderToString(<ApiaryMarker apiary={apiary} />),
             });
             return (
                 <Marker
-                    key={key}
+                    key={apiary.name}
                     position={[apiary.lat, apiary.lng]}
                     icon={icon}
                 />

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -151,7 +151,7 @@ class Map extends Component {
             });
             return (
                 <Marker
-                    key={apiary.name}
+                    key={apiary.marker}
                     position={[apiary.lat, apiary.lng]}
                     icon={icon}
                 />

--- a/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
@@ -59,7 +59,7 @@ class Sidebar extends Component {
 
         const apiaryCards = apiaries.map(apiary => (
             <ApiaryCard
-                key={apiary.lat.toString() + apiary.lng.toString()}
+                key={apiary.marker}
                 apiary={apiary}
                 forageRange={forageRange}
             />

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
@@ -3,15 +3,19 @@ import { connect } from 'react-redux';
 
 import { Apiary } from '../propTypes';
 
+import { listMonthYearsSinceCreation } from '../utils';
+
 const SurveyCard = ({ apiary }) => {
     const {
         name,
         // surveyed,
         // monthyear,
     } = apiary;
-    
-    const surveyedMonthYears = apiary.surveys.map(s => (
-        <a href="/">{s.month_year}</a>
+
+    const monthYears = listMonthYearsSinceCreation(apiary);
+
+    const surveyedMonthYears = monthYears.map(m => (
+        <a href="/">{m}</a>
     ));
 
     return (

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
@@ -33,15 +33,16 @@ const SurveyCard = ({ apiary, dispatch, completed }) => {
         );
     } else {
         const monthYears = listMonthYearsSinceCreation(apiary);
+        const lastFourMonthYears = monthYears.slice(0, 4);
         if (completed) {
-            cardBody = monthYears.map(m => (
+            cardBody = lastFourMonthYears.map(m => (
                 <div className="listing">
                     <div className="listing__icon--completed">✓</div>
                     <a className="listing__monthYear" href="/">{m}</a>
                 </div>
             ));
         } else {
-            cardBody = monthYears.map(m => (
+            cardBody = lastFourMonthYears.map(m => (
                 <div className="listing">
                     <div className="listing__icon">◯</div>
                     <a className="listing__monthYear" href="/">{m}</a>
@@ -53,7 +54,7 @@ const SurveyCard = ({ apiary, dispatch, completed }) => {
         if (monthYears.length > 4) {
             cardFooter = (
                 <div className="surveyCard__footer">
-                    <button type="button" onClick="">View full history</button>
+                    <button type="button" className="button" onClick="">View full history</button>
                     <div>...</div>
                 </div>
             );

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
@@ -13,10 +13,21 @@ const SurveyCard = ({ apiary }) => {
     } = apiary;
 
     const monthYears = listMonthYearsSinceCreation(apiary);
-
+    const icon = 'star';
     const surveyedMonthYears = monthYears.map(m => (
-        <a href="/">{m}</a>
+        <div className="listing">
+            <i className={`icon-${icon}-fill listing__icon`} />
+            <a className="listing__monthYear" href="/">{m}</a>
+            <a className="listing__start" href="/">Start survey</a>
+        </div>
     ));
+
+
+    // TODO: Create correct monthyear link styles
+
+    // TODO: Sort surveys into 3 buckets
+
+    // TODO: or pinch off the map into a separate card ?
 
     return (
         <li className="surveyCard">

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { Apiary } from '../propTypes';
+
+const SurveyCard = ({ apiary }) => {
+    const {
+        name,
+        // surveyed,
+        // monthyear,
+    } = apiary;
+    
+    const surveyedMonthYears = apiary.surveys.map(s => (
+        <a href="/">{s.month_year}</a>
+    ));
+
+    return (
+        <li className="surveyCard">
+            <div className="surveyCard__map">
+                TODO map
+            </div>
+            <div className="surveyCard__content">
+                <div className="surveyCard__title">{name}</div>
+                <div className="surveyCard__body">
+                    {surveyedMonthYears}
+                </div>
+            </div>
+        </li>
+    );
+};
+
+SurveyCard.propTypes = {
+    apiary: Apiary.isRequired,
+};
+
+export default connect()(SurveyCard);

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
@@ -1,31 +1,53 @@
 import React from 'react';
 import { connect } from 'react-redux';
-
+import { bool, func } from 'prop-types';
 import { Apiary } from '../propTypes';
 
 import { listMonthYearsSinceCreation } from '../utils';
+import { setApiarySurvey } from '../actions';
 
-const SurveyCard = ({ apiary }) => {
+const SurveyCard = ({ apiary, dispatch, surveyed }) => {
     const {
         name,
         // surveyed,
         // monthyear,
     } = apiary;
 
-    const monthYears = listMonthYearsSinceCreation(apiary);
-    const icon = 'star';
-    const surveyedMonthYears = monthYears.map(m => (
-        <div className="listing">
-            <i className={`icon-${icon}-fill listing__icon`} />
-            <a className="listing__monthYear" href="/">{m}</a>
-            <a className="listing__start" href="/">Start survey</a>
-        </div>
-    ));
+    let cardBody;
 
-
-    // TODO: Create correct monthyear link styles
+    if (!surveyed) {
+        const onSurvey = () => dispatch(setApiarySurvey(apiary));
+        cardBody = (
+            <>
+                <div className="listing">
+                    This apiary is not in the study.
+                </div>
+                <button
+                    type="button"
+                    className="button--long"
+                    onClick={onSurvey}
+                >
+                    Add to study
+                </button>
+            </>
+        );
+    } else {
+        const monthYears = listMonthYearsSinceCreation(apiary);
+        const icon = 'star';
+        cardBody = monthYears.map(m => (
+            <div className="listing">
+                <i className={`icon-${icon}-fill listing__icon`} />
+                <a className="listing__monthYear" href="/">{m}</a>
+                <a className="listing__start" href="/">Start survey</a>
+            </div>
+        ));
+    }
 
     // TODO: Sort surveys into 3 buckets
+
+    // TODO: view full history
+
+    // TODO: ...
 
     // TODO: or pinch off the map into a separate card ?
 
@@ -37,7 +59,7 @@ const SurveyCard = ({ apiary }) => {
             <div className="surveyCard__content">
                 <div className="surveyCard__title">{name}</div>
                 <div className="surveyCard__body">
-                    {surveyedMonthYears}
+                    {cardBody}
                 </div>
             </div>
         </li>
@@ -46,6 +68,12 @@ const SurveyCard = ({ apiary }) => {
 
 SurveyCard.propTypes = {
     apiary: Apiary.isRequired,
+    dispatch: func.isRequired,
+    surveyed: bool,
+};
+
+SurveyCard.defaultProps = {
+    surveyed: true,
 };
 
 export default connect()(SurveyCard);

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { bool, func } from 'prop-types';
+import { func } from 'prop-types';
 import { Apiary } from '../propTypes';
 
-import { listMonthYearsSinceCreation } from '../utils';
+import { listMonthYearsSinceCreation, monthToText } from '../utils';
 import { setApiarySurvey } from '../actions';
 
-const SurveyCard = ({ apiary, dispatch, completed }) => {
+const SurveyCard = ({ apiary, dispatch }) => {
     const {
         name,
         surveyed,
@@ -19,7 +19,7 @@ const SurveyCard = ({ apiary, dispatch, completed }) => {
         const onSurvey = () => dispatch(setApiarySurvey(apiary));
         cardBody = (
             <>
-                <div className="listing">
+                <div className="listing" key={name}>
                     This apiary is not in the study.
                 </div>
                 <button
@@ -34,27 +34,34 @@ const SurveyCard = ({ apiary, dispatch, completed }) => {
     } else {
         const monthYears = listMonthYearsSinceCreation(apiary);
         const lastFourMonthYears = monthYears.slice(0, 4);
-        if (completed) {
-            cardBody = lastFourMonthYears.map(m => (
-                <div className="listing">
-                    <div className="listing__icon--completed">✓</div>
-                    <a className="listing__monthYear" href="/">{m}</a>
-                </div>
-            ));
-        } else {
-            cardBody = lastFourMonthYears.map(m => (
-                <div className="listing">
+        const apiarySurveyDates = apiary.surveys.map((s) => {
+            const monthName = monthToText(Number(s.month_year.substring(0, 2)) - 1);
+            const year = s.month_year.substring(2, 6);
+            return `${monthName}-${year}`;
+        });
+        cardBody = lastFourMonthYears.map((m) => {
+            const i = apiarySurveyDates.findIndex(date => date === m);
+            if (i >= 0) {
+                return (
+                    <div className="listing" key={name + m}>
+                        <div className="listing__icon--completed">✓</div>
+                        <a className="listing__monthYear" href="/">{m}</a>
+                    </div>
+                );
+            }
+            return (
+                <div className="listing" key={name + m}>
                     <div className="listing__icon">◯</div>
                     <a className="listing__monthYear" href="/">{m}</a>
                     <a className="listing__start" href="/">Start survey</a>
                 </div>
-            ));
-        }
+            );
+        });
 
         if (monthYears.length > 4) {
             cardFooter = (
                 <div className="surveyCard__footer">
-                    <button type="button" className="button" onClick="">View full history</button>
+                    <button type="button" className="button">View full history</button>
                     <div>...</div>
                 </div>
             );
@@ -69,7 +76,7 @@ const SurveyCard = ({ apiary, dispatch, completed }) => {
     }
 
     return (
-        <div className="surveyCard">
+        <div className="surveyCard" key={name}>
             <div className="surveyCard__content">
                 <div className="surveyCard__title">{name}</div>
                 <div className="surveyCard__body">
@@ -84,11 +91,6 @@ const SurveyCard = ({ apiary, dispatch, completed }) => {
 SurveyCard.propTypes = {
     apiary: Apiary.isRequired,
     dispatch: func.isRequired,
-    completed: bool,
-};
-
-SurveyCard.defaultProps = {
-    completed: true,
 };
 
 export default connect()(SurveyCard);

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
@@ -6,14 +6,14 @@ import { Apiary } from '../propTypes';
 import { listMonthYearsSinceCreation } from '../utils';
 import { setApiarySurvey } from '../actions';
 
-const SurveyCard = ({ apiary, dispatch, surveyed }) => {
+const SurveyCard = ({ apiary, dispatch, completed }) => {
     const {
         name,
-        // surveyed,
-        // monthyear,
+        surveyed,
     } = apiary;
 
     let cardBody;
+    let cardFooter = null;
 
     if (!surveyed) {
         const onSurvey = () => dispatch(setApiarySurvey(apiary));
@@ -33,47 +33,61 @@ const SurveyCard = ({ apiary, dispatch, surveyed }) => {
         );
     } else {
         const monthYears = listMonthYearsSinceCreation(apiary);
-        const icon = 'star';
-        cardBody = monthYears.map(m => (
-            <div className="listing">
-                <i className={`icon-${icon}-fill listing__icon`} />
-                <a className="listing__monthYear" href="/">{m}</a>
-                <a className="listing__start" href="/">Start survey</a>
-            </div>
-        ));
+        if (completed) {
+            cardBody = monthYears.map(m => (
+                <div className="listing">
+                    <div className="listing__icon--completed">✓</div>
+                    <a className="listing__monthYear" href="/">{m}</a>
+                </div>
+            ));
+        } else {
+            cardBody = monthYears.map(m => (
+                <div className="listing">
+                    <div className="listing__icon">◯</div>
+                    <a className="listing__monthYear" href="/">{m}</a>
+                    <a className="listing__start" href="/">Start survey</a>
+                </div>
+            ));
+        }
+
+        if (monthYears.length > 4) {
+            cardFooter = (
+                <div className="surveyCard__footer">
+                    <button type="button" onClick="">View full history</button>
+                    <div>...</div>
+                </div>
+            );
+        } else {
+            cardFooter = (
+                <div className="surveyCard__footer">
+                    <div />
+                    <div>...</div>
+                </div>
+            );
+        }
     }
 
-    // TODO: Sort surveys into 3 buckets
-
-    // TODO: view full history
-
-    // TODO: ...
-
-    // TODO: or pinch off the map into a separate card ?
-
     return (
-        <li className="surveyCard">
-            <div className="surveyCard__map">
-                TODO map
-            </div>
+        <div className="surveyCard">
             <div className="surveyCard__content">
                 <div className="surveyCard__title">{name}</div>
                 <div className="surveyCard__body">
                     {cardBody}
                 </div>
             </div>
-        </li>
+            {cardFooter}
+        </div>
     );
 };
 
 SurveyCard.propTypes = {
     apiary: Apiary.isRequired,
     dispatch: func.isRequired,
-    surveyed: bool,
+    completed: bool,
 };
 
 SurveyCard.defaultProps = {
-    surveyed: true,
+    completed: true,
 };
 
 export default connect()(SurveyCard);

--- a/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
@@ -18,7 +18,7 @@ const SurveyView = ({ apiaries }) => {
             const year = s.month_year.substring(2, 6);
             return `${monthName}-${year}`;
         });
-        const surveyCard = <SurveyCard apiary={a} key={a.name} />;
+        const surveyCard = <SurveyCard apiary={a} key={a.marker} />;
         if (monthYearsSinceCreation.every(date => apiarySurveyDates.find(d => d === date))) {
             surveyCards.complete.push(surveyCard);
         } else {
@@ -27,7 +27,7 @@ const SurveyView = ({ apiaries }) => {
     });
 
     const noSurveyCards = apiaries.map(a => (
-        !a.surveyed ? <SurveyCard apiary={a} key={a.name} /> : null
+        !a.surveyed ? <SurveyCard apiary={a} key={a.marker} /> : null
     ));
 
     return (

--- a/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
@@ -4,14 +4,28 @@ import { arrayOf } from 'prop-types';
 import { Apiary } from '../propTypes';
 
 import SurveyCard from './SurveyCard';
+import { listMonthYearsSinceCreation, monthToText } from '../utils';
 
 const SurveyView = ({ apiaries }) => {
-    const surveyCards = apiaries.map(a => (
-        a.surveyed ? <SurveyCard apiary={a} /> : null
-    ));
+    const surveyedApiaries = apiaries.filter(a => a.surveyed);
+
+    const surveyCards = { complete: [], incomplete: [] };
+
+    surveyedApiaries.forEach((a) => {
+        const monthYearsSinceCreation = listMonthYearsSinceCreation(a);
+        const apiarySurveyDates = a.surveys.map((s) => {
+            const monthName = monthToText(Number(s.month_year.substring(0, 2)) - 1);
+            const year = s.month_year.substring(2, 6);
+            return `${monthName}-${year}`;
+        });
+        if (monthYearsSinceCreation.every(date => apiarySurveyDates.find(d => d === date))) {
+            return surveyCards.complete.push(<SurveyCard apiary={a} />);
+        }
+        return surveyCards.incomplete.push(<SurveyCard apiary={a} completed={false} />);
+    });
 
     const noSurveyCards = apiaries.map(a => (
-        !a.surveyed ? <SurveyCard apiary={a} surveyed={false} /> : null
+        !a.surveyed ? <SurveyCard apiary={a} /> : null
     ));
 
     return (
@@ -26,10 +40,11 @@ const SurveyView = ({ apiaries }) => {
                 </div>
                 <div className="survey__body--section">
                     Response needed
-                    {surveyCards}
+                    {surveyCards.incomplete}
                 </div>
                 <div className="survey__body--section">
                     Up to date
+                    {surveyCards.complete}
                 </div>
                 <div className="survey__body--section">
                     This is not in the study

--- a/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
@@ -6,7 +6,13 @@ import { Apiary } from '../propTypes';
 import SurveyCard from './SurveyCard';
 
 const SurveyView = ({ apiaries }) => {
-    const surveyCards = apiaries.map(a => <SurveyCard apiary={a} />);
+    const surveyCards = apiaries.map(a => (
+        a.surveyed ? <SurveyCard apiary={a} /> : null
+    ));
+
+    const noSurveyCards = apiaries.map(a => (
+        !a.surveyed ? <SurveyCard apiary={a} surveyed={false} /> : null
+    ));
 
     return (
         <div className="survey">
@@ -27,6 +33,7 @@ const SurveyView = ({ apiaries }) => {
                 </div>
                 <div className="survey__body--section">
                     This is not in the study
+                    {noSurveyCards}
                 </div>
             </div>
         </div>

--- a/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
@@ -3,30 +3,35 @@ import React from 'react';
 import { arrayOf } from 'prop-types';
 import { Apiary } from '../propTypes';
 
+import SurveyCard from './SurveyCard';
 
-const SurveyView = ({ apiaries }) => (
-    <div className="survey">
-        <div className="survey__header">
-            Survey
+const SurveyView = ({ apiaries }) => {
+    const surveyCards = apiaries.map(a => <SurveyCard apiary={a} />);
+
+    return (
+        <div className="survey">
+            <div className="survey__header">
+                Survey
+            </div>
+            <div className="survey__body">
+                <div>
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+                    eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                </div>
+                <div className="survey__body--section">
+                    Response needed
+                    {surveyCards}
+                </div>
+                <div className="survey__body--section">
+                    Up to date
+                </div>
+                <div className="survey__body--section">
+                    This is not in the study
+                </div>
+            </div>
         </div>
-        <div className="survey__body">
-            <div>
-                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-                eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                {apiaries[0].name}
-            </div>
-            <div className="survey__body--section">
-                Response needed
-            </div>
-            <div className="survey__body--section">
-                Up to date
-            </div>
-            <div className="survey__body--section">
-                This is not in the study
-            </div>
-        </div>
-    </div>
-);
+    );
+};
 
 SurveyView.propTypes = {
     apiaries: arrayOf(Apiary).isRequired,

--- a/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
@@ -18,14 +18,16 @@ const SurveyView = ({ apiaries }) => {
             const year = s.month_year.substring(2, 6);
             return `${monthName}-${year}`;
         });
+        const surveyCard = <SurveyCard apiary={a} key={a.name} />;
         if (monthYearsSinceCreation.every(date => apiarySurveyDates.find(d => d === date))) {
-            return surveyCards.complete.push(<SurveyCard apiary={a} />);
+            surveyCards.complete.push(surveyCard);
+        } else {
+            surveyCards.incomplete.push(surveyCard);
         }
-        return surveyCards.incomplete.push(<SurveyCard apiary={a} completed={false} />);
     });
 
     const noSurveyCards = apiaries.map(a => (
-        !a.surveyed ? <SurveyCard apiary={a} /> : null
+        !a.surveyed ? <SurveyCard apiary={a} key={a.name} /> : null
     ));
 
     return (

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -86,8 +86,7 @@ export function monthToText(month) {
 export function listMonthYearsSinceCreation(apiary) {
     // Count months from 0-11, where January is 0
     const createdYear = Number(apiary.created_at.substring(0, 4));
-    // TODO: why the +1 ??
-    const createdMonth = Number(apiary.created_at.substring(5, 7)) + 1;
+    const createdMonth = Number(apiary.created_at.substring(5, 7)) - 1;
 
     // The Date API counts months from 0
     const timeNow = new Date();

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -82,9 +82,11 @@ export function monthToText(month) {
     return monthNames[month];
 }
 
+
 export function listMonthYearsSinceCreation(apiary) {
     // Count months from 0-11, where January is 0
     const createdYear = Number(apiary.created_at.substring(0, 4));
+    // TODO: why the +1 ??
     const createdMonth = Number(apiary.created_at.substring(5, 7)) + 1;
 
     // The Date API counts months from 0

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -73,3 +73,43 @@ export function getMarkerClass({ selected, starred, surveyed }) {
 
     return '';
 }
+
+export const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul',
+    'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+export function monthToText(month) {
+    // Counts months from 0-11
+    return monthNames[month];
+}
+
+export function listMonthYearsSinceCreation(apiary) {
+    // Count months from 0-11, where January is 0
+    const createdYear = Number(apiary.created_at.substring(0, 4));
+    const createdMonth = Number(apiary.created_at.substring(5, 7)) + 1;
+
+    // The Date API counts months from 0
+    const timeNow = new Date();
+    const monthNow = timeNow.getMonth();
+    const yearNow = timeNow.getFullYear();
+
+    let months = 0;
+    months = (yearNow - createdYear) * 12;
+    months -= createdMonth;
+    months += monthNow;
+    const monthDiff = months <= 0 ? 0 : months;
+
+    let monthCounter = monthNow;
+    let yearCounter = yearNow;
+    const monthYears = [];
+    let i = 0;
+    for (i = 0; i < monthDiff + 1; i += 1) {
+        monthYears.push(`${monthToText(monthCounter)}-${String(yearCounter)}`);
+        monthCounter -= 1;
+        if (monthCounter < 1) {
+            yearCounter -= 1;
+            monthCounter = 11;
+        }
+    }
+
+    return monthYears;
+}

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -74,8 +74,8 @@ export function getMarkerClass({ selected, starred, surveyed }) {
     return '';
 }
 
-export const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul',
-    'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+export const monthNames = ['January', 'February', 'March', 'April', 'May',
+    'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 
 export function monthToText(month) {
     // Counts months from 0-11

--- a/src/icp/apps/beekeepers/sass/06_components/_survey.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_survey.scss
@@ -79,3 +79,21 @@
         text-decoration: none;
     }
 }
+
+.listing {
+    &__icon {
+        padding-right: 10px;
+        color: #19cb35;
+    }
+
+    &__monthYear {
+        padding-right: 10px;
+        color: $color-black;
+        text-decoration: none;
+    }
+
+    &__start {
+        color: $color-primary;
+        text-decoration: none;
+    }
+}

--- a/src/icp/apps/beekeepers/sass/06_components/_survey.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_survey.scss
@@ -2,7 +2,9 @@
     display: flex;
     flex-direction: column;
     width: 100%;
-    height: max-content;
+    height: auto;
+    min-height: max-content;
+    padding-left: 20px;
     background-color: $color-grey-5;
 
     &.empty {
@@ -48,17 +50,16 @@
 
 .surveyCard {
     display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 200px;
+    padding: 10px 15px;
     background-color: #fff;
     border-radius: 4px;
     box-shadow: 0 0 4px -1px rgba(0, 0, 0, 0.5);
 
     &:not(:last-child) {
         margin-bottom: 1.4rem;
-    }
-
-    &__map {
-        width: 200px;
-        height: 200px;
     }
 
     &__content {
@@ -79,12 +80,25 @@
         font: $font-med;
         text-decoration: none;
     }
+
+    &__footer {
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+    }
 }
 
 .listing {
+    display: flex;
+
     &__icon {
         padding-right: 10px;
-        color: #19cb35;
+        color: #de9b00;
+
+        &--completed {
+            padding-right: 10px;
+            color: #19cb35;
+        }
     }
 
     &__monthYear {

--- a/src/icp/apps/beekeepers/sass/06_components/_survey.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_survey.scss
@@ -2,7 +2,7 @@
     display: flex;
     flex-direction: column;
     width: 100%;
-    height: 100%;
+    height: max-content;
     background-color: $color-grey-5;
 
     &.empty {
@@ -10,7 +10,7 @@
     }
 
     &__header {
-        width: 500px;
+        width: 600px;
         margin-top: 3rem;
         font: $font-xxl;
         font-weight: $font-weight-bold;
@@ -23,7 +23,7 @@
     &__body {
         display: flex;
         flex-direction: column;
-        width: 500px;
+        width: 600px;
         margin: 2rem 0;
         font: $font-med;
 
@@ -43,5 +43,39 @@
         text-decoration: none;
         background: $color-primary;
         border: none;
+    }
+}
+
+.surveyCard {
+    display: flex;
+    background-color: #fff;
+    border-radius: 4px;
+    box-shadow: 0 0 4px -1px rgba(0, 0, 0, 0.5);
+
+    &:not(:last-child) {
+        margin-bottom: 1.4rem;
+    }
+
+    &__map {
+        width: 200px;
+        height: 200px;
+    }
+
+    &__content {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    &__title {
+        font: $font-lg;
+        font-weight: $font-weight-bold;
+    }
+
+    &__body {
+        display: flex;
+        flex-direction: column;
+        font: $font-med;
+        text-decoration: none;
     }
 }

--- a/src/icp/apps/beekeepers/sass/06_components/_survey.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_survey.scss
@@ -68,6 +68,7 @@
     }
 
     &__title {
+        margin: 10px 0;
         font: $font-lg;
         font-weight: $font-weight-bold;
     }
@@ -95,5 +96,16 @@
     &__start {
         color: $color-primary;
         text-decoration: none;
+    }
+}
+
+.button {
+    &--long {
+        width: 150px;
+        margin-top: 20px;
+        padding: 15px;
+        color: $color-white;
+        background: $color-primary;
+        border: none;
     }
 }

--- a/src/icp/apps/beekeepers/sass/06_components/_survey.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_survey.scss
@@ -48,6 +48,17 @@
     }
 }
 
+.button {
+    &--long {
+        width: 150px;
+        margin-top: 20px;
+        padding: 15px;
+        color: $color-white;
+        background: $color-primary;
+        border: none;
+    }
+}
+
 .surveyCard {
     display: flex;
     flex-direction: column;
@@ -85,6 +96,11 @@
         display: flex;
         justify-content: space-between;
         width: 100%;
+
+        .button {
+            font: $font-sm;
+            border: none;
+        }
     }
 }
 
@@ -110,16 +126,5 @@
     &__start {
         color: $color-primary;
         text-decoration: none;
-    }
-}
-
-.button {
-    &--long {
-        width: 150px;
-        margin-top: 20px;
-        padding: 15px;
-        color: $color-white;
-        background: $color-primary;
-        border: none;
     }
 }


### PR DESCRIPTION
## Overview

Builds out the survey feature by sorting and displaying the survey cards. The only button or link that works is the "add to study" blue button. The rest go to root, for now.

There's basic styling, but there's much left to be desired. I've added some items to #393. I also didn't implement the map inset for time savings, I think the feature should be an enhancement instead #396 

Some assumptions were made about sorting and displaying data:
- Only month years between when the apiary was created and now will be avail for survey data collection
- Month years available to survey includes the current month (i.e. December-2018 as I write this PR)
- For April/Nov there is no specific check implemented for if a subsurvey for that month is Monthly or specialty April/Nov survey for that month. I figured that could be handled later..

Connects #337

### Demo

![screen shot 2018-12-26 at 12 23 37 pm](https://user-images.githubusercontent.com/10568752/50452758-14838f80-090a-11e9-8645-d84a0317affe.png)


## Testing Instructions

Ensure your database is up to date on migrations (none in this PR, but you'll need to play with the data).
- Login
- Create some apiaries and toggle some of them to be "surveyed"
- Select an apiary that you will work with. In the django shell:
  - change that apiary's `created_at` date to some months ago. for example:
```
from datetime import datetime
from apps.beekeepers.models import Apiary
a = Apiary.objects.first()
a.created_at = datetime(year=2017, month=1, day=12)
a.name = "Jenny's Apiary"
a.save()
```
I also found it useful to change the name to something identifiable
- In the Django admin interface (easiest way) add a few surveys with subsurveys to an apiary in the time since said apiary was created (i.e. Jan 2017, as above).
- Visit http://localhost:8000/survey/?beekeepers and see the cards in different states.
