### PR TITLE
Scores in Label Tooltips

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
@@ -38,20 +38,22 @@ const ScoresLabel = ({ indicator, scores }) => {
                 <table className="scoreTable">
                     <thead>
                         <tr>
-                            <th className="scoreTable__th">Min</th>
                             <th className="scoreTable__th">Low</th>
-                            <th className="scoreTable__th">Med</th>
+                            <th className="scoreTable__th">Medium</th>
                             <th className="scoreTable__th">High</th>
-                            <th className="scoreTable__th">Max</th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr>
-                            <td className="scoreTable__td">{indicatorDetails.scoreStops[0]}</td>
-                            <td className="scoreTable__td">{indicatorDetails.scoreStops[1]}</td>
-                            <td className="scoreTable__td">{indicatorDetails.scoreStops[2]}</td>
-                            <td className="scoreTable__td">{indicatorDetails.scoreStops[3]}</td>
-                            <td className="scoreTable__td">{indicatorDetails.scoreStops[4]}</td>
+                            <td className="scoreTable__td">
+                                {`≤ ${indicatorDetails.scoreStops[1]}`}
+                            </td>
+                            <td className="scoreTable__td">
+                                {indicatorDetails.scoreStops[2]}
+                            </td>
+                            <td className="scoreTable__td">
+                                {`${indicatorDetails.scoreStops[3]} ≤`}
+                            </td>
                         </tr>
                     </tbody>
                 </table>

--- a/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
@@ -3,7 +3,7 @@ import { arrayOf, string } from 'prop-types';
 import Popup from 'reactjs-popup';
 
 import { Score } from '../propTypes';
-import { toDashedString } from '../utils';
+import { classifyScore, toDashedString } from '../utils';
 import { INDICATOR_DETAILS } from '../constants';
 
 
@@ -55,6 +55,11 @@ const ScoresLabel = ({ indicator, scores }) => {
                         </tr>
                     </tbody>
                 </table>
+                <div className="scoreVerdict">
+                    {score}
+                    {' = '}
+                    {classifyScore(score, indicatorDetails.scoreStops)}
+                </div>
                 <div className="description">{indicatorDetails.description}</div>
             </div>
         </Popup>

--- a/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ScoresLabel.jsx
@@ -35,6 +35,26 @@ const ScoresLabel = ({ indicator, scores }) => {
         >
             <div className="indicator__popup">
                 <div className="name">{indicatorDetails.name}</div>
+                <table className="scoreTable">
+                    <thead>
+                        <tr>
+                            <th className="scoreTable__th">Min</th>
+                            <th className="scoreTable__th">Low</th>
+                            <th className="scoreTable__th">Med</th>
+                            <th className="scoreTable__th">High</th>
+                            <th className="scoreTable__th">Max</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td className="scoreTable__td">{indicatorDetails.scoreStops[0]}</td>
+                            <td className="scoreTable__td">{indicatorDetails.scoreStops[1]}</td>
+                            <td className="scoreTable__td">{indicatorDetails.scoreStops[2]}</td>
+                            <td className="scoreTable__td">{indicatorDetails.scoreStops[3]}</td>
+                            <td className="scoreTable__td">{indicatorDetails.scoreStops[4]}</td>
+                        </tr>
+                    </tbody>
+                </table>
                 <div className="description">{indicatorDetails.description}</div>
             </div>
         </Popup>

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -18,30 +18,35 @@ export const INDICATOR_DETAILS = {
         description: 'Lorem ipsum of nesting quality.',
         scoreLabels: ['Nesting'],
         shortLabel: 'Nesting',
+        scoreStops: [7, 33, 39, 46, 66],
     },
     pesticide: {
         name: 'Pesticide quality',
         description: 'Lorem ipsum of pesticide quality.',
         scoreLabels: ['Pesticide'],
         shortLabel: 'Pesticide',
+        scoreStops: [0, 13, 26, 37, 208],
     },
     floral_spring: {
         name: 'Spring Floral quality',
         description: 'Lorem ipsum of spring floral quality.',
         scoreLabels: ['Spring Floral'],
         shortLabel: 'Spr. Floral',
+        scoreStops: [18, 40, 46, 53, 69],
     },
     floral_summer: {
         name: 'Summer Floral quality',
         description: 'Lorem ipsum of summer floral quality.',
         scoreLabels: ['Summer Floral'],
         shortLabel: 'Sum. Floral',
+        scoreStops: [21, 44, 46, 49, 56],
     },
     floral_fall: {
         name: 'Fall Floral quality',
         description: 'Lorem ipsum of fall floral quality.',
         scoreLabels: ['Fall Floral'],
         shortLabel: 'Fall Floral',
+        scoreStops: [15, 30, 33, 36, 44],
     },
 };
 

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -323,13 +323,13 @@ export function getOrCreateSurveyRequest({ apiary, id, form }) {
  * @param {array} stops
  */
 export function classifyScore(score, stops) {
-    if (score < stops[1]) {
+    if (score <= stops[1]) {
         return 'Low';
     }
 
-    if (score < stops[3]) {
-        return 'Medium';
+    if (score >= stops[3]) {
+        return 'High';
     }
 
-    return 'High';
+    return 'Medium';
 }

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -313,3 +313,23 @@ export function getOrCreateSurveyRequest({ apiary, id, form }) {
 
     return request;
 }
+
+/**
+ * Given a score an a 5-value array of stops, classifies the score as
+ * "Low", "Medium", or "High". Scores below stops[1] are "Low". Scores
+ * above stops[2] are "High". Other scores are "Medium".
+ *
+ * @param {number} score
+ * @param {array} stops
+ */
+export function classifyScore(score, stops) {
+    if (score < stops[1]) {
+        return 'Low';
+    }
+
+    if (score < stops[3]) {
+        return 'Medium';
+    }
+
+    return 'High';
+}

--- a/src/icp/apps/beekeepers/sass/06_components/_indicator.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_indicator.scss
@@ -30,6 +30,23 @@
             text-align: left;
         }
 
+        .scoreTable {
+            width: 100%;
+
+            &__th {
+                padding: 0 2px;
+                color: $color-grey-3;
+                font-weight: $font-weight-light;
+                font-size: $font-size-base;
+                text-transform: capitalize;
+            }
+
+            &__td {
+                color: $color-grey-2;
+                font-size: $font-size-base;
+            }
+        }
+
         .description {
             font-size: $font-size-base;
             text-align: left;


### PR DESCRIPTION
## Overview

Adds score ranges, classification in the score popup.

This could potentially use some design input.

Connects #468 

### Demo

![image](https://user-images.githubusercontent.com/1430060/52505726-6a5e7f00-2bba-11e9-9f97-0b13f656ddde.png)

Tagging @dboyer for visual review.

### Notes

Need to confirm the Pesticide scores, which we are showing differently than their scale.

## Testing Instructions

* Check out this branch and `beekeepers start`
* Go to [:8000/?beekeepers](http://localhost:8000/?beekeepers) and add some apiaries
* Hover over their scores.
  - Ensure you see the table of expected results in the popup
  - Ensure the scores and their classification is in line with the description in #468 