### PR TITLE
Add a tooltip to Apiary Card buttons

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -59,9 +59,24 @@ const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
                         <div className="card__name">{name}</div>
                     </div>
                     <div className="card__buttons">
-                        <CardButton icon="star" filled={starred} onClick={onStar} />
-                        <CardButton icon="clipboard" filled={surveyed} onClick={onSurvey} />
-                        <CardButton icon="trash" filled onClick={onDelete} />
+                        <CardButton
+                            icon="star"
+                            filled={starred}
+                            tooltip="Mark apiary as important"
+                            onClick={onStar}
+                        />
+                        <CardButton
+                            icon="clipboard"
+                            filled={surveyed}
+                            tooltip="Include apiary in surveys"
+                            onClick={onSurvey}
+                        />
+                        <CardButton
+                            icon="trash"
+                            filled
+                            tooltip="Delete apiary"
+                            onClick={onDelete}
+                        />
                     </div>
                 </div>
                 <div className="card__bottom">

--- a/src/icp/apps/beekeepers/js/src/components/CardButton.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/CardButton.jsx
@@ -1,13 +1,19 @@
 import React from 'react';
 import { bool, func, string } from 'prop-types';
 
-const CardButton = ({ icon, filled, onClick }) => {
+const CardButton = ({
+    icon,
+    filled,
+    tooltip,
+    onClick,
+}) => {
     const fillOrOutline = filled ? 'fill' : 'outline';
 
     return (
         <button
             type="button"
             className="card__button"
+            title={tooltip}
             onClick={onClick}
         >
             <i className={`icon-${icon}-${fillOrOutline}`} />
@@ -18,6 +24,7 @@ const CardButton = ({ icon, filled, onClick }) => {
 CardButton.propTypes = {
     icon: string.isRequired,
     filled: bool.isRequired,
+    tooltip: string.isRequired,
     onClick: func,
 };
 


### PR DESCRIPTION
## Overview

The tooltips help explain the purpose of each icon button. The copy was slightly modified from the original card in accordance with discussion, and to ensure each statement started with a verb, to better describe the action.

Connects #376 

### Demo

![2019-01-28 14 21 30](https://user-images.githubusercontent.com/1430060/51860857-b67f0900-2308-11e9-84f8-766f70cdd0b2.gif)

Tagging @dboyer 	for visual review.

## Testing Instructions

* Check out this branch and `beekeepers start`
* Hover over the three action buttons on an apiary. Ensure you see a tooltip explaining its purpose.