### PR TITLE
Fix Apiary Add / Remove Behavior on Sort

### DIFF
--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -203,7 +203,7 @@ export function login(form) {
                     username: data.username || '',
                     authError: '',
                     message: '',
-                    isStaff: data.is_staff,
+                    isStaff: data.is_staff || false,
                     userId: data.id || null,
                     userSurvey: data.beekeeper_survey,
                 }));

--- a/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
@@ -34,21 +34,21 @@ class Sidebar extends Component {
             dispatch,
         } = this.props;
 
-        // Make a deep copy of the apiaries to sort
-        const apiaries = JSON.parse(JSON.stringify(unsortedApiaries));
-
-        if (apiaries.length === 0) {
+        if (unsortedApiaries.length === 0) {
             return <Splash />;
         }
 
-        if (sortBy !== DEFAULT_SORT) {
-            apiaries.sort((a, b) => {
+        // unsortedApiaries is in DEFAULT_SORT already, so can be used directly.
+        // In other cases, we make a deep copy and sort that, so as not to alter
+        // the redux state out of band.
+        const apiaries = sortBy === DEFAULT_SORT
+            ? unsortedApiaries
+            : JSON.parse(JSON.stringify(unsortedApiaries)).sort((a, b) => {
                 if (!b.scores[forageRange][sortBy] || !a.scores[forageRange][sortBy]) {
                     return 0;
                 }
                 return b.scores[forageRange][sortBy].data - a.scores[forageRange][sortBy].data;
             });
-        }
 
         const apiaryCards = apiaries.map(apiary => (
             <ApiaryCard

--- a/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
@@ -41,17 +41,7 @@ class Sidebar extends Component {
             return <Splash />;
         }
 
-        if (sortBy === DEFAULT_SORT) {
-            apiaries.sort((a, b) => {
-                if (a.marker.length === b.marker.length) {
-                    if (a.marker < b.marker) { return -1; }
-                    if (a.marker > b.marker) { return 1; }
-                    return 0;
-                }
-
-                return a.marker.length - b.marker.length;
-            });
-        } else {
+        if (sortBy !== DEFAULT_SORT) {
             apiaries.sort((a, b) => {
                 if (!b.scores[forageRange][sortBy] || !a.scores[forageRange][sortBy]) {
                     return 0;

--- a/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
@@ -28,11 +28,14 @@ class Sidebar extends Component {
 
     render() {
         const {
-            apiaries,
+            apiaries: unsortedApiaries,
             forageRange,
             sortBy,
             dispatch,
         } = this.props;
+
+        // Make a deep copy of the apiaries to sort
+        const apiaries = JSON.parse(JSON.stringify(unsortedApiaries));
 
         if (apiaries.length === 0) {
             return <Splash />;


### PR DESCRIPTION
## Overview

Previously, we would inadvertently sort the apiaries in place, causing their order in the redux state to be different. This interfered with the marker assignment for new apiaries, a function that assumes that the list in redux state is sorted by the default order.

Since changing the ordering of the redux state was inadvertent, this is now fixed by making a deep copy and sorting that when a non-default sort order is specified.

Also fixes a small issue where the Header component's prop type check would fail because `isStaff` was `undefined` for non-logged-in users.

Connects #437 

### Demo

![2019-01-28 11 55 06](https://user-images.githubusercontent.com/1430060/51852308-d6580200-22f3-11e9-83fc-eb4698893817.gif)

### Notes

The third commit 69bab1e basically wipes out the first two, so they could've been dropped, but I've preserved them to show the process of thought.

## Testing Instructions

* Check out this branch
* Add a few apiaries. Change the sort order so that the last one in the default sort is not at the bottom.
* Add a new apiary. Ensure that it is assigned the correct marker.
* Delete an apiary. Ensure the correct one is removed.
* Ensure sorting works correctly as before.