### PR TITLE
Fix redis-server installation on services

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -44,3 +44,5 @@ model_data_path: "/opt/icp-crop-data"
 numpy_version: "1.11.1"
 
 ubuntu_ssl_cert_path: "/etc/ssl/certs/ca-certificates.crt"
+
+redis_version: "2:2.8.4-2ubuntu0.2"


### PR DESCRIPTION
## Overview

Without this we were getting:

```
vagrant@services:~$ sudo apt-get install 'redis-server=2:2.8.4-2'
Reading package lists... Done
Building dependency tree
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 redis-server : Depends: redis-tools (= 2:2.8.4-2) but 2:2.8.4-2ubuntu0.2 is to be installed
E: Unable to correct problems, you have held broken packages.
```

See https://github.com/azavea/ansible-redis/issues/1
And https://github.com/WikiWatershed/model-my-watershed/pull/3048

### Notes

`kibana` installation also fails, that is often commented out for local builds:

```diff
diff --git a/deployment/ansible/services.yml b/deployment/ansible/services.yml
index 035e887e..4c63a4cf 100644
--- a/deployment/ansible/services.yml
+++ b/deployment/ansible/services.yml
@@ -15,4 +15,4 @@
     - { role: "azavea.redis", when: "['development', 'test'] | some_are_in(group_names)" }
     - { role: "bee-pollinator.graphite", when: "['test'] | is_not_in(group_names)" }
     - { role: "bee-pollinator.logstash", when: "['test'] | is_not_in(group_names)" }
-    - { role: "azavea.kibana", when: "['test'] | is_not_in(group_names)" }
+    # - { role: "azavea.kibana", when: "['test'] | is_not_in(group_names)" }
```
