### PR TITLE
Fix Build Failures by Copying Symlinks as Target Files

### DIFF
--- a/deployment/ansible/roles/bee-pollinator.app/tasks/app.yml
+++ b/deployment/ansible/roles/bee-pollinator.app/tasks/app.yml
@@ -17,6 +17,7 @@
 
 - name: Synchronize Django application into app_home
   synchronize: archive=no
+               copy_links=yes
                checksum=yes
                compress=no
                recursive=yes

--- a/deployment/ansible/roles/bee-pollinator.celery-worker/tasks/app.yml
+++ b/deployment/ansible/roles/bee-pollinator.celery-worker/tasks/app.yml
@@ -17,6 +17,7 @@
 
 - name: Synchronize Django application into app_home
   synchronize: archive=no
+               copy_links=yes
                checksum=yes
                compress=no
                recursive=yes


### PR DESCRIPTION
## Overview

A few files were converted to be symlinks in https://github.com/project-icp/bee-pollinator-app/commit/462882e1248198c0f630a877bd0e7b75bd8668d9. While this works for Vagrant, this broke for AMI builds. By adding `copy_links=yes` according to the [synchronize module](https://docs.ansible.com/ansible/latest/modules/synchronize_module.html), we ensure they are copied as the targets and not symlinks and work correctly.

Connects #404 

### Demo

http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-app-and-worker/109/console
http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-staging-deployment/108/

The map legend (which relies on the symlinked files) is working correctly on staging:

![image](https://user-images.githubusercontent.com/1430060/50660863-3ebef800-0f6f-11e9-8a13-9b899441decc.png)
