### PR TITLE
Add copy to app

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/EmptySurveyView.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/EmptySurveyView.jsx
@@ -6,14 +6,12 @@ export default function () {
     return (
         <div className="survey empty">
             <div className="survey__header empty">
-                Add locations of interest
+                Add your apiaries
             </div>
             <div className="survey__body">
                 <div>
-                    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-                    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-                    minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-                    aliquip ex ea commodo consequat.
+                    Please drop a pin to locate your apiaries on the map. Then come back to this
+                    page and select the apiaries that you want to include in the survey.
                 </div>
                 <Link to="/" className="survey__button">Go to location finder</Link>
             </div>

--- a/src/icp/apps/beekeepers/js/src/components/Header.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Header.jsx
@@ -88,14 +88,14 @@ const Header = ({ dispatch, username, isStaff }) => {
         <header className="header">
             <div className="navbar">
                 <div className="navbar__logo">
-                    Landscape4Bees
+                    Beescape
                     <NavLink exact to="/" className="navbar__item">Location finder</NavLink>
                     <NavLink to="/survey" className="navbar__item">Survey</NavLink>
                 </div>
                 <ul className="navbar__items">
                     <li className="navbar__item">
                         <button type="button" className="navbar__button">
-                            About
+                            Home
                         </button>
                     </li>
                     <li className="navbar__item">

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -65,7 +65,7 @@ class Map extends Component {
                     categories: ['Address', 'Postal'],
                 }),
             ],
-            placeholder: 'Find location',
+            placeholder: 'Search location',
             expanded: true,
             collapseAfterResult: false,
             position: 'topleft',

--- a/src/icp/apps/beekeepers/js/src/components/ParticipateModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ParticipateModal.jsx
@@ -23,9 +23,14 @@ const ParticipateModal = ({ isParticipateModalOpen, dispatch }) => (
                 </div>
                 <div className="authModal__content">
                     <div className="title">
-                        Help give the beekeeping community better data!
+                        Help us see the world as a bee!
                     </div>
-                    Lorem ipsum
+                    Our goal is to give beekeepers, gardeners, and growers detailed information
+                    about the quality of their landscapes for bees, and site-specific
+                    recommendations for land and bee management practices. But, to do this, we
+                    need your help, so we can have data from many diverse landscapes! If you
+                    have a wild bee hotel and would like to participate in our study, please
+                    click here. If you are a beekeeper, please follow the link below.
                 </div>
                 <div className="authModal__footer">
                     <button

--- a/src/icp/apps/beekeepers/js/src/components/Splash.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Splash.jsx
@@ -5,21 +5,21 @@ export default function () {
         <div className="sidebar splash">
             <div className="splash__content">
                 <h2 className="splash__header">
-                    Locate your next bee hive anywhere in the world
+                    Get a bees’ eye view of your landscape!
                 </h2>
                 <p>
-                    {/* TODO Replace with actual content */}
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-                    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-                    enim ad minim veniam, quis nostrud exercitation ullamco laboris
-                    nisi ut aliquip ex ea commodo consequat.
+                    Managed honey bees and wild bees travel far from their nests to find food.
+                    What are your bees experiencing during their journey? This tool will help
+                    you understand how the landscape surrounding your apiary, garden, or farm
+                    stacks up in terms of the floral resources bees can find, the pesticides
+                    they encounter, and, for wild bees, the nesting sites that are available.
                 </p>
                 <div className="infobox">
                     <div className="infobox__title">
                         Get Started
                     </div>
                     <div className="infobox__body">
-                        Click on the map to see how it stacks up
+                        Click on the map to see how your landscape stacks up!
                     </div>
                 </div>
             </div>

--- a/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
@@ -60,8 +60,11 @@ const SurveyView = ({ apiaries, isProUser }) => {
             </div>
             <div className="survey__body">
                 <div>
-                    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-                    eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                    Here, you will find links to the available surveys for your selected apiaries.
+                    If the link is in red, it is a reminder to add information. If the link is in
+                    green, it means the information has already been added. You can add more
+                    apiaries at any time. Please note that you need to complete the survey after
+                    you initiate it - it is not possible to partially save your work.
                 </div>
                 <div className="survey__body--section">
                     <h2 className="survey__title">Response needed</h2>

--- a/src/icp/apps/beekeepers/js/src/components/Tooltip.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Tooltip.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import Popup from 'reactjs-popup';
 
-import { arrayOf, string } from 'prop-types';
+import { arrayOf, shape, string } from 'prop-types';
 
 const Tooltip = ({ description }) => {
-    const sections = description.map(d => <div className="tooltip__text" key={d}>{d}</div>);
+    const sections = description.map(({ title, body }) => (
+        <div className="tooltip__text" key={body}>
+            <strong>{title}</strong>
+            <span>{body}</span>
+        </div>
+    ));
     return (
         <Popup
             trigger={<i className="icon-info-circle" />}
@@ -20,7 +25,10 @@ const Tooltip = ({ description }) => {
 };
 
 Tooltip.propTypes = {
-    description: arrayOf(string).isRequired,
+    description: arrayOf(shape({
+        title: string.isRequired,
+        body: string.isRequired,
+    })).isRequired,
 };
 
 export default Tooltip;

--- a/src/icp/apps/beekeepers/js/src/components/Tooltip.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Tooltip.jsx
@@ -7,7 +7,7 @@ const Tooltip = ({ description }) => {
     const sections = description.map(d => <div className="tooltip__text" key={d}>{d}</div>);
     return (
         <Popup
-            trigger={<span className="info">ℹ</span>}
+            trigger={<i className="icon-info-circle" />}
             position="top center"
             className="tooltip"
             on="hover"

--- a/src/icp/apps/beekeepers/js/src/components/Tooltip.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Tooltip.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Popup from 'reactjs-popup';
+
+import { arrayOf, string } from 'prop-types';
+
+const Tooltip = ({ description }) => {
+    const sections = description.map(d => <div className="tooltip__text" key={d}>{d}</div>);
+    return (
+        <Popup
+            trigger={<span className="info">ℹ</span>}
+            position="top center"
+            className="tooltip"
+            on="hover"
+        >
+            <>
+                {sections}
+            </>
+        </Popup>
+    );
+};
+
+Tooltip.propTypes = {
+    description: arrayOf(string).isRequired,
+};
+
+export default Tooltip;

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -146,7 +146,8 @@ class UserSurveyModal extends Component {
                         <div>User survey</div>
                     </div>
                     <div className="authModal__content">
-                        <div className="title">Fill out your user survey</div>
+                        <div className="title">Beescape Team Registration</div>
+                        Please provide us with some basic information about your honey bees.
                         <form className="form" onSubmit={this.handleSubmit}>
                             {errorWarning}
                             <div className="form__group">
@@ -463,7 +464,7 @@ class UserSurveyModal extends Component {
                                         onChange={this.handleChange}
                                         value="8_FRAME_LANGSTROTH"
                                     />
-                                    <label htmlFor="equipment_8_frame">8 frame langstroth</label>
+                                    <label htmlFor="equipment_8_frame">8 frame Langstroth</label>
                                 </div>
                                 <div className="form__checkbox">
                                     <input
@@ -475,7 +476,7 @@ class UserSurveyModal extends Component {
                                         onChange={this.handleChange}
                                         value="10_FRAME_LANGSTROTH"
                                     />
-                                    <label htmlFor="equipment_10_frame">10 frame langstroth</label>
+                                    <label htmlFor="equipment_10_frame">10 frame Langstroth</label>
                                 </div>
                                 <div className="form__checkbox">
                                     <input

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -6,6 +6,13 @@ import { connect } from 'react-redux';
 import { createUserSurvey } from '../actions';
 import { arrayToSemicolonDelimitedString } from '../utils';
 
+import Tooltip from './Tooltip';
+import {
+    CONTRIBUTION_LEVEL_LIGHT_DESCRIPTION,
+    RELOCATE_COLONIES_DESCRIPTION,
+    CONTRIBUTION_LEVEL_PRO_DESCRIPTION,
+} from '../constants';
+
 class UserSurveyModal extends Component {
     constructor(props) {
         super(props);
@@ -153,6 +160,12 @@ class UserSurveyModal extends Component {
                             <div className="form__group">
                                 <label htmlFor="contribution_level">
                                     What level will you contribute at?
+                                    <Tooltip
+                                        description={[
+                                            CONTRIBUTION_LEVEL_LIGHT_DESCRIPTION,
+                                            CONTRIBUTION_LEVEL_PRO_DESCRIPTION,
+                                        ]}
+                                    />
                                 </label>
                                 <select
                                     id="contribution_level"
@@ -242,6 +255,7 @@ class UserSurveyModal extends Component {
                                 <div className="form__checkbox">
                                     <label htmlFor="relocate">
                                         Do you relocate your colonies throughout the year?
+                                        <Tooltip description={[RELOCATE_COLONIES_DESCRIPTION]} />
                                     </label>
                                     <input
                                         type="checkbox"

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -101,8 +101,17 @@ export const ACTIVITY_SINCE_LAST = [
     'FED_SUGAR',
 ];
 
-export const CONTRIBUTION_LEVEL_LIGHT_DESCRIPTION = 'Light: You will be asked to fill out a survey about your bees in November and April.';
+export const CONTRIBUTION_LEVEL_LIGHT_DESCRIPTION = {
+    title: 'Light: ',
+    body: 'You will be asked to fill out a survey about your bees in November and April.',
+};
 
-export const CONTRIBUTION_LEVEL_PRO_DESCRIPTION = 'Pro: You will be asked to fill out a monthly survey, providing information for one to three colonies per apiary. This information includes colony size, Varroa counts, and colony management. You can access the surveys later, so you can also see how your colonies perform over time.';
+export const CONTRIBUTION_LEVEL_PRO_DESCRIPTION = {
+    title: 'Pro: ',
+    body: 'You will be asked to fill out a monthly survey, providing information for one to three colonies per apiary. This information includes colony size, Varroa counts, and colony management. You can access the surveys later, so you can also see how your colonies perform over time.',
+};
 
-export const RELOCATE_COLONIES_DESCRIPTION = 'At this point, we are only gathering data on colonies that remain in one location throughout the year.';
+export const RELOCATE_COLONIES_DESCRIPTION = {
+    title: '',
+    body: 'At this point, we are only gathering data on colonies that remain in one location throughout the year.',
+};

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -100,3 +100,9 @@ export const ACTIVITY_SINCE_LAST = [
     'FED_POLLEN_PROTEIN',
     'FED_SUGAR',
 ];
+
+export const CONTRIBUTION_LEVEL_LIGHT_DESCRIPTION = 'Light: You will be asked to fill out a survey about your bees in November and April.';
+
+export const CONTRIBUTION_LEVEL_PRO_DESCRIPTION = 'Pro: You will be asked to fill out a monthly survey, providing information for one to three colonies per apiary. This information includes colony size, Varroa counts, and colony management. You can access the surveys later, so you can also see how your colonies perform over time.';
+
+export const RELOCATE_COLONIES_DESCRIPTION = 'At this point, we are only gathering data on colonies that remain in one location throughout the year.';

--- a/src/icp/apps/beekeepers/sass/06_components/_icons.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_icons.scss
@@ -5,3 +5,17 @@
 .icon-clipboard-fill {
     color: $color-clipboard;
 }
+
+.icon-info-circle {
+    padding: 5px;
+}
+
+.tooltip {
+    min-width: fit-content;
+    max-width: 500px;
+
+    &__text {
+        font: $font-size-xs;
+        font-weight: $font-weight-light;
+    }
+}

--- a/src/icp/apps/beekeepers/sass/06_components/_modal.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_modal.scss
@@ -102,17 +102,3 @@
     width: 400px !important;
     padding: 0 !important;
 }
-
-.info {
-    padding: 5px;
-}
-
-.tooltip {
-    min-width: fit-content;
-    max-width: 500px;
-
-    &__text {
-        font: $font-size-xs;
-        font-weight: $font-weight-light;
-    }
-}

--- a/src/icp/apps/beekeepers/sass/06_components/_modal.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_modal.scss
@@ -102,3 +102,17 @@
     width: 400px !important;
     padding: 0 !important;
 }
+
+.info {
+    padding: 5px;
+}
+
+.tooltip {
+    min-width: fit-content;
+    max-width: 500px;
+
+    &__text {
+        font: $font-size-xs;
+        font-weight: $font-weight-light;
+    }
+}

--- a/src/icp/apps/beekeepers/sass/06_components/_tooltip.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_tooltip.scss
@@ -1,0 +1,5 @@
+.tooltip {
+    &__text {
+        margin-bottom: 5px;
+    }
+}

--- a/src/icp/apps/beekeepers/templates/beekeepers/beekeepers.html
+++ b/src/icp/apps/beekeepers/templates/beekeepers/beekeepers.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
-    <title>Beekeepers App</title>
+    <title>Beescape</title>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/normalize/7.0.0/normalize.min.css">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.css">
 </head>

--- a/src/icp/apps/user/views.py
+++ b/src/icp/apps/user/views.py
@@ -139,9 +139,11 @@ def sign_up(request):
     form = RegistrationFormUniqueEmail(request.POST)
 
     if form.is_valid():
+        from_beekeepers = ('app.beescape.org' in request.get_host() or
+                           'beekeepers' in request.GET)
         user = view.register(request, form)
         origin_app = \
-            UserProfile.BEEKEEPERS if 'beekeepers' in request.GET else \
+            UserProfile.BEEKEEPERS if from_beekeepers else \
             UserProfile.POLLINATION
 
         UserProfile.objects.create(

--- a/src/icp/templates/registration/activation_email.html
+++ b/src/icp/templates/registration/activation_email.html
@@ -27,11 +27,20 @@
         {{site.domain}}{% url 'registration_activate' activation_key %}
     </a>
 </p>
+
 <p>
-    {% blocktrans with site_name=site.name %}
-    Sincerely,
-    {{ site_name }} Management
-    {% endblocktrans %}
+    {% if "Beekeepers" == user.userprofile.origin_app or "beescape.org" in site.domain %}
+        We are looking forward to working with you to make the world a better
+        place for bees!
+
+        Sincerely,
+        Beescape Team
+    {% else %}
+        {% blocktrans with site_name=site.name %}
+        Sincerely,
+        {{ site_name }} Management
+        {% endblocktrans %}
+    {% endif %}
 </p>
 </body>
 

--- a/src/icp/templates/registration/activation_email.txt
+++ b/src/icp/templates/registration/activation_email.txt
@@ -12,11 +12,19 @@ To activate this account, please click the following link within the next
 
 http://{{site.domain}}{% url 'registration_activate' activation_key %}
 
-{% blocktrans with site_name=site.name %}
-Sincerely,
-{{ site_name }} Management
-{% endblocktrans %}
 
+{% if "Beekeepers" == user.userprofile.origin_app or "beescape.org" in site.domain %}
+    We are looking forward to working with you to make the world a better
+    place for bees!
+
+    Sincerely,
+    Beescape Team
+{% else %}
+    {% blocktrans with site_name=site.name %}
+    Sincerely,
+    {{ site_name }} Management
+    {% endblocktrans %}
+{% endif %}
 
 {% comment %}
 **registration/activation_email.txt**

--- a/src/icp/templates/registration/password_reset_email.html
+++ b/src/icp/templates/registration/password_reset_email.html
@@ -15,7 +15,8 @@ Your username, in case you've forgotten: {{ user.username }}
 
 
 Best regards,
-{{ site_name }} Management
+
+{{ domain }} Management
 
 
 {# This is used by django.contrib.auth #}

--- a/src/icp/templates/registration/registration_base.html
+++ b/src/icp/templates/registration/registration_base.html
@@ -3,7 +3,6 @@
 {% block header %}
 <header>
     <nav id="app-header" class="navbar-watershed">
-        <div class="brand"><a href="{% url 'home_page' %}">Bee Pollinator</a></div>
         <div class="navigation">
         </div>
     </nav>


### PR DESCRIPTION
## Overview

The client provided copy to update around the app, which is full of lorem-ipsum placeholder text. This PR captures all requested changes to date with provided copy.

Connects #433 

### Demo

The only really new thing are tooltips. They're pretty basic.

<img width="488" alt="screen shot 2019-01-31 at 4 38 37 pm" src="https://user-images.githubusercontent.com/10568752/52087252-dca9e080-2576-11e9-83b9-6c30e763530e.png">


### Notes

Still awaiting some text from client.

## Testing Instructions

Most of the copy was copy & paste around the app.

Some of the changes are in email copy -- go through a sign up, activate your account, and resend activation link to make sure you see those changes in your console running `./scripts/debugserver.sh`. The check is not ideal but works I think -- the django templates only receive so much relevant info (I couldn't get a full path name to check for the `?beekeepers` querystring for example. If I missed something, lemme know).