### PR TITLE
Ensure user options are atop Survey Cards

### DIFF
--- a/src/icp/apps/beekeepers/sass/06_components/_navbar.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_navbar.scss
@@ -14,6 +14,7 @@
         position: absolute;
         top: 45px;
         right: 0;
+        z-index: 5;
         display: none;
         padding: 0 1rem;
         background: $color-white;


### PR DESCRIPTION
## Overview

Because we use the score labels as hover items, when a user hovers on them, the Popup library adds an inline style of `{ position: "relative" }` to the score label. This by default renders above the absolutely positioned user options dropdown. To fix this, we give the dropdown a small z-index.

Connects #438 

### Demo

![image](https://user-images.githubusercontent.com/1430060/51859785-fabcda00-2305-11e9-9ac6-1125c873dc4d.png)

## Testing Instructions

* Check out this branch and `beekeepers start`
* Add a number of apiaries
* Scroll up, then hover over the user options dropdown. Ensure the options are not obscured.