### PR TITLE
Show error message and retry button upon failed fetch request

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -4,7 +4,12 @@ import { connect } from 'react-redux';
 
 import { Apiary } from '../propTypes';
 import { INDICATORS } from '../constants';
-import { setApiaryStar, setApiarySurvey, deleteApiary } from '../actions';
+import {
+    setApiaryStar,
+    setApiarySurvey,
+    deleteApiary,
+    fetchApiaryScores,
+} from '../actions';
 import { getMarkerClass } from '../utils';
 
 import CardButton from './CardButton';
@@ -27,9 +32,23 @@ const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
     const onSurvey = () => dispatch(setApiarySurvey(apiary));
     const onDelete = () => dispatch(deleteApiary(apiary));
 
-    const scoreCard = !Object.keys(apiary.scores[forageRange]).length
-        ? <div className="spinner" />
-        : (
+    let scoreCard;
+    if (!Object.keys(apiary.scores[forageRange]).length && !apiary.fetching) {
+        scoreCard = (
+            <>
+                Error fetching apiary data
+                <button
+                    type="button"
+                    onClick={() => dispatch(fetchApiaryScores([apiary], forageRange))}
+                >
+                    Try again?
+                </button>
+            </>
+        );
+    } else if (!Object.keys(apiary.scores[forageRange]).length) {
+        scoreCard = <div className="spinner" />;
+    } else {
+        scoreCard = (
             <>
                 <div className="card__top">
                     <div className="card__identification">
@@ -64,6 +83,7 @@ const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
                 </div>
             </>
         );
+    }
 
     return (
         <li className="card">

--- a/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
@@ -13,16 +13,16 @@ function generateScore(data, error) {
         return '--';
     }
 
-    return error ? NaN : Math.round(data * 100);
+    return error ? 'Err' : Math.round(data * 100);
 }
 
 const ScoresLabel = ({ indicator, scores }) => {
-    const formattedScores = scores.map(({ data, err }) => generateScore(data, err)).join('/');
+    const formattedScores = scores.map(({ data, error }) => generateScore(data, error)).join('/');
     const score = formattedScores[0] ? formattedScores : '!';
     const indicatorDetails = INDICATOR_DETAILS[indicator];
     const hoverScores = indicatorDetails.scoreLabels.map((label, idx) => (
         <div className="score" key={label}>
-            <div className="value">{generateScore(scores[idx].data)}</div>
+            <div className="value">{generateScore(scores[idx].data, scores[idx].error)}</div>
             <div className="label">{label}</div>
         </div>
     ));

--- a/src/icp/apps/beekeepers/sass/06_components/_card.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_card.scss
@@ -1,7 +1,10 @@
 .card {
     display: flex;
     flex-direction: column;
+    justify-content: space-evenly;
+    align-items: center;
     min-height: 80px;
+    font-size: $font-size-med;
     background-color: #fff;
     border-radius: 4px;
     box-shadow: 0 0 4px -1px rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
## Overview

Currently if a fetch request for apiary data fails, we will see a spinner infinitely. This PR renders an error state and retry fetch button upon fetch failure. Clicking "try again?" will kick off `fetchApiaryScores` again.

I also fixed a reference error. We now show `Err` for the score of an indicator that had a fetching error. Open to showing something else, before we were accidentally showing `0`. 

Connects #356

### Demo

<img width="408" alt="screen shot 2019-01-15 at 5 40 06 pm" src="https://user-images.githubusercontent.com/10568752/51258542-3952ac00-1978-11e9-93f1-523a4de070d0.png">

<img width="408" alt="screen shot 2019-01-16 at 9 51 30 am" src="https://user-images.githubusercontent.com/10568752/51258546-3eaff680-1978-11e9-8d0f-38ce828154e9.png">

### Notes

Very basic styling...

## Testing Instructions

`./scripts/beekeepers.sh start`
Visit http://localhost:8000/?beekeepers
We want to stimulate a 5xx error from the backend, so shut off the service:
```
vagrant ssh app
sudo stop icp-app
```
Now, click the map to add an apiary. Don't refresh the page because it won't rerender with Django shut off.
You should see the error message load.
To test the "try again" button works, restart the service within the app VM: `sudo start icp-app`
Click the "try again" button again and the data should come back (may take a few tries ?)
