### PR TITLE
Add back map label layer

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -201,6 +201,11 @@ class Map extends Component {
                         attribution="Tiles &copy; Esri"
                         url="https://server.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
                     />
+                    <TileLayer
+                        attribution='&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
+                        url="https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}{r}.png"
+                        subdomains="abcd"
+                    />
                     <CropLayerControl
                         position="bottomleft"
                         enableMapZoom={this.enableMapZoom}


### PR DESCRIPTION
The label layer got removed accidentally when the crop tile layer was added.

Refs #415

## Overview

The label layer on the map was accidentally booted. Reinstate it.

Connects #415

### Demo

<img width="253" alt="screen shot 2019-01-15 at 11 05 31 am" src="https://user-images.githubusercontent.com/10568752/51192875-8752ab80-18b5-11e9-87b3-ec624b95cce5.png">

## Testing Instructions

See labels on the map at http://localhost:8000/?beekeepers
