### PR TITLE
Make Yes/No questions a dropdown everywhere

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
@@ -120,6 +120,15 @@ class NovemberSurveyForm extends Component {
                 finalValue = checked ? value : '';
             }
         }
+
+        // Convert boolean strings to bools
+        if (finalValue === 'true') {
+            finalValue = true;
+        }
+        if (finalValue === 'false') {
+            finalValue = false;
+        }
+
         this.setState({ [name]: finalValue });
     }
 
@@ -370,18 +379,17 @@ class NovemberSurveyForm extends Component {
                             <label htmlFor="small_hive_beetles">
                                 Have you observed small hive beetles in your hives?
                             </label>
-                            <input
-                                type="checkbox"
+                            <select
                                 className="form__control"
                                 id="small_hive_beetles"
                                 name="small_hive_beetles"
-                                checked={small_hive_beetles}
+                                value={small_hive_beetles}
                                 onChange={this.handleChange}
                                 disabled={!!completedSurvey}
-                            />
-                            <label htmlFor="small_hive_beetles">
-                                yes
-                            </label>
+                            >
+                                <option key="true" value="true">Yes</option>
+                                <option key="false" value="false">No</option>
+                            </select>
                         </div>
                         <div className="form__group">
                             <label htmlFor="varroa_check_frequency">

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -64,6 +64,15 @@ class UserSurveyModal extends Component {
                 finalValue = checked ? value : '';
             }
         }
+
+        // Convert boolean strings to bools
+        if (finalValue === 'true') {
+            finalValue = true;
+        }
+        if (finalValue === 'false') {
+            finalValue = false;
+        }
+
         this.setState({ [name]: finalValue });
     }
 
@@ -253,23 +262,20 @@ class UserSurveyModal extends Component {
                                 </select>
                             </div>
                             <div className="form__group">
-                                <div className="form__checkbox">
-                                    <label htmlFor="relocate">
-                                        Do you relocate your colonies throughout the year?
-                                        <Tooltip description={[RELOCATE_COLONIES_DESCRIPTION]} />
-                                    </label>
-                                    <input
-                                        type="checkbox"
-                                        className="form__control"
-                                        id="relocate"
-                                        name="relocate"
-                                        checked={relocate}
-                                        onChange={this.handleChange}
-                                    />
-                                    <label htmlFor="relocate">
-                                        Yes
-                                    </label>
-                                </div>
+                                <label htmlFor="relocate">
+                                    Do you relocate your colonies throughout the year?
+                                    <Tooltip description={[RELOCATE_COLONIES_DESCRIPTION]} />
+                                </label>
+                                <select
+                                    className="form__control"
+                                    id="relocate"
+                                    name="relocate"
+                                    value={relocate}
+                                    onChange={this.handleChange}
+                                >
+                                    <option key="true" value="true">Yes</option>
+                                    <option key="false" value="false">No</option>
+                                </select>
                             </div>
                             <div className="form__group">
                                 <label htmlFor="income">
@@ -355,23 +361,20 @@ class UserSurveyModal extends Component {
                                 </select>
                             </div>
                             <div className="form__group">
-                                <div className="form__checkbox">
-                                    <label htmlFor="varroa_management">
-                                        Do you manage for Varroa?
-                                        <Tooltip description={[VARROA_MANAGEMENT_DESCRIPTION]} />
-                                    </label>
-                                    <input
-                                        type="checkbox"
-                                        className="form__control"
-                                        id="varroa_management"
-                                        name="varroa_management"
-                                        checked={varroa_management}
-                                        onChange={this.handleChange}
-                                    />
-                                    <label htmlFor="varroa_management">
-                                        Yes
-                                    </label>
-                                </div>
+                                <label htmlFor="varroa_management">
+                                    Do you manage for Varroa?
+                                    <Tooltip description={[VARROA_MANAGEMENT_DESCRIPTION]} />
+                                </label>
+                                <select
+                                    className="form__control"
+                                    id="varroa_management"
+                                    name="varroa_management"
+                                    value={varroa_management}
+                                    onChange={this.handleChange}
+                                >
+                                    <option key="true" value="true">Yes</option>
+                                    <option key="false" value="false">No</option>
+                                </select>
                             </div>
                             <div className="form__group">
                                 <label htmlFor="varroa_management_trigger">
@@ -387,22 +390,19 @@ class UserSurveyModal extends Component {
                                 />
                             </div>
                             <div className="form__group">
-                                <div className="form__checkbox">
-                                    <label htmlFor="purchased_queens">
-                                        Do you buy queens, nucs or packages?
-                                    </label>
-                                    <input
-                                        type="checkbox"
-                                        className="form__control"
-                                        id="purchased_queens"
-                                        name="purchased_queens"
-                                        checked={purchased_queens}
-                                        onChange={this.handleChange}
-                                    />
-                                    <label htmlFor="purchased_queens">
-                                        Yes
-                                    </label>
-                                </div>
+                                <label htmlFor="purchased_queens">
+                                    Do you buy queens, nucs or packages?
+                                </label>
+                                <select
+                                    className="form__control"
+                                    id="purchased_queens"
+                                    name="purchased_queens"
+                                    value={purchased_queens}
+                                    onChange={this.handleChange}
+                                >
+                                    <option key="true" value="true">Yes</option>
+                                    <option key="false" value="false">No</option>
+                                </select>
                             </div>
                             <div className="form__group">
                                 <label htmlFor="purchased_queens_sources">
@@ -418,22 +418,19 @@ class UserSurveyModal extends Component {
                                 />
                             </div>
                             <div className="form__group">
-                                <div className="form__checkbox">
-                                    <label htmlFor="resistant_queens">
-                                        Do you use Varroa-resistant queens?
-                                    </label>
-                                    <input
-                                        type="checkbox"
-                                        className="form__control"
-                                        id="resistant_queens"
-                                        name="resistant_queens"
-                                        checked={resistant_queens}
-                                        onChange={this.handleChange}
-                                    />
-                                    <label htmlFor="resistant_queens">
-                                        Yes
-                                    </label>
-                                </div>
+                                <label htmlFor="resistant_queens">
+                                    Do you use Varroa-resistant queens?
+                                </label>
+                                <select
+                                    className="form__control"
+                                    id="resistant_queens"
+                                    name="resistant_queens"
+                                    value={resistant_queens}
+                                    onChange={this.handleChange}
+                                >
+                                    <option key="true" value="true">Yes</option>
+                                    <option key="false" value="false">No</option>
+                                </select>
                             </div>
                             <div className="form__group">
                                 <label htmlFor="resistant_queens_genetics">
@@ -449,22 +446,19 @@ class UserSurveyModal extends Component {
                                 />
                             </div>
                             <div className="form__group">
-                                <div className="form__checkbox">
-                                    <label htmlFor="rear_queens">
-                                        Do you rear queens?
-                                    </label>
-                                    <input
-                                        type="checkbox"
-                                        className="form__control"
-                                        id="rear_queens"
-                                        name="rear_queens"
-                                        checked={rear_queens}
-                                        onChange={this.handleChange}
-                                    />
-                                    <label htmlFor="rear_queens">
-                                        Yes
-                                    </label>
-                                </div>
+                                <label htmlFor="rear_queens">
+                                    Do you rear queens?
+                                </label>
+                                <select
+                                    className="form__control"
+                                    id="rear_queens"
+                                    name="rear_queens"
+                                    value={rear_queens}
+                                    onChange={this.handleChange}
+                                >
+                                    <option key="true" value="true">Yes</option>
+                                    <option key="false" value="false">No</option>
+                                </select>
                             </div>
                             <div className="form__group">
                                 <label htmlFor="equipment">


### PR DESCRIPTION
## Overview

Previously, in the User Survey, Yes/No questions were presented as checkboxes. These are changed to be dropdowns, consistent with Apiary Surveys.

The final Confirmation checkbox for Apiary surveys is left as is.

Connects #466 

### Demo

![image](https://user-images.githubusercontent.com/1430060/52500581-5ca1fd00-2bac-11e9-82ae-e31cebbcb36e.png)

![image](https://user-images.githubusercontent.com/1430060/52500862-eb167e80-2bac-11e9-9ba1-549faede3ad5.png)


## Testing Instructions

* Check out this branch and `beekeepers start`
* Go to [:8000/?beekeepers](http://localhost:8000/?beekeepers) and ensure you have a user without a User Survey
* Log in as that user.
  - Ensure you see the User Survey.
  - Ensure all the Yes/No questions are shown as dropdowns.
  - Ensure they have the correct default values.
* Change some of them. Submit the form. Inspect the database.
  - Ensure both Yes and No values are recorded correctly.