### PR TITLE
Add tooltips to more survey questions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -134,8 +134,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     }.merge(VAGRANT_NETWORK_OPTIONS)
     # Testem server
     app.vm.network "forwarded_port", {
-      guest: 7357,
-      host: 7357
+      guest: 7358,
+      host: 7358
     }.merge(VAGRANT_NETWORK_OPTIONS)
 
     app.ssh.forward_x11 = true

--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
@@ -7,43 +7,63 @@ import {
     ACTIVITY_SINCE_LAST,
     VARROA_CHECK_METHODS,
     MITE_MANAGEMENT_OPTIONS,
+    VARROA_ALCOHOL_WASH_DESCRIPTION,
+    VARROA_STICKYBOARD_DESCRIPTION,
+    VARROA_SUGAR_SHAKE_DESCRIPTION,
+    DEEP_HIVE_BODIES_DESCRIPTION,
+    MEDIUM_HIVE_BODIES_DESCRIPTION,
+    SHALLOW_HIVE_BODIES_DESCRIPTION,
+    QUEEN_STOCK_DESCRIPTION,
+    QUEENRIGHT_DESCRIPTION,
 } from '../constants';
-
 import { MonthlySurveyColony } from '../propTypes';
+
+import Tooltip from './Tooltip';
+
 
 class MonthlySurveyColonyForm extends Component {
     inputFactory(inputType) {
         const { data, onChange } = this.props;
         const disabled = data.id !== null;
 
-        return (key, label, required) => (
-            <div className="form__group">
-                <label htmlFor={key}>
-                    {label}
-                </label>
-                <input
-                    type={inputType}
-                    className="form__control"
-                    id={key}
-                    name={key}
-                    value={data[key]}
-                    onChange={onChange}
-                    disabled={disabled}
-                    required={required}
-                />
-            </div>
-        );
+        return (key, label, required, tooltipDescription) => {
+            const tooltip = tooltipDescription
+                ? <Tooltip description={[tooltipDescription]} />
+                : null;
+            return (
+                <div className="form__group">
+                    <label htmlFor={key}>
+                        {label}
+                        {tooltip}
+                    </label>
+                    <input
+                        type={inputType}
+                        className="form__control"
+                        id={key}
+                        name={key}
+                        value={data[key]}
+                        onChange={onChange}
+                        disabled={disabled}
+                        required={required}
+                    />
+                </div>
+            );
+        };
     }
 
-    inputSelect(key, label, options) {
+    inputSelect(key, label, options, tooltipDescription) {
         const { data, onChange } = this.props;
         const value = data[key] && data[key].toString();
         const disabled = data.id !== null;
+        const tooltip = tooltipDescription
+            ? <Tooltip description={tooltipDescription} />
+            : null;
 
         return (
             <div className="form__group">
                 <label htmlFor={key}>
                     {label}
+                    {tooltip}
                 </label>
                 <select
                     className="form__control"
@@ -128,6 +148,13 @@ class MonthlySurveyColonyForm extends Component {
                 <div className="form__group">
                     <label htmlFor="varroa_count_technique">
                         How did you do a Varroa count?
+                        <Tooltip
+                            description={[
+                                VARROA_ALCOHOL_WASH_DESCRIPTION,
+                                VARROA_SUGAR_SHAKE_DESCRIPTION,
+                                VARROA_STICKYBOARD_DESCRIPTION,
+                            ]}
+                        />
                     </label>
                     {this.makeMultipleChoiceInputs('varroa_count_technique', VARROA_CHECK_METHODS)}
                     <div className="form__secondary">
@@ -149,6 +176,13 @@ class MonthlySurveyColonyForm extends Component {
                 {colonyLossReasons}
                 <div className="form__group">
                     Total number of hive bodies and supers:
+                    <Tooltip
+                        description={[
+                            DEEP_HIVE_BODIES_DESCRIPTION,
+                            MEDIUM_HIVE_BODIES_DESCRIPTION,
+                            SHALLOW_HIVE_BODIES_DESCRIPTION,
+                        ]}
+                    />
                     <div className="form__secondary">
                         {inputNumber('num_bodies_supers_deep', 'Deep')}
                         {inputNumber('num_bodies_supers_medium', 'Medium')}
@@ -182,7 +216,7 @@ class MonthlySurveyColonyForm extends Component {
                 {this.inputSelect('queenright', 'Is the colony queenright?', [
                     ['true', 'Yes'],
                     ['false', 'No'],
-                ])}
+                ], [QUEENRIGHT_DESCRIPTION])}
                 {this.inputSelect('same_queen', 'Is this the same queen from the last assessment?', [
                     ['YES', 'Yes: Same Queen'],
                     ['NO_BEEKEEPER_REPLACED', 'No: Beekeeper Replaced'],
@@ -190,7 +224,12 @@ class MonthlySurveyColonyForm extends Component {
                     ['NO_SUPERSEDURE', 'No: Supersedure'],
                     ['NO_QUEEN_DEATH', 'No: Queen Death'],
                 ])}
-                {inputText('queen_stock', 'To the best of your knowledge, what is the stock of the queen?')}
+                {inputText(
+                    'queen_stock',
+                    'To the best of your knowledge, what is the stock of the queen?',
+                    false,
+                    QUEEN_STOCK_DESCRIPTION,
+                )}
                 {this.inputSelect('queen_source', 'Where did the queen come from?', [
                     ['NON_LOCAL_COMMERCIAL', 'Non-local commercial breeder'],
                     ['LOCAL_COMMERCIAL', 'Local commercial breeder'],

--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyForm.jsx
@@ -51,7 +51,7 @@ class MonthlySurveyForm extends Component {
             colony_loss_reason_OTHER: '',
             activity_since_last_REMOVED_HONEY: false,
             activity_since_last_REMOVED_BROOD: false,
-            activity_since_last_FED_POLLEN_PROTEIN: false,
+            activity_since_last_FED_POLLEN_OR_PROTEIN: false,
             activity_since_last_FED_SUGAR: false,
             varroa_count_technique_ALCOHOL_WASH: false,
             varroa_count_technique_SUGAR_SHAKE: false,

--- a/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
@@ -8,9 +8,13 @@ import {
     MITE_MANAGEMENT_OPTIONS,
     SEASONS,
     VARROA_CHECK_METHODS,
+    VARROA_ALCOHOL_WASH_DESCRIPTION,
+    VARROA_STICKYBOARD_DESCRIPTION,
+    VARROA_SUGAR_SHAKE_DESCRIPTION,
 } from '../constants';
 import { arrayToSemicolonDelimitedString, getOrCreateSurveyRequest } from '../utils';
 import { Survey } from '../propTypes';
+import Tooltip from './Tooltip';
 
 
 class NovemberSurveyForm extends Component {
@@ -177,12 +181,15 @@ class NovemberSurveyForm extends Component {
     }
 
     /* eslint-disable react/destructuring-assignment */
-    makeMultipleChoiceInputs(groupName, options) {
+    makeMultipleChoiceInputs(groupName, options, tooltipDescriptions) {
         const { completedSurvey } = this.state;
 
-        return options.map((option) => {
+        return options.map((option, index) => {
             const key = `${groupName}_${option}`;
             const label = option.split('_').join(' ').toLowerCase();
+            const tooltip = tooltipDescriptions
+                ? <Tooltip description={[tooltipDescriptions[index]]} />
+                : null;
             return (
                 <div
                     key={key}
@@ -197,7 +204,10 @@ class NovemberSurveyForm extends Component {
                         onChange={this.handleChange}
                         disabled={!!completedSurvey}
                     />
-                    <label htmlFor={key}>{label}</label>
+                    <label htmlFor={key}>
+                        {label}
+                        {tooltip}
+                    </label>
                 </div>
             );
         });
@@ -294,7 +304,15 @@ class NovemberSurveyForm extends Component {
 
         const supplementalProteinInputs = this.makeSeasonalInputs('supplemental_protein');
 
-        const varroaCheckMethodCheckboxInputs = this.makeMultipleChoiceInputs('varroa_check_method', VARROA_CHECK_METHODS);
+        const varroaCheckMethodCheckboxInputs = this.makeMultipleChoiceInputs(
+            'varroa_check_method',
+            VARROA_CHECK_METHODS,
+            [
+                VARROA_ALCOHOL_WASH_DESCRIPTION,
+                VARROA_SUGAR_SHAKE_DESCRIPTION,
+                VARROA_STICKYBOARD_DESCRIPTION,
+            ],
+        );
 
         const surveyForm = (
             <>

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -11,6 +11,7 @@ import {
     CONTRIBUTION_LEVEL_LIGHT_DESCRIPTION,
     RELOCATE_COLONIES_DESCRIPTION,
     CONTRIBUTION_LEVEL_PRO_DESCRIPTION,
+    VARROA_MANAGEMENT_DESCRIPTION,
 } from '../constants';
 
 class UserSurveyModal extends Component {
@@ -357,6 +358,7 @@ class UserSurveyModal extends Component {
                                 <div className="form__checkbox">
                                     <label htmlFor="varroa_management">
                                         Do you manage for Varroa?
+                                        <Tooltip description={[VARROA_MANAGEMENT_DESCRIPTION]} />
                                     </label>
                                     <input
                                         type="checkbox"

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -97,7 +97,7 @@ export const COLONY_LOSS_REASONS = [
 export const ACTIVITY_SINCE_LAST = [
     'REMOVED_HONEY',
     'REMOVED_BROOD',
-    'FED_POLLEN_PROTEIN',
+    'FED_POLLEN_OR_PROTEIN',
     'FED_SUGAR',
 ];
 
@@ -114,4 +114,49 @@ export const CONTRIBUTION_LEVEL_PRO_DESCRIPTION = {
 export const RELOCATE_COLONIES_DESCRIPTION = {
     title: '',
     body: 'At this point, we are only gathering data on colonies that remain in one location throughout the year.',
+};
+
+export const VARROA_MANAGEMENT_DESCRIPTION = {
+    title: '',
+    body: 'Beekeepers manage for varroa in numerous ways. Chemical treatments include organic acids (oxalic and formic acids), thymol and other menthols, and synthetics. Mechanical strategies include removing drone brood and briefly caging the queen in the summer.',
+};
+
+export const VARROA_ALCOHOL_WASH_DESCRIPTION = {
+    title: '',
+    body: 'The alcohol wash is the gold standard in Varroa monitoring and is recommended due to precision and consistency. Premade cups designed for the alcohol wash work very well. Submerge nurse bees (1/2 cup or 300 bees) in alcohol, shake for 30 seconds, and allow to soak for 30 seconds to 1 minute. Next, strain the bees from the alcohol and count the mites. An important consideration when monitoring for mites is to do things as consistently as possible.',
+};
+
+export const VARROA_SUGAR_SHAKE_DESCRIPTION = {
+    title: '',
+    body: 'The sugar shake or sugar roll method is similar to the alcohol wash. Powdered sugar is used instead of alcohol and the bees are vigorously shaken for 2 minutes or more to dislodge mites. The mites are then separated through a screened lid and counted. This method is less accurate and more time consuming than the alcohol wash but is preferred by beekeepers who want to reduce bee deaths and who are not monitoring large numbers of colonies.',
+};
+
+export const VARROA_STICKYBOARD_DESCRIPTION = {
+    title: '',
+    body: 'Stickyboards are a less reliable form of regular Varroa monitoring. The number of mites that drop can vary greatly and the boards require specific equipment, regular visits to the colonies, and the time to count multiple boards over many days. Mite counts with using this method cannot be integrated into the pro level of participation at this time.',
+};
+
+export const DEEP_HIVE_BODIES_DESCRIPTION = {
+    title: 'Deep hive bodies ',
+    body: 'for 10 frame Langstroth measure 19 ⅞” in length, 16 ¼” wide and 9 ⅝” in height, the frames measures 19” in length and 9 ⅛” in height.',
+};
+
+export const MEDIUM_HIVE_BODIES_DESCRIPTION = {
+    title: 'Medium hive bodies ',
+    body: 'or Illinois super for 10 frame Langstroth measure 19 ⅞” in length, 16 ¼” wide and 6 ⅝” in height, the frames measures 19” in length and 6 ¼” in height.',
+};
+
+export const SHALLOW_HIVE_BODIES_DESCRIPTION = {
+    title: 'Shallow hive bodies ',
+    body: 'or honey super for 10 frame Langstroth measure 19 ⅞” in length, 16 ¼” wide and 5 11/16” in height, the frames measures 19” in length and 5 ⅝” in height.',
+};
+
+export const QUEEN_STOCK_DESCRIPTION = {
+    title: '',
+    body: 'Please note here if your queen came from a particular genetic line such as Russian, Italian, or has Varroa sensitive or mite resistant genetics.',
+};
+
+export const QUEENRIGHT_DESCRIPTION = {
+    title: '',
+    body: 'You can determine if a queen is present by locating her physically or checking for eggs. However, by late fall the queen stops laying eggs. We ask that beekeepers use their best judgement when making the assessments during these times.',
 };

--- a/src/icp/apps/beekeepers/models.py
+++ b/src/icp/apps/beekeepers/models.py
@@ -283,7 +283,7 @@ class MonthlySurvey(models.Model):
         blank=True,
         help_text='Total number of hive bodies and supers (shallow)')
     activity_since_last = models.CharField(
-        # REMOVED_HONEY;REMOVED_BROOD;FED_POLLEN_PROTEIN;FED_SUGAR
+        # REMOVED_HONEY;REMOVED_BROOD;FED_POLLEN_OR_PROTEIN;FED_SUGAR
         max_length=255,
         null=True,
         blank=True,


### PR DESCRIPTION
## Overview

A flurry more of survey questions have tooltips now.

Connects #433

### Demo
A subset of the changes.

![screen shot 2019-02-08 at 2 42 58 pm](https://user-images.githubusercontent.com/10568752/52503492-ae9a5100-2bb3-11e9-8a34-60218d43fd02.png)
![screen shot 2019-02-08 at 2 41 24 pm](https://user-images.githubusercontent.com/10568752/52503493-ae9a5100-2bb3-11e9-9fd6-a51eb14bca7c.png)
![screen shot 2019-02-08 at 2 41 07 pm](https://user-images.githubusercontent.com/10568752/52503494-ae9a5100-2bb3-11e9-968d-1837f928d1b9.png)
<img width="653" alt="screen shot 2019-02-08 at 3 06 47 pm" src="https://user-images.githubusercontent.com/10568752/52503495-ae9a5100-2bb3-11e9-82ac-d54fbe465ece.png">


### Notes

Tooltips are not optimally placed on Firefox. You can probably tell which they are on the demo's above.

I changed of the project ports because of a conflict with another app, harkening back to my suggestion that it would be helpful to keep track of projects and ports for when we start new projects.

## Testing Instructions

Pull down the PR and see tooltips across surveys.