### PR TITLE
Add ability to remove unfetched apiaries

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -36,7 +36,20 @@ const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
     if (!Object.keys(apiary.scores[forageRange]).length && !apiary.fetching) {
         scoreCard = (
             <>
-                Error fetching apiary data
+                <div className="card__top">
+                    <div className="card__identification">
+                        <div className={`marker ${markerClass}`}>{marker}</div>
+                        <div className="card__name">Error fetching apiary data</div>
+                    </div>
+                    <div className="card__buttons">
+                        <CardButton
+                            icon="trash"
+                            filled
+                            tooltip="Delete apiary"
+                            onClick={onDelete}
+                        />
+                    </div>
+                </div>
                 <button
                     type="button"
                     onClick={() => dispatch(fetchApiaryScores([apiary], forageRange))}


### PR DESCRIPTION
## Overview

Currently, if there is a server error while fetching apiary scores, they remain on screen and cannot be removed. By adding the same trash button to them that filled-in apiaries have, we allow the user two exits from the state: to retry and to remove the apiary.

Also, the apiary's marker is also added to the card, so the user can associate the malfunctioning API to the map.

Connects #453 

### Demo

![2019-01-31 17 08 02](https://user-images.githubusercontent.com/1430060/52088768-d4ec3b00-257a-11e9-9708-d7bc2f79a984.gif)

Also tagging @jfrankl 	for visual review.

### Notes

The card asked for an ✖️ but I reused an existing component, and have the "trash" icon instead. I can change that if needed.

## Testing Instructions

* Check out this branch and `beekeepers start`
* Go to [:8000/?beekeepers](http://localhost:8000/?beekeepers)
* Stop the server `vagrant ssh app -c 'sudo service icp-app stop'`
* Add an apiary. See the new failed UI.
* Ensure you can retry. Ensure you can delete it. Ensure deleting an unsaved apiary doesn't cause any network calls.
* Start the server `vagrant ssh app -c 'sudo service icp-app start'`
* Ensure retrying fetches scores correctly