### PR TITLE
Overlap spinner to entire apiary card

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -23,49 +23,51 @@ const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
 
     const markerClass = getMarkerClass(apiary);
 
-    const scoresBody = !Object.keys(apiary.scores[forageRange]).length
-        ? <div className="spinner" />
-        : (
-            <div className="indicator-container">
-                <ScoresLabel
-                    indicator={INDICATORS.NESTING_QUALITY}
-                    scores={[values[INDICATORS.NESTING_QUALITY]]}
-                />
-                <ScoresLabel
-                    indicator={INDICATORS.PESTICIDE}
-                    scores={[values[INDICATORS.PESTICIDE]]}
-                />
-                <ScoresLabel
-                    indicator="forage"
-                    scores={[
-                        values[INDICATORS.FLORAL_SPRING],
-                        values[INDICATORS.FLORAL_SUMMER],
-                        values[INDICATORS.FLORAL_FALL],
-                    ]}
-                />
-            </div>
-        );
-
     const onStar = () => dispatch(setApiaryStar(apiary));
     const onSurvey = () => dispatch(setApiarySurvey(apiary));
     const onDelete = () => dispatch(deleteApiary(apiary));
 
+    const scoreCard = !Object.keys(apiary.scores[forageRange]).length
+        ? <div className="spinner" />
+        : (
+            <>
+                <div className="card__top">
+                    <div className="card__identification">
+                        <div className={`marker ${markerClass}`}>{marker}</div>
+                        <div className="card__name">{name}</div>
+                    </div>
+                    <div className="card__buttons">
+                        <CardButton icon="star" filled={starred} onClick={onStar} />
+                        <CardButton icon="clipboard" filled={surveyed} onClick={onSurvey} />
+                        <CardButton icon="trash" filled onClick={onDelete} />
+                    </div>
+                </div>
+                <div className="card__bottom">
+                    <div className="indicator-container">
+                        <ScoresLabel
+                            indicator={INDICATORS.NESTING_QUALITY}
+                            scores={[values[INDICATORS.NESTING_QUALITY]]}
+                        />
+                        <ScoresLabel
+                            indicator={INDICATORS.PESTICIDE}
+                            scores={[values[INDICATORS.PESTICIDE]]}
+                        />
+                        <ScoresLabel
+                            indicator="forage"
+                            scores={[
+                                values[INDICATORS.FLORAL_SPRING],
+                                values[INDICATORS.FLORAL_SUMMER],
+                                values[INDICATORS.FLORAL_FALL],
+                            ]}
+                        />
+                    </div>
+                </div>
+            </>
+        );
+
     return (
         <li className="card">
-            <div className="card__top">
-                <div className="card__identification">
-                    <div className={`marker ${markerClass}`}>{marker}</div>
-                    <div className="card__name">{name}</div>
-                </div>
-                <div className="card__buttons">
-                    <CardButton icon="star" filled={starred} onClick={onStar} />
-                    <CardButton icon="clipboard" filled={surveyed} onClick={onSurvey} />
-                    <CardButton icon="trash" filled onClick={onDelete} />
-                </div>
-            </div>
-            <div className="card__bottom">
-                {scoresBody}
-            </div>
+            {scoreCard}
         </li>
     );
 };

--- a/src/icp/apps/beekeepers/sass/06_components/_card.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_card.scss
@@ -1,6 +1,7 @@
 .card {
     display: flex;
     flex-direction: column;
+    min-height: 80px;
     background-color: #fff;
     border-radius: 4px;
     box-shadow: 0 0 4px -1px rgba(0, 0, 0, 0.5);

--- a/src/icp/apps/beekeepers/sass/06_components/_spinner.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_spinner.scss
@@ -1,5 +1,9 @@
+.spinner {
+    margin: auto;
+}
+
 .spinner::after {
-    position: absolute;
+    display: flex;
     box-sizing: border-box;
     width: 20px;
     height: 20px;


### PR DESCRIPTION
## Overview

The spinners when apiary cards loaded covered only the scores, and were displayed absolute to the page, not the card. Therefore, when the card list grew long and scrollable, spinners would float in space over the list.

This card fixes the spinners and fixes them over the entire card, not just the scores -- this has the benefit of not showing the apiary name until it is successfully reverse geocoded.

I gave cards a minimum height of 80px, which is roughly their height already when loaded with info.

Connects #392 

### Demo

<img width="401" alt="screen shot 2019-01-09 at 5 30 18 pm" src="https://user-images.githubusercontent.com/10568752/50934063-71686500-1435-11e9-9856-8d5dcfc63d6a.png">


## Testing Instructions

Click the map, add an apiary. Toggle the buffer. Add enough apiaries so the list scrolls. Spinners should act as you expect.
