### PR TITLE
Update the worker snapshot volume for 2017 CDL

### DIFF
--- a/deployment/packer/template.js
+++ b/deployment/packer/template.js
@@ -41,7 +41,7 @@
             "ami_block_device_mappings": [
                 {
                     "device_name": "/dev/sdf",
-                    "snapshot_id": "snap-08429591cf7ae1fb7",
+                    "snapshot_id": "snap-0a40643aeb3029eb0",
                     "volume_type": "gp2",
                     "delete_on_termination": true
                 }


### PR DESCRIPTION
## Overview

The CDL tif has been updated to the 2017 version and placed on the
snapshot identified by the id added to our packer template.

Connects #407 
Connects #377 

### Demo

I ran a scenario on the 2015 raster and another scenario on the 2017 version.  As you can see, one version had Cucurbits dropped between versions.

![screenshot 2019-01-04 at 1 56 02 pm](https://user-images.githubusercontent.com/1014341/50705454-e8ae8b00-1028-11e9-8a7b-1f50e328dab9.png)

### Notes

The 2017 CDL was reclassified according to the excellent notes in the readme.  The articaft, aside from being available on the snapshot volume, is in the publically available `icp-cdl-data`.  As the readme indicates, the 2017 prefixed version can be copied (sans prefix) to your host `/opt/icp-crop-data` directory in order to use/test it locally.  The other proportions remain largely the same.

## Testing Instructions

* Update your local CDL version, as described in the Notes above.
* Confirm you can still run the pollination model with reasonable results
* Confirm the snapshot ID is valid.

When this is merged, we can verify that it's being used on staging. 
