### PR TITLE
Update Settings for Domain Change

### DIFF
--- a/src/icp/apps/home/views.py
+++ b/src/icp/apps/home/views.py
@@ -15,7 +15,8 @@ from apps.modeling.models import Project, Scenario
 
 
 def home_page(request):
-    beekeepers = 'beekeepers' in request.GET
+    beekeepers = ('app.beescape.org' in request.get_host() or
+                  'beekeepers' in request.GET)
     template = 'beekeepers/beekeepers.html' if beekeepers else 'home/home.html'
     return render_to_response(template, get_context(request))
 

--- a/src/icp/icp/settings/production.py
+++ b/src/icp/icp/settings/production.py
@@ -26,6 +26,8 @@ if not instance_metadata:
 ALLOWED_HOSTS = [
     'app.pollinationmapper.org',
     'staging.app.pollinationmapper.org',
+    'app.beescape.org',
+    'staging.app.beescape.org',
     '.elb.amazonaws.com',
     'localhost'
 ]


### PR DESCRIPTION
## Overview

Add support for staging and production domains for the beekeepers app. The `?beekeepers` query string parameter is kept for local development.

Connects #432 

### Demo

![image](https://user-images.githubusercontent.com/1430060/51869819-ba6a5580-231f-11e9-85dc-12e84cc6fa6a.png)

## Testing Instructions

* Edit your `/etc/hosts` file (`$ sudo vim /etc/hosts`), and add this line at the very bottom:

      127.0.0.1 app.beescape.org

* Check out this branch
* Add the following line to `base.py` (to allow this domain during development):

    ```diff
    diff --git a/src/icp/icp/settings/base.py b/src/icp/icp/settings/base.py
    index 5bbb8ceb..b4126c6d 100644
    --- a/src/icp/icp/settings/base.py
    +++ b/src/icp/icp/settings/base.py
    @@ -208,6 +208,7 @@ SECRET_KEY = get_env_setting('DJANGO_SECRET_KEY')
     ALLOWED_HOSTS = [
         '.internal.azavea.com',
         'localhost',
    +    'app.beescape.org',
     ]
     # END SITE CONFIGURATION
    ```

* Go to http://app.beescape.org:8000/ and ensure you see the beekeepers app.
* Go to http://localhost:8000/?beekeepers and ensure you see the beekeepers app.
* Go to http://localhost:8000/ and ensure you see the Pollination Mapper.
* Remove the added line from `base.py` (`$ git reset --hard HEAD`)
* Remove the added line from `/etc/hosts`