### PR TITLE
Implement Sign Up workflow

### DIFF
--- a/src/icp/apps/beekeepers/js/src/App.jsx
+++ b/src/icp/apps/beekeepers/js/src/App.jsx
@@ -17,7 +17,7 @@ import ParticipateModal from './components/ParticipateModal';
 import UserSurveyModal from './components/UserSurveyModal';
 
 import { UserSurvey } from './propTypes';
-import { login, fetchUserApiaries, openUserSurveyModal } from './actions';
+import { login, saveAndFetchApiaries, openUserSurveyModal } from './actions';
 
 class App extends React.Component {
     componentDidMount() {
@@ -30,9 +30,9 @@ class App extends React.Component {
         const { dispatch, userId, userSurvey } = this.props;
 
         if (userId && userId !== prevProps.userId) {
-            if (userSurvey) {
-                dispatch(fetchUserApiaries());
-            } else {
+            dispatch(saveAndFetchApiaries());
+
+            if (!userSurvey) {
                 dispatch(openUserSurveyModal());
             }
         }

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -148,7 +148,7 @@ export function fetchApiaryScores(apiaryList, forageRange) {
 }
 
 export function signUp(form) {
-    return dispatch => csrfRequest.post('/user/sign_up', form)
+    return dispatch => csrfRequest.post('/user/sign_up?beekeepers', form)
         .then(({ data: { result } }) => {
             if (result === 'success') {
                 dispatch(closeSignUpModal());

--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -147,6 +147,28 @@ export function fetchApiaryScores(apiaryList, forageRange) {
     };
 }
 
+export function signUp(form) {
+    return dispatch => csrfRequest.post('/user/sign_up', form)
+        .then(({ data: { result } }) => {
+            if (result === 'success') {
+                dispatch(closeSignUpModal());
+                dispatch(setAuthState({
+                    username: '',
+                    authError: 'Please click the validation link in your email and then log in.',
+                    userId: null,
+                }));
+                dispatch(openLoginModal());
+            }
+        })
+        .catch((error) => {
+            dispatch(setAuthState({
+                username: '',
+                authError: error.response.data.errors[0],
+                userId: null,
+            }));
+        });
+}
+
 export function login(form) {
     return (dispatch) => {
         const request = form

--- a/src/icp/apps/beekeepers/js/src/components/SignUpModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SignUpModal.jsx
@@ -1,58 +1,151 @@
-import React from 'react';
-import { bool, func } from 'prop-types';
+import React, { Component } from 'react';
+import { bool, func, string } from 'prop-types';
 import Popup from 'reactjs-popup';
 import { connect } from 'react-redux';
 
-import { closeSignUpModal, openLoginModal } from '../actions';
+import { closeSignUpModal, openLoginModal, signUp } from '../actions';
+import { toFormData } from '../utils';
 
 
-const SignUpModal = ({ isSignUpModalOpen, dispatch }) => (
-    <Popup open={isSignUpModalOpen} onClose={() => dispatch(closeSignUpModal())} modal>
-        {close => (
-            <div className="authModal">
-                <div className="authModal__header">
-                    <div>Participate in study</div>
-                    <button type="button" className="button" onClick={close}>
-                        &times;
-                    </button>
-                </div>
-                <div className="authModal__content">
-                    <div className="title">Sign up for the study</div>
-                </div>
-                <div className="authModal__footer">
-                    <button
-                        type="button"
-                        className="button--long"
-                        onClick={close}
-                    >
-                        Sign up
-                    </button>
-                    <span>
-                        Already a participant?
-                        <button
-                            type="button"
-                            className="button"
-                            onClick={() => {
-                                close();
-                                dispatch(openLoginModal());
-                            }}
-                        >
-                            Log in
-                        </button>
-                    </span>
-                </div>
+class SignUpModal extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            email: '',
+            username: '',
+            password1: '',
+            password2: '',
+        };
+        this.handleChange = this.handleChange.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+    }
+
+    handleChange({ currentTarget: { name, value } }) {
+        this.setState({ [name]: value });
+    }
+
+    handleSubmit(event) {
+        const { dispatch } = this.props;
+        dispatch(signUp(toFormData(this.state)));
+        event.preventDefault();
+    }
+
+    render() {
+        const { isSignUpModalOpen, dispatch, authError } = this.props;
+        const {
+            email,
+            username,
+            password1,
+            password2,
+        } = this.state;
+
+        const errorWarning = authError ? (
+            <div className="form__group--error">
+                {authError}
             </div>
-        )}
-    </Popup>
-);
+        ) : null;
+
+        return (
+            <Popup open={isSignUpModalOpen} onClose={() => dispatch(closeSignUpModal())} modal>
+                {close => (
+                    <div className="authModal">
+                        <div className="authModal__header">
+                            <div>Participate in study</div>
+                            <button type="button" className="button" onClick={close}>
+                                &times;
+                            </button>
+                        </div>
+                        <div className="authModal__content">
+                            <div className="title">Sign up for the study</div>
+                            <form className="form" onSubmit={this.handleSubmit}>
+                                {errorWarning}
+                                <div className="form__group">
+                                    <label htmlFor="email">Email</label>
+                                    <input
+                                        type="email"
+                                        name="email"
+                                        value={email}
+                                        onChange={this.handleChange}
+                                        className="form__control"
+                                        required
+                                    />
+                                </div>
+                                <div className="form__group">
+                                    <label htmlFor="username">Username</label>
+                                    <input
+                                        type="text"
+                                        name="username"
+                                        value={username}
+                                        onChange={this.handleChange}
+                                        className="form__control"
+                                        required
+                                    />
+                                </div>
+                                <div className="form__group">
+                                    <label htmlFor="password1">Password</label>
+                                    <input
+                                        type="password"
+                                        className="form__control"
+                                        name="password1"
+                                        value={password1}
+                                        onChange={this.handleChange}
+                                        required
+                                    />
+                                </div>
+                                <div className="form__group">
+                                    <label htmlFor="password2">Repeat Password</label>
+                                    <input
+                                        type="password"
+                                        className="form__control"
+                                        name="password2"
+                                        value={password2}
+                                        onChange={this.handleChange}
+                                        required
+                                    />
+                                </div>
+                                <button
+                                    type="submit"
+                                    value="Submit"
+                                    className="button--long"
+                                >
+                                    Sign Up
+                                </button>
+                            </form>
+                        </div>
+                        <div className="authModal__footer">
+                            <span>
+                                Already a participant?
+                                <button
+                                    type="button"
+                                    className="button"
+                                    onClick={() => {
+                                        close();
+                                        dispatch(openLoginModal());
+                                    }}
+                                >
+                                    Log in
+                                </button>
+                            </span>
+                        </div>
+                    </div>
+                )}
+            </Popup>
+        );
+    }
+}
 
 function mapStateToProps(state) {
-    return state.main;
+    return {
+        isSignUpModalOpen: state.main.isSignUpModalOpen,
+        dispatch: state.main.dispatch,
+        authError: state.auth.authError,
+    };
 }
 
 SignUpModal.propTypes = {
     isSignUpModalOpen: bool.isRequired,
     dispatch: func.isRequired,
+    authError: string.isRequired,
 };
 
 export default connect(mapStateToProps)(SignUpModal);

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -132,3 +132,10 @@ export function sortByValue(a, b) {
 export function arrayToSemicolonDelimitedString(arrayOfStrings) {
     return arrayOfStrings.filter(s => s.length > 0).join(';');
 }
+
+// Converts JSON data to Form Data since some back-end endpoints require that
+export function toFormData(json) {
+    const formData = new FormData();
+    Object.entries(json).forEach(([key, value]) => formData.append(key, value));
+    return formData;
+}

--- a/src/icp/apps/user/views.py
+++ b/src/icp/apps/user/views.py
@@ -138,19 +138,14 @@ def sign_up(request):
 
     if form.is_valid():
         user = view.register(request, form)
+        origin_app = \
+            UserProfile.BEEKEEPERS if 'beekeepers' in request.GET else \
+            UserProfile.POLLINATION
 
-        # Create a user profile with correct origin app
-        # TODO: Correct the check for the beekeepers app
-        if request.META['HTTP_REFERER'] is 'http://localhost:8000/?beekeepers':
-            UserProfile.objects.create(
-                user=user,
-                origin_app=UserProfile.BEEKEEPERS
-            )
-        else:
-            UserProfile.objects.create(
-                user=user,
-                origin_app=UserProfile.POLLINATION
-            )
+        UserProfile.objects.create(
+            user=user,
+            origin_app=origin_app
+        )
 
         response_data = {'result': 'success',
                          'username': user.username,


### PR DESCRIPTION
## Overview

Expands the Sign Up dialog to have four entry fields for email, username, and two password fields. All fields are required, and HTML5 validation is used to ensure they are filled before sending it to the server.

Once complete, the data is sent to the `/user/sign_up?beekeepers` endpoint as form data, which returns validation errors or a success response. The first validation error is shown at the top of the dialog, using similar styling as in the Log In dialog. The query string is used to classify the new users as having signed up from the Beekeepers app,  as opposed to Pollination app.

If the sign up is successful, the Sign Up dialog is closed and the Log In dialog is opened, with a message prompting the user to click the activation link in their email. Once they have activated their account, they can log in with the specified credentials. Upon first log in, any work they have done so far (in terms of apiaries created) are saved to the database.

Connects #326 
Connects #328 

### Demo

![2018-12-31 16 39 38](https://user-images.githubusercontent.com/1430060/50568107-2f477100-0d1b-11e9-8f10-ba5302864a8a.gif)

### Notes

* The issue mentions something about enabling Pollination users for Beekeepers. I don't think there's such a separation anymore, so that can be disregarded.

* I noticed that when a user is created via this sign up dialog, in the `user_userprofile` table they are still listed as coming from the Pollination app. This is likely because the check for HTTP_REFERRER doesn't correctly capture the querystring parameter or something:

    https://github.com/project-icp/bee-pollinator-app/blob/3a82e6753d7dc572714e27977b839cd89d936c52/src/icp/apps/user/views.py#L127-L133

    ```sql
    SELECT username, origin_app
    FROM auth_user u INNER JOIN user_userprofile p ON u.id = p.user_id
    WHERE u.username = 'test4';
    
     username | origin_app  
    ----------+-------------
     test4    | Pollination
    (1 row)
    ```

    When this changes to looking at the domain name, I think this'll fix itself.

* "Forgot Password" and "Resend Activation Link" workflows are alluded to, but not implemented herein. That is deferred until later in #402.

* The activation link takes the user to the Pollination Mapper app. There's very little content on the page, so I think it's alright for now.

## Testing Instructions

* Check out this branch and `beekeepers start`
* Go to [:8000/?beekeepers](http://localhost:8000/?beekeepers) and ensure you are logged out
* Open the sign up dialog and sign up. Try not filling out all fields, making the passwords mismatch, an invalid email, and using a username that already exists. Ensure you get proper error messages for each.
* Run `./scripts/debugserver.sh`
* Fill in valid details in the Sign Up modal. Ensure you are redirected to the Log In dialog.
* Try to log in. Ensure it asks to activate the account first.
* In your `debugserver` output, find the activation link. Open it.
* Try logging in again. Ensure it works correctly.
* Log out, and create some apiaries. Log in again, and ensure those apiaries are still there.
* Refresh the page while logged in and ensure the apiaries are still there.
* Log out, and create some apiaries. Log in again, and ensure you see the apiaries already saved in the account, not the new ones you created while logged out.