### PR TITLE
Add hover popups to scores

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/LoginModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/LoginModal.jsx
@@ -62,6 +62,7 @@ class LoginModal extends Component {
                     dispatch(clearAuthMessages());
                     dispatch(closeLoginModal());
                 }}
+                className="modal"
                 modal
             >
                 {close => (

--- a/src/icp/apps/beekeepers/js/src/components/ParticipateModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ParticipateModal.jsx
@@ -7,7 +7,12 @@ import { closeParticipateModal, openSignUpModal, openLoginModal } from '../actio
 
 
 const ParticipateModal = ({ isParticipateModalOpen, dispatch }) => (
-    <Popup open={isParticipateModalOpen} onClose={() => dispatch(closeParticipateModal())} modal>
+    <Popup
+        open={isParticipateModalOpen}
+        onClose={() => dispatch(closeParticipateModal())}
+        className="modal"
+        modal
+    >
         {close => (
             <div className="authModal">
                 <div className="authModal__header">

--- a/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { arrayOf, string } from 'prop-types';
+import Popup from 'reactjs-popup';
 
 import { Score } from '../propTypes';
 import { toDashedString, toSpacedString } from '../utils';
+import { INDICATOR_DETAILS } from '../constants';
 
 
 function generateScore(data, error) {
@@ -17,13 +19,33 @@ function generateScore(data, error) {
 const ScoresLabel = ({ indicator, scores }) => {
     const formattedScores = scores.map(({ data, err }) => generateScore(data, err)).join('/');
     const score = formattedScores[0] ? formattedScores : '!';
-    return (
-        <div className={`indicator indicator--${toDashedString(indicator)}`}>
-            <div className="indicator__number">
-                {score}
-            </div>
-            <div className="indicator__name">{toSpacedString(indicator)}</div>
+    const indicatorDetails = INDICATOR_DETAILS[indicator];
+    const hoverScores = indicatorDetails.scoreLabels.map((label, idx) => (
+        <div className="score">
+            <div className="value">{generateScore(scores[idx].data)}</div>
+            <div className="label">{label}</div>
         </div>
+    ));
+    return (
+        <Popup
+            trigger={(
+                <div className={`indicator indicator--${toDashedString(indicator)}`}>
+                    <div className="indicator__number">
+                        {score}
+                    </div>
+                    <div className="indicator__name">{toSpacedString(indicator)}</div>
+                </div>
+            )}
+            position="top center"
+            on="hover"
+        >
+            <div className="indicator__popup">
+                <div className="name">{indicatorDetails.name}</div>
+                <div className="description">{indicatorDetails.description}</div>
+                <div className="scores">{hoverScores}</div>
+            </div>
+        </Popup>
+
     );
 };
 

--- a/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
@@ -21,7 +21,7 @@ const ScoresLabel = ({ indicator, scores }) => {
     const score = formattedScores[0] ? formattedScores : '!';
     const indicatorDetails = INDICATOR_DETAILS[indicator];
     const hoverScores = indicatorDetails.scoreLabels.map((label, idx) => (
-        <div className="score">
+        <div className="score" key={label}>
             <div className="value">{generateScore(scores[idx].data)}</div>
             <div className="label">{label}</div>
         </div>

--- a/src/icp/apps/beekeepers/js/src/components/SignUpModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SignUpModal.jsx
@@ -57,6 +57,7 @@ class SignUpModal extends Component {
                     dispatch(closeSignUpModal());
                     dispatch(clearAuthMessages());
                 }}
+                className="modal"
                 modal
             >
                 {close => (

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -135,6 +135,7 @@ class UserSurveyModal extends Component {
                 open={isUserSurveyModalOpen}
                 closeOnEscape={false}
                 closeOnDocumentClick={false}
+                className="modal"
                 modal
             >
                 <div className="authModal">

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -12,6 +12,24 @@ export const INDICATORS = {
     FLORAL_FALL: 'floral_fall',
 };
 
+export const INDICATOR_DETAILS = {
+    nesting: {
+        name: 'Nesting quality',
+        description: 'Lorem ipsum of nesting quality.',
+        scoreLabels: ['Nesting'],
+    },
+    pesticide: {
+        name: 'Pesticide quality',
+        description: 'Lorem ipsum of pesticide quality.',
+        scoreLabels: ['Pesticide'],
+    },
+    forage: {
+        name: 'Forage quality',
+        description: 'Lorem ipsum of forage quality.',
+        scoreLabels: ['Spring', 'Summer', 'Fall'],
+    },
+};
+
 export const SORT_OPTIONS = [DEFAULT_SORT].concat(Object.values(INDICATORS));
 
 export const MAP_CENTER = [40.0, -76.079];

--- a/src/icp/apps/beekeepers/sass/06_components/_indicator.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_indicator.scss
@@ -13,6 +13,25 @@
         color: $color-grey-3;
         text-transform: capitalize;
     }
+
+    &__popup {
+        display: flex;
+        flex-direction: column;
+        justify-content: left;
+
+        .name {
+            font-weight: $font-weight-bold;
+        }
+
+        .scores {
+            display: flex;
+            justify-content: space-around;
+        }
+
+        .value {
+            font-weight: $font-weight-bold;
+        }
+    }
 }
 
 @include media("<=tablet") {

--- a/src/icp/apps/beekeepers/sass/06_components/_indicator.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_indicator.scss
@@ -17,10 +17,14 @@
     &__popup {
         display: flex;
         flex-direction: column;
-        justify-content: left;
 
         .name {
             font-weight: $font-weight-bold;
+            text-align: left;
+        }
+
+        .description {
+            text-align: left;
         }
 
         .scores {

--- a/src/icp/apps/beekeepers/sass/06_components/_modal.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_modal.scss
@@ -4,6 +4,7 @@
 }
 
 .popup-content {
+    z-index: 1000 !important;
     width: 380px !important;
     padding: 0 !important;
 }

--- a/src/icp/apps/beekeepers/sass/06_components/_modal.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_modal.scss
@@ -5,6 +5,9 @@
 
 .popup-content {
     z-index: 1000 !important;
+}
+
+.modal {
     width: 380px !important;
     padding: 0 !important;
 }


### PR DESCRIPTION
## Overview

To give a little more context to the apiary card content, scores will have popovers explaining the indicator and the score(s). The copy is yet to be provided.

Connects #372

### Demo

<img width="683" alt="screen shot 2019-01-14 at 5 33 37 pm" src="https://user-images.githubusercontent.com/10568752/51145989-79ece100-1823-11e9-9ba3-be5b93886d7b.png">

<img width="245" alt="screen shot 2019-01-14 at 5 33 55 pm" src="https://user-images.githubusercontent.com/10568752/51145990-79ece100-1823-11e9-936f-66a5eef2b485.png">

<img width="400" alt="screen shot 2019-01-14 at 5 33 43 pm" src="https://user-images.githubusercontent.com/10568752/51145991-79ece100-1823-11e9-9ec0-4e5dd79ccfd5.png">


### Notes

I could have broken the popover content into its own functional component but the apiary cards are already really nested and I didn't think doing so would add clarity.

## Testing Instructions

Run the project `./scripts/beekeepers.sh start`
Hover over an apiary card score
