### PR TITLE
Use 2017 CDL Raster

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -180,8 +180,9 @@ class Map extends Component {
         });
         const cropLayer = !isCropLayerActive ? null : (
             <TileLayer
-                url="https://{s}.tiles.azavea.com/cdl-reclass/{z}/{x}/{y}.png"
+                url="https://{s}.tiles.azavea.com/cdl-reclass-2017-gdal/{z}/{x}/{y}.png"
                 subdomains="abcd"
+                maxNativeZoom={13}
                 opacity={cropLayerOpacity}
             />
         );

--- a/src/icp/icp/settings/base.py
+++ b/src/icp/icp/settings/base.py
@@ -373,8 +373,8 @@ BASEMAPS = [
 ]
 
 OVERLAY = {
-    'url': 'https://{s}.tiles.azavea.com/cdl-reclass/{z}/{x}/{y}.png',
-    'maxNativeZoom': 15
+    'url': 'https://{s}.tiles.azavea.com/cdl-reclass-2017-gdal/{z}/{x}/{y}.png',
+    'maxNativeZoom': 13
 }
 
 DRAW_TOOLS = [


### PR DESCRIPTION
## Overview

Updates the app to use the new 2017 CDL raster for visualization. See https://github.com/project-icp/bee-pollinator-app/issues/371#issuecomment-456216003 for details.

Connects #371 

## Testing Instructions

* Check out this branch and `beekeepers start`
* Ensure the CDL layer loads and works correctly
* Also check the main app, ensure it loads the CDL layer correctly too