### PR TITLE
List Surveys Based on User Contribution Level

### DIFF
--- a/src/icp/apps/beekeepers/.eslintrc
+++ b/src/icp/apps/beekeepers/.eslintrc
@@ -11,6 +11,7 @@
         "react"
     ],
     "rules": {
+        "camelcase": 0,
         "indent": [2, 4, { "SwitchCase": 1, "VariableDeclarator": 2 }],
         "react/jsx-indent": [2, 4],
         "react/jsx-indent-props": [2, 4],

--- a/src/icp/apps/beekeepers/js/src/components/ApiarySurveyListing.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiarySurveyListing.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { arrayOf } from 'prop-types';
+
+import { Apiary, Survey } from '../propTypes';
+import SurveyCardListing from './SurveyCardListing';
+
+const ApiarySurveyListing = ({ apiary, surveys }) => {
+    const { name } = apiary;
+    const listings = surveys.map(survey => (
+        <SurveyCardListing
+            key={name + survey.month_year + survey.survey_type}
+            survey={survey}
+        />
+    ));
+
+    return (
+        <div>
+            <h2>{name}</h2>
+            {listings}
+        </div>
+    );
+};
+
+ApiarySurveyListing.propTypes = {
+    apiary: Apiary.isRequired,
+    surveys: arrayOf(Survey).isRequired,
+};
+
+export default ApiarySurveyListing;

--- a/src/icp/apps/beekeepers/js/src/components/Survey.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Survey.jsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { arrayOf, number } from 'prop-types';
+import { arrayOf, number, string } from 'prop-types';
 import { Apiary } from '../propTypes';
+import { CONTRIBUTION_LEVEL_PRO } from '../constants';
 
 import GuestSurveyView from './GuestSurveyView';
 import EmptySurveyView from './EmptySurveyView';
 import SurveyView from './SurveyView';
 
-const Survey = ({ userId, apiaries }) => {
+const Survey = ({ userId, apiaries, contributionLevel }) => {
     if (!userId) {
         return <GuestSurveyView />;
     }
@@ -17,23 +18,32 @@ const Survey = ({ userId, apiaries }) => {
         return <EmptySurveyView />;
     }
 
-    return <SurveyView apiaries={apiaries} />;
+    return (
+        <SurveyView
+            apiaries={apiaries}
+            isProUser={contributionLevel === CONTRIBUTION_LEVEL_PRO}
+        />
+    );
 };
 
 function mapStateToProps(state) {
     return {
         userId: state.auth.userId,
         apiaries: state.main.apiaries,
+        contributionLevel: state.auth.userSurvey
+            && state.auth.userSurvey.contribution_level,
     };
 }
 
 Survey.propTypes = {
     userId: number,
     apiaries: arrayOf(Apiary).isRequired,
+    contributionLevel: string,
 };
 
 Survey.defaultProps = {
     userId: null,
+    contributionLevel: null,
 };
 
 export default connect(mapStateToProps)(Survey);

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { func } from 'prop-types';
-import { Apiary } from '../propTypes';
+import { arrayOf, func } from 'prop-types';
+import { Apiary, Survey } from '../propTypes';
 
-import { listMonthYearsSinceCreation, monthToText } from '../utils';
+import {
+    monthNames2,
+} from '../utils';
 import { setApiarySurvey } from '../actions';
 
-const SurveyCard = ({ apiary, dispatch }) => {
+const SurveyCard = ({ apiary, dispatch, surveys }) => {
     const {
         name,
         surveyed,
@@ -32,33 +34,26 @@ const SurveyCard = ({ apiary, dispatch }) => {
             </>
         );
     } else {
-        const monthYears = listMonthYearsSinceCreation(apiary);
-        const lastFourMonthYears = monthYears.slice(0, 4);
-        const apiarySurveyDates = apiary.surveys.map((s) => {
-            const monthName = monthToText(Number(s.month_year.substring(0, 2)) - 1);
-            const year = s.month_year.substring(2, 6);
-            return `${monthName}-${year}`;
-        });
-        cardBody = lastFourMonthYears.map((m) => {
-            const i = apiarySurveyDates.findIndex(date => date === m);
-            if (i >= 0) {
-                return (
-                    <div className="listing" key={name + m}>
-                        <div className="listing__icon--completed">✓</div>
-                        <a className="listing__monthYear" href="/">{m}</a>
-                    </div>
-                );
-            }
-            return (
-                <div className="listing" key={name + m}>
-                    <div className="listing__icon">◯</div>
-                    <a className="listing__monthYear" href="/">{m}</a>
-                    <a className="listing__start" href="/">Start survey</a>
-                </div>
-            );
-        });
+        const shownSurveys = surveys.slice(0, 4);
 
-        if (monthYears.length > 4) {
+        cardBody = shownSurveys.map(({ month_year, survey_type, completed }) => (
+            <div className="listing" key={name + month_year + survey_type}>
+                <div className={`listing__icon${completed ? '--completed' : ''}`}>
+                    {completed ? '✓' : '◯'}
+                </div>
+                <a className="listing__monthYear" href="/">
+                    {monthNames2[month_year.slice(0, 2)]}
+                    {' '}
+                    {month_year.slice(-4)}
+                    {' '}
+                    (
+                    {survey_type}
+                    )
+                </a>
+            </div>
+        ));
+
+        if (surveys.length > 4) {
             cardFooter = (
                 <div className="surveyCard__footer">
                     <button type="button" className="button">View full history</button>
@@ -91,6 +86,7 @@ const SurveyCard = ({ apiary, dispatch }) => {
 SurveyCard.propTypes = {
     apiary: Apiary.isRequired,
     dispatch: func.isRequired,
+    surveys: arrayOf(Survey).isRequired,
 };
 
 export default connect()(SurveyCard);

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { arrayOf, func } from 'prop-types';
-import { Apiary, Survey } from '../propTypes';
 
-import {
-    monthNames2,
-} from '../utils';
+import { Apiary, Survey } from '../propTypes';
 import { setApiarySurvey } from '../actions';
+
+import SurveyCardListing from './SurveyCardListing';
 
 const SurveyCard = ({ apiary, dispatch, surveys }) => {
     const {
@@ -36,21 +35,11 @@ const SurveyCard = ({ apiary, dispatch, surveys }) => {
     } else {
         const shownSurveys = surveys.slice(0, 4);
 
-        cardBody = shownSurveys.map(({ month_year, survey_type, completed }) => (
-            <div className="listing" key={name + month_year + survey_type}>
-                <div className={`listing__icon${completed ? '--completed' : ''}`}>
-                    {completed ? '✓' : '◯'}
-                </div>
-                <a className="listing__monthYear" href="/">
-                    {monthNames2[month_year.slice(0, 2)]}
-                    {' '}
-                    {month_year.slice(-4)}
-                    {' '}
-                    (
-                    {survey_type}
-                    )
-                </a>
-            </div>
+        cardBody = shownSurveys.map(survey => (
+            <SurveyCardListing
+                key={name + survey.month_year + survey.survey_type}
+                survey={survey}
+            />
         ));
 
         if (surveys.length > 4) {

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { arrayOf, func } from 'prop-types';
+import Popup from 'reactjs-popup';
 
 import { Apiary, Survey } from '../propTypes';
 import { setApiarySurvey } from '../actions';
 
+import ApiarySurveyListing from './ApiarySurveyListing';
 import SurveyCardListing from './SurveyCardListing';
 
 const SurveyCard = ({ apiary, dispatch, surveys }) => {
@@ -45,7 +47,19 @@ const SurveyCard = ({ apiary, dispatch, surveys }) => {
         if (surveys.length > 4) {
             cardFooter = (
                 <div className="surveyCard__footer">
-                    <button type="button" className="button">View full history</button>
+                    <Popup
+                        modal
+                        trigger={(
+                            <button
+                                type="button"
+                                className="button"
+                            >
+                                View full history
+                            </button>
+                        )}
+                    >
+                        <ApiarySurveyListing apiary={apiary} surveyItems={surveyItems} />
+                    </Popup>
                     <div>...</div>
                 </div>
             );

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
@@ -44,33 +44,29 @@ const SurveyCard = ({ apiary, dispatch, surveys }) => {
             />
         ));
 
-        if (surveys.length > 4) {
-            cardFooter = (
-                <div className="surveyCard__footer">
-                    <Popup
-                        modal
-                        trigger={(
-                            <button
-                                type="button"
-                                className="button"
-                            >
-                                View full history
-                            </button>
-                        )}
-                    >
-                        <ApiarySurveyListing apiary={apiary} surveyItems={surveyItems} />
-                    </Popup>
-                    <div>...</div>
-                </div>
-            );
-        } else {
-            cardFooter = (
-                <div className="surveyCard__footer">
-                    <div />
-                    <div>...</div>
-                </div>
-            );
-        }
+        const cardDetailTrigger = (
+            <button
+                type="button"
+                className="button"
+            >
+                View full history
+            </button>
+        );
+        const cardDetails = surveys.length <= 4 ? null : (
+            <Popup
+                modal
+                trigger={cardDetailTrigger}
+            >
+                <ApiarySurveyListing apiary={apiary} surveys={surveys} />
+            </Popup>
+        );
+
+        cardFooter = (
+            <div className="surveyCard__footer">
+                {cardDetails}
+                <div>...</div>
+            </div>
+        );
     }
 
     return (

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCardListing.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCardListing.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { Survey } from '../propTypes';
+import { monthNames2 } from '../utils';
+
+const SurveyCardListing = ({ survey: { month_year, survey_type, completed } }) => (
+    <div className="listing">
+        <div className={`listing__icon${completed ? '--completed' : ''}`}>
+            {completed ? '✓' : '◯'}
+        </div>
+        <a className="listing__monthYear" href="/">
+            {monthNames2[month_year.slice(0, 2)]}
+            {' '}
+            {month_year.slice(-4)}
+            {' '}
+            (
+            {survey_type}
+            )
+        </a>
+    </div>
+);
+
+SurveyCardListing.propTypes = {
+    survey: Survey.isRequired,
+};
+
+export default SurveyCardListing;

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCardListing.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCardListing.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Survey } from '../propTypes';
-import { monthNames2 } from '../utils';
+import { monthNames } from '../utils';
 
 const SurveyCardListing = ({ survey: { month_year, survey_type, completed } }) => (
     <div className="listing">
@@ -9,7 +9,7 @@ const SurveyCardListing = ({ survey: { month_year, survey_type, completed } }) =
             {completed ? '✓' : '◯'}
         </div>
         <a className="listing__monthYear" href="/">
-            {monthNames2[month_year.slice(0, 2)]}
+            {monthNames[month_year.slice(0, 2)]}
             {' '}
             {month_year.slice(-4)}
             {' '}

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import { createUserSurvey } from '../actions';
 import { arrayToSemicolonDelimitedString } from '../utils';
 
-/* eslint-disable camelcase */
 class UserSurveyModal extends Component {
     constructor(props) {
         super(props);
@@ -475,7 +474,6 @@ class UserSurveyModal extends Component {
     }
 }
 
-/* eslint-enable camelcase */
 
 function mapStateToProps(state) {
     return {

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -16,3 +16,10 @@ export const SORT_OPTIONS = [DEFAULT_SORT].concat(Object.values(INDICATORS));
 
 export const MAP_CENTER = [40.0, -76.079];
 export const MAP_ZOOM = 10;
+
+export const CONTRIBUTION_LEVEL_LIGHT = 'LIGHT';
+export const CONTRIBUTION_LEVEL_PRO = 'PRO';
+
+export const SURVEY_TYPE_NOVEMBER = 'NOVEMBER';
+export const SURVEY_TYPE_APRIL = 'APRIL';
+export const SURVEY_TYPE_MONTHLY = 'MONTHLY';

--- a/src/icp/apps/beekeepers/js/src/propTypes.js
+++ b/src/icp/apps/beekeepers/js/src/propTypes.js
@@ -52,3 +52,13 @@ export const UserSurvey = shape({
     rear_queens: bool.isRequired,
     equipment: string,
 });
+
+export const Survey = shape({
+    id: number,
+    month_year: string.isRequired,
+    num_colonies: number,
+    created_at: string,
+    survey_type: string.isRequired,
+    apiary: number.isRequired,
+    completed: bool.isRequired,
+});

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -80,10 +80,7 @@ export function getMarkerClass({ selected, starred, surveyed }) {
     return '';
 }
 
-export const monthNames = ['January', 'February', 'March', 'April', 'May',
-    'June', 'July', 'August', 'September', 'October', 'November', 'December'];
-
-export const monthNames2 = {
+export const monthNames = {
     '01': 'January',
     '02': 'February',
     '03': 'March',
@@ -97,43 +94,6 @@ export const monthNames2 = {
     11: 'November',
     12: 'December',
 };
-
-export function monthToText(month) {
-    // Counts months from 0-11
-    return monthNames[month];
-}
-
-export function listMonthYearsSinceCreation(apiary) {
-    // Count months from 0-11, where January is 0
-    const createdYear = Number(apiary.created_at.substring(0, 4));
-    const createdMonth = Number(apiary.created_at.substring(5, 7)) - 1;
-
-    // The Date API counts months from 0
-    const timeNow = new Date();
-    const monthNow = timeNow.getMonth();
-    const yearNow = timeNow.getFullYear();
-
-    let months = 0;
-    months = (yearNow - createdYear) * 12;
-    months -= createdMonth;
-    months += monthNow;
-    const monthDiff = months <= 0 ? 0 : months;
-
-    let monthCounter = monthNow;
-    let yearCounter = yearNow;
-    const monthYears = [];
-    let i = 0;
-    for (i = 0; i < monthDiff + 1; i += 1) {
-        monthYears.push(`${monthToText(monthCounter)}-${String(yearCounter)}`);
-        monthCounter -= 1;
-        if (monthCounter < 1) {
-            yearCounter -= 1;
-            monthCounter = 11;
-        }
-    }
-
-    return monthYears;
-}
 
 export function sortByValue(a, b) {
     const valA = a[1].toUpperCase();

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -1,3 +1,9 @@
+import {
+    SURVEY_TYPE_NOVEMBER,
+    SURVEY_TYPE_APRIL,
+    SURVEY_TYPE_MONTHLY,
+} from './constants';
+
 export function toDashedString(value) {
     return value.toLowerCase().replace('_', '-');
 }
@@ -77,6 +83,21 @@ export function getMarkerClass({ selected, starred, surveyed }) {
 export const monthNames = ['January', 'February', 'March', 'April', 'May',
     'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 
+export const monthNames2 = {
+    '01': 'January',
+    '02': 'February',
+    '03': 'March',
+    '04': 'April',
+    '05': 'May',
+    '06': 'June',
+    '07': 'July',
+    '08': 'August',
+    '09': 'September',
+    10: 'October',
+    11: 'November',
+    12: 'December',
+};
+
 export function monthToText(month) {
     // Counts months from 0-11
     return monthNames[month];
@@ -138,4 +159,156 @@ export function toFormData(json) {
     const formData = new FormData();
     Object.entries(json).forEach(([key, value]) => formData.append(key, value));
     return formData;
+}
+
+/**
+ * Given a list of surveys, returns a function that takes a month_year and
+ * returns true the survey if found, otherwise null.
+ *
+ * @param {arrayOf(Survey)} surveys
+ */
+function makeSurveyMatcher(surveys) {
+    return (month_year) => {
+        const survey = surveys.find(s => s.month_year === month_year);
+        if (survey) {
+            survey.completed = true;
+            return survey;
+        }
+
+        return null;
+    };
+}
+
+/**
+ * Given an Apiary, returns a list of November Survey objects since 2018,
+ * like this:
+ *
+ * [{ month_year: '112018', survey_type: SURVEY_TYPE_NOVEMBER, completed: true },
+ *  { month_year: '112019', survey_type: SURVEY_TYPE_NOVEMBER, completed: false }]
+ *
+ * @param {Apiary} apiary
+ */
+export function getNovemberSurveys({ id: apiary, surveys }) {
+    const survey_type = SURVEY_TYPE_NOVEMBER;
+    const startYear = 2018;
+    const currentDate = new Date();
+    const currentMonth = currentDate.getMonth();
+    const currentYear = currentDate.getFullYear();
+    // End at this year if after November (0-indexed 10), else last year
+    const endYear = currentMonth >= 10 ? currentYear : currentYear - 1;
+    const matchSurvey = makeSurveyMatcher(
+        surveys.filter(s => s.survey_type === survey_type),
+    );
+    const novSurveys = [];
+
+    for (let i = startYear; i <= endYear; i += 1) {
+        const month_year = `11${i}`;
+        const survey = matchSurvey(month_year) || {
+            apiary,
+            month_year,
+            survey_type,
+            completed: false,
+        };
+
+        novSurveys.push(survey);
+    }
+
+    return novSurveys;
+}
+
+/**
+ * Given an Apiary, returns a list of April Survey objects since 2019,
+ * like this:
+ *
+ * [{ month_year: '042019', survey_type: SURVEY_TYPE_APRIL, completed: true },
+ *  { month_year: '042020', survey_type: SURVEY_TYPE_APRIL, completed: false }]
+ *
+ * @param {Apiary} apiary
+ */
+export function getAprilSurveys({ id: apiary, surveys }) {
+    const survey_type = SURVEY_TYPE_APRIL;
+    const startYear = 2019;
+    const currentDate = new Date();
+    const currentMonth = currentDate.getMonth();
+    const currentYear = currentDate.getFullYear();
+    // End at this year if after April (0-indexed 3), else last year
+    const endYear = currentMonth >= 3 ? currentYear : currentYear - 1;
+    const matchSurvey = makeSurveyMatcher(
+        surveys.filter(s => s.survey_type === survey_type),
+    );
+    const aprSurveys = [];
+
+    for (let i = startYear; i <= endYear; i += 1) {
+        const month_year = `04${i}`;
+        const survey = matchSurvey(month_year) || {
+            apiary,
+            month_year,
+            survey_type,
+            completed: false,
+        };
+
+        aprSurveys.push(survey);
+    }
+
+    return aprSurveys;
+}
+
+/**
+ * Given an Apiary, returns a list of Monthly Survey objects since the date
+ * of apiary creation, like this:
+ *
+ * [{ month_year: '012019', survey_type: SURVEY_TYPE_MONTHLY, completed: true },
+ *  { month_year: '022019', survey_type: SURVEY_TYPE_MONTHLY, completed: false },
+ *  { month_year: '032019', survey_type: SURVEY_TYPE_MONTHLY, completed: false }]
+ *
+ * @param {Apiary} apiary
+ */
+export function getMonthlySurveys({ id: apiary, created_at: createdAt, surveys }) {
+    const survey_type = SURVEY_TYPE_MONTHLY;
+    const currentDate = new Date();
+
+    const startYear = Number(createdAt.substring(0, 4));
+    const endYear = currentDate.getFullYear();
+
+    const createdMonth = Number(createdAt.substring(5, 7));
+    const currentMonth = currentDate.getMonth() + 1; // Add one to make 1-indexed
+
+    const matchSurvey = makeSurveyMatcher(
+        surveys.filter(s => s.survey_type === survey_type),
+    );
+    const mthSurveys = [];
+
+    for (let y = startYear; y <= endYear; y += 1) {
+        const startMonth = y === startYear ? createdMonth : 1;
+        const endMonth = y === endYear ? currentMonth : 12;
+
+        for (let m = startMonth; m <= endMonth; m += 1) {
+            const twoDigitMonth = `0${m}`.slice(-2);
+            const month_year = `${twoDigitMonth}${y}`;
+            const survey = matchSurvey(month_year) || {
+                apiary,
+                month_year,
+                survey_type,
+                completed: false,
+            };
+
+            mthSurveys.push(survey);
+        }
+    }
+
+    return mthSurveys;
+}
+
+export function sortSurveysByMonthYearDescending(a, b) {
+    const monthA = a.month_year.slice(0, 2);
+    const yearA = a.month_year.slice(-4);
+
+    const monthB = b.month_year.slice(0, 2);
+    const yearB = b.month_year.slice(-4);
+
+    if (yearA === yearB) {
+        return Number(monthB) - Number(monthA);
+    }
+
+    return Number(yearB) - Number(yearA);
 }


### PR DESCRIPTION
## Overview

Updates the Survey Listing for each apiary to list November, April, and Monthly surveys separately, with explicit marking. Pro users see all three kinds of listings, and Light users see only November and April listings. We begin counting from November 2018 for November and April surveys, and from the date of the apiary's creation for the Monthly surveys.

We still show the four most recent survey listings in a survey card, with the rest hidden behind a "View full history" button. Clicking that button opens a popup that lists all the surveys for that apiary.

Connects #398 
Connects #378 

### Demo

For Pro Users:

![image](https://user-images.githubusercontent.com/1430060/50704890-f236f380-1026-11e9-9a15-ffb48feb1040.png)

![2019-01-04 13 44 08](https://user-images.githubusercontent.com/1430060/50704937-1692d000-1027-11e9-9938-63e0dd705c7d.gif)

For Light Users:

![image](https://user-images.githubusercontent.com/1430060/50705031-6d000e80-1027-11e9-8051-78049fef9b28.png)

### Notes

The Survey Detail dialog needs styling. I've made a note in #393.

## Testing Instructions

* Check out this branch and `beekeepers start`
* Go to [:8000/?beekeepers](http://localhost:8000/?beekeepers) and log in as a Pro user.
* Make some apiaries. Opt some in to the survey. Switch to the survey tab. Make sure you see an entry for November 2018, and a Monthly entry for each month since the apiary's creation.
* Go to [:5433](http://localhost:5433) and update one of the apiaries to have an older creation date. Refresh the survey page and ensure you see more entries for Monthly surveys
* If any apiary has more than 4 survey listings, ensure you see the "View full history" button, and clicking it opens the detail dialog, which has the same list but now complete, not just limited to the last 4.
* Log out. Log in as a Light user. Make some apiaries and opt them in to the survey. Switch to the survey tab. Ensure you only see entries for November 2018, and none for Monthly surveys.