### PR TITLE
Add a confirm submission checkbox to all apiary surveys

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
@@ -196,6 +196,28 @@ class AprilSurveyForm extends Component {
             ? 'Survey results'
             : 'Fill out this survey about your apiary';
 
+        const confirmationButton = completedSurvey
+            ? null
+            : (
+                <div className="form__group">
+                    <label htmlFor="confirmation">
+                        Have you provided all the information available for these
+                        colonies and are ready to submit the survey? Surveys cannot
+                        be edited after submission.
+                    </label>
+                    <input
+                        type="checkbox"
+                        className="form__control"
+                        id="confirmed"
+                        name="confirmed"
+                        required
+                    />
+                    <label htmlFor="confirmation">
+                        Yes
+                    </label>
+                </div>
+            );
+
         const colonyLossReasonCheckboxInputs = this.makeMultipleChoiceInputs('colony_loss_reason', COLONY_LOSS_REASONS);
 
         const surveyForm = (
@@ -218,7 +240,7 @@ class AprilSurveyForm extends Component {
                         />
                         <label htmlFor="colony_loss_reason">
                             What do you think the most likely cause of colony loss was?
-                            Check all that apply.
+                            Check all that apply. Required.
                         </label>
                         {colonyLossReasonCheckboxInputs}
                         <label htmlFor="colony_loss_reason_OTHER">OTHER</label>
@@ -231,6 +253,7 @@ class AprilSurveyForm extends Component {
                             onChange={this.handleChange}
                             disabled={!!completedSurvey}
                         />
+                        {confirmationButton}
                     </div>
                     {submitButton}
                 </form>

--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyForm.jsx
@@ -333,14 +333,31 @@ class MonthlySurveyForm extends Component {
             </div>
         ) : null;
 
-        const submitButton = completed ? null : (
-            <button
-                type="submit"
-                value="Submit"
-                className="button--long"
-            >
-                Submit
-            </button>
+        const submitButtons = completed ? null : (
+            <div className="confirmation form__group">
+                <label htmlFor="confirmation">
+                    Have you provided all the information available for these
+                    colonies and are ready to submit the survey? Surveys cannot
+                    be edited after submission.
+                </label>
+                <input
+                    type="checkbox"
+                    className="form__control"
+                    id="confirmed"
+                    name="confirmed"
+                    required
+                />
+                <label htmlFor="confirmation">
+                    Yes
+                </label>
+                <button
+                    type="submit"
+                    value="Submit"
+                    className="button--long"
+                >
+                    Submit
+                </button>
+            </div>
         );
 
         const tabs = monthlies.map((_, idx) => (
@@ -399,7 +416,7 @@ class MonthlySurveyForm extends Component {
                         </TabList>
                         {tabPanels}
                     </Tabs>
-                    {submitButton}
+                    {submitButtons}
                 </form>
             </>
         );

--- a/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
@@ -266,6 +266,28 @@ class NovemberSurveyForm extends Component {
             ? 'Survey results'
             : 'Fill out this survey about your apiary';
 
+        const confirmationButton = completedSurvey
+            ? null
+            : (
+                <div className="form__group">
+                    <label htmlFor="confirmation">
+                        Have you provided all the information available for these
+                        colonies and are ready to submit the survey? Surveys cannot
+                        be edited after submission.
+                    </label>
+                    <input
+                        type="checkbox"
+                        className="form__control"
+                        id="confirmed"
+                        name="confirmed"
+                        required
+                    />
+                    <label htmlFor="confirmation">
+                        Yes
+                    </label>
+                </div>
+            );
+
         const miteManagementCheckboxInputs = this.makeMultipleChoiceInputs('mite_management', MITE_MANAGEMENT_OPTIONS);
 
         const supplementalSugarInputs = this.makeSeasonalInputs('supplemental_sugar');
@@ -439,6 +461,7 @@ class NovemberSurveyForm extends Component {
                                 />
                             </div>
                         </div>
+                        {confirmationButton}
                     </div>
                     {submitButton}
                 </form>

--- a/src/icp/apps/beekeepers/sass/06_components/_survey.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_survey.scss
@@ -218,10 +218,13 @@
     margin: 15px 0;
     padding-top: 25px;
     font-style: italic;
-    border-top: 1px solid #ccc;
 }
 
 .empty-message {
     font-weight: normal;
     font-size: $font-size-med;
+}
+
+.confirmation {
+    border-top: 1px solid #ccc;
 }


### PR DESCRIPTION
## Overview

A lightweight change to ensure users don't submit incomplete forms, as they are uneditable after submission

Connects #445

### Demo
Monthly:
<img width="624" alt="screen shot 2019-02-04 at 3 21 07 pm" src="https://user-images.githubusercontent.com/10568752/52235009-f148ea00-2890-11e9-9784-cf3a72c147db.png">

In action:
<img width="824" alt="screen shot 2019-02-04 at 2 48 34 pm" src="https://user-images.githubusercontent.com/10568752/52235027-fd34ac00-2890-11e9-83d2-b3f094836c62.png">

## Notes
This UI change is a UX compromise in light of the tight timeline and project constraints.

## Testing Instructions

Pull down branch.
`./scripts/beekeepers.sh start`
Ensure that you cannot submit any apiary survey without checking the box.
Check that opening completed surveys is no problem, either. The confirmation checkbox should not show.