### PR TITLE
Mixed bag of bugs

### DIFF
--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -40,6 +40,7 @@ export const openEmailFormModal = createAction('Open email form modal');
 export const closeEmailFormModal = createAction('Close email form modal');
 export const openSuccessModal = createAction('Open success message modal');
 export const closeSuccessModal = createAction('Close success message modal');
+export const setMapCenter = createAction('Set map center');
 
 
 export function fetchApiaryScores(apiaryList, forageRange) {

--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -53,7 +53,7 @@ const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
                             scores={[values[INDICATORS.PESTICIDE]]}
                         />
                         <ScoresLabel
-                            indicator="forage"
+                            indicator="floral"
                             scores={[
                                 values[INDICATORS.FLORAL_SPRING],
                                 values[INDICATORS.FLORAL_SUMMER],

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -23,12 +23,13 @@ import {
     fetchApiaryScores,
     setApiaryList,
     updateApiary,
+    setMapCenter,
 } from '../actions';
 import {
-    MAP_CENTER,
-    MAP_ZOOM,
     FORAGE_RANGE_3KM,
     FORAGE_RANGE_5KM,
+    MAP_ZOOM,
+    MAP_CENTER,
 } from '../constants';
 import { getNextInSequence, isSameLocation } from '../utils';
 
@@ -41,6 +42,7 @@ class Map extends Component {
         this.onClickAddMarker = this.onClickAddMarker.bind(this);
         this.enableMapZoom = this.enableMapZoom.bind(this);
         this.disableMapZoom = this.disableMapZoom.bind(this);
+        this.onMapMove = this.onMapMove.bind(this);
         this.mapRef = createRef();
         this.addressLookup = (new esri.GeocodeService()).reverse();
 
@@ -50,6 +52,7 @@ class Map extends Component {
     }
 
     componentDidMount() {
+        const { mapCenter } = this.props;
         const geocoderUrl = 'https://utility.arcgis.com/usrsvcs/appservices/OvpAtyJwoLLdQcLC/rest/services/World/GeocodeServer/';
         const map = this.mapRef.current.leafletElement;
         const geocoder = new esri.Geosearch({
@@ -72,7 +75,7 @@ class Map extends Component {
             useMapBounds: false,
             zoomToResult: false,
         }).addTo(map);
-
+        map.setView(mapCenter);
         geocoder.on('results', ({ results }) => {
             const selectedResult = results && results[0];
             if (selectedResult) {
@@ -155,6 +158,12 @@ class Map extends Component {
         }, 300);
     }
 
+    onMapMove(event) {
+        const { dispatch } = this.props;
+        const center = event.target.getCenter();
+        dispatch(setMapCenter([center.lat, center.lng]));
+    }
+
     enableMapZoom() {
         this.mapRef.current.leafletElement.scrollWheelZoom.enable();
     }
@@ -164,7 +173,11 @@ class Map extends Component {
     }
 
     render() {
-        const { apiaries, cropLayerOpacity, isCropLayerActive } = this.props;
+        const {
+            apiaries,
+            cropLayerOpacity,
+            isCropLayerActive,
+        } = this.props;
         const markers = apiaries.map((apiary) => {
             const icon = L.divIcon({
                 className: 'custom icon',
@@ -193,6 +206,7 @@ class Map extends Component {
                     zoom={MAP_ZOOM}
                     zoomControl={false}
                     onClick={this.onClickAddMarker}
+                    onMoveEnd={this.onMapMove}
                     ref={this.mapRef}
                     maxZoom={18}
                 >
@@ -215,7 +229,14 @@ class Map extends Component {
 }
 
 function mapStateToProps(state) {
-    return state.main;
+    return {
+        apiaries: state.main.apiaries,
+        forageRange: state.main.forageRange,
+        isCropLayerActive: state.main.isCropLayerActive,
+        cropLayerOpacity: state.main.cropLayerOpacity,
+        dispatch: state.main.dispatch,
+        mapCenter: state.saved.mapCenter,
+    };
 }
 
 Map.propTypes = {
@@ -224,6 +245,7 @@ Map.propTypes = {
     isCropLayerActive: bool.isRequired,
     cropLayerOpacity: number.isRequired,
     dispatch: func.isRequired,
+    mapCenter: arrayOf(number).isRequired,
 };
 
 export default connect(mapStateToProps)(Map);

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -23,9 +23,9 @@ export const INDICATOR_DETAILS = {
         description: 'Lorem ipsum of pesticide quality.',
         scoreLabels: ['Pesticide'],
     },
-    forage: {
-        name: 'Forage quality',
-        description: 'Lorem ipsum of forage quality.',
+    floral: {
+        name: 'Floral quality',
+        description: 'Lorem ipsum of floral quality.',
         scoreLabels: ['Spring', 'Summer', 'Fall'],
     },
 };

--- a/src/icp/apps/beekeepers/js/src/reducers.js
+++ b/src/icp/apps/beekeepers/js/src/reducers.js
@@ -4,6 +4,7 @@ import update from 'immutability-helper';
 import {
     DEFAULT_SORT,
     FORAGE_RANGE_3KM,
+    MAP_CENTER,
 } from './constants';
 import {
     setSort,
@@ -26,6 +27,7 @@ import {
     closeEmailFormModal,
     openSuccessModal,
     closeSuccessModal,
+    setMapCenter,
 } from './actions';
 
 const initialState = {
@@ -81,8 +83,15 @@ const mainReducer = createReducer({
         state => update(state, { isSuccessModalOpen: { $set: false } }),
 }, initialState);
 
+const savedState = {
+    mapCenter: MAP_CENTER,
+};
+
 // Placeholder reducer for parts of state that will be persisted to localStorage
-const savedReducer = createReducer({}, {});
+const savedReducer = createReducer({
+    [setMapCenter]:
+        (state, payload) => update(state, { mapCenter: { $set: payload } }),
+}, savedState);
 
 const initialAuthState = {
     username: '',


### PR DESCRIPTION
## Overview

Small clean ups that didn't warrant individual PRs
- Refreshing or reopening the page should load the map where the user last was, rather than initializing the map to the default location in PA. This makes more sense from the user's perspective. For this, I used redux persist! It finally came into handy.
- Forage rasters were renamed Floral rasters, but the new wording wasn't *official* until now. Make the resulting copy changes.

Connects #414, #391

### Demo

![map persist](https://user-images.githubusercontent.com/10568752/51500269-70bbc100-1d9b-11e9-82a8-ec993c291cdf.gif)

<img width="430" alt="screen shot 2019-01-21 at 4 36 29 pm" src="https://user-images.githubusercontent.com/10568752/51500270-70bbc100-1d9b-11e9-9c76-264268887680.png">


### Notes

I considered initializing the map at the bounds of the apiaries but I prefer this UX and the alternative felt overly complicated.

## Testing Instructions

`./scripts/beekeepers.sh start` 
Move the map and refresh or open a new page -- make sure the map opens at the last spot.

See the sort dropdown works and the text is correct
