### PR TITLE
Reset User Survey form state on submit

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -9,7 +9,7 @@ import { arrayToSemicolonDelimitedString } from '../utils';
 class UserSurveyModal extends Component {
     constructor(props) {
         super(props);
-        this.state = {
+        this.initialState = {
             // each form input corresponds to a state var
             contribution_level: 'PRO',
             phone: '',
@@ -38,6 +38,7 @@ class UserSurveyModal extends Component {
             equipment_top_bar: '',
             equipment_other: '',
         };
+        this.state = this.initialState;
         this.handleChange = this.handleChange.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
     }
@@ -89,6 +90,8 @@ class UserSurveyModal extends Component {
             equipment,
         });
         dispatch(createUserSurvey(form));
+
+        this.setState(this.initialState);
     }
 
     render() {


### PR DESCRIPTION
## Overview

Previously, we did not clear out the state of the User Survey form when it was submitted. This led to previous values being reused if a user were to sign in to one account, fill out the survey, sign out, and sign in to another account, and fill it out again.

To prevent this from happening, we now clear the local state when the form is submitted.

Connects #409 

## Testing Instructions

* Make sure you have two accounts that haven't filled out the User Survey. One way of doing this would be to delete two rows from the `beekeepers_usersurvey` table for the two accounts you're picking.
* Log in as the first account. Fill out the user survey. Make sure you specify a phone number.
* Log out. Log in as the second account. Ensure the user survey form is shown with initial values. Make sure the phone number field is empty.