### PR TITLE
Split combined Floral scores into three top level scores

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -48,6 +48,9 @@ const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
     } else if (!Object.keys(apiary.scores[forageRange]).length) {
         scoreCard = <div className="spinner" />;
     } else {
+        const scoreLabels = Object.values(INDICATORS).map(i => (
+            <ScoresLabel key={i} indicator={i} scores={[values[i]]} />
+        ));
         scoreCard = (
             <>
                 <div className="card__top">
@@ -63,22 +66,7 @@ const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
                 </div>
                 <div className="card__bottom">
                     <div className="indicator-container">
-                        <ScoresLabel
-                            indicator={INDICATORS.NESTING_QUALITY}
-                            scores={[values[INDICATORS.NESTING_QUALITY]]}
-                        />
-                        <ScoresLabel
-                            indicator={INDICATORS.PESTICIDE}
-                            scores={[values[INDICATORS.PESTICIDE]]}
-                        />
-                        <ScoresLabel
-                            indicator="floral"
-                            scores={[
-                                values[INDICATORS.FLORAL_SPRING],
-                                values[INDICATORS.FLORAL_SUMMER],
-                                values[INDICATORS.FLORAL_FALL],
-                            ]}
-                        />
+                        {scoreLabels}
                     </div>
                 </div>
             </>

--- a/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
@@ -3,7 +3,7 @@ import { arrayOf, string } from 'prop-types';
 import Popup from 'reactjs-popup';
 
 import { Score } from '../propTypes';
-import { toDashedString, toSpacedString } from '../utils';
+import { toDashedString } from '../utils';
 import { INDICATOR_DETAILS } from '../constants';
 
 
@@ -33,7 +33,7 @@ const ScoresLabel = ({ indicator, scores }) => {
                     <div className="indicator__number">
                         {score}
                     </div>
-                    <div className="indicator__name">{toSpacedString(indicator)}</div>
+                    <div className="indicator__name">{indicatorDetails.shortLabel}</div>
                 </div>
             )}
             position="top center"

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -17,16 +17,31 @@ export const INDICATOR_DETAILS = {
         name: 'Nesting quality',
         description: 'Lorem ipsum of nesting quality.',
         scoreLabels: ['Nesting'],
+        shortLabel: 'Nesting',
     },
     pesticide: {
         name: 'Pesticide quality',
         description: 'Lorem ipsum of pesticide quality.',
         scoreLabels: ['Pesticide'],
+        shortLabel: 'Pesticide',
     },
-    floral: {
-        name: 'Floral quality',
-        description: 'Lorem ipsum of floral quality.',
-        scoreLabels: ['Spring', 'Summer', 'Fall'],
+    floral_spring: {
+        name: 'Spring Floral quality',
+        description: 'Lorem ipsum of spring floral quality.',
+        scoreLabels: ['Spring Floral'],
+        shortLabel: 'Spr. Floral',
+    },
+    floral_summer: {
+        name: 'Summer Floral quality',
+        description: 'Lorem ipsum of summer floral quality.',
+        scoreLabels: ['Summer Floral'],
+        shortLabel: 'Sum. Floral',
+    },
+    floral_fall: {
+        name: 'Fall Floral quality',
+        description: 'Lorem ipsum of fall floral quality.',
+        scoreLabels: ['Fall Floral'],
+        shortLabel: 'Fall Floral',
     },
 };
 


### PR DESCRIPTION
## Overview

Splits the combined Floral scores into three top-level entries.

Connects #435 

### Demo

![image](https://user-images.githubusercontent.com/1430060/51637501-fe2d1b80-1f29-11e9-9840-61ae0dc59a71.png)

### Notes

This doesn't quite match the styling in the issue, because I imagine that's being worked on separately by @jfrankl.

## Testing Instructions

* Check out this branch and `./scripts/beekeepers.sh start`
* Look at apiaries in the sidebar, ensure they match the new look proposed in the card