### PR TITLE
Pin Docker to 18.06.1 during provisioning

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -38,7 +38,9 @@ graphite_carbon_version: "0.9.13-pre1"
 graphite_whisper_version: "0.9.13-pre1"
 graphite_web_version: "0.9.13-pre1"
 
-docker_version: "18.*"
+# 18.06.2 is incompatible with Linux kernel v3.13.*. See:
+# https://github.com/docker/for-linux/issues/591
+docker_version: "18.06.1~ce~3-0~ubuntu"
 
 model_data_path: "/opt/icp-crop-data"
 numpy_version: "1.11.1"

--- a/deployment/ansible/roles/bee-pollinator.beekeepers/tasks/main.yml
+++ b/deployment/ansible/roles/bee-pollinator.beekeepers/tasks/main.yml
@@ -43,3 +43,7 @@
         group="icp"
         owner="icp"
   when: "['development', 'test'] | some_are_in(group_names)"
+
+- name: Uninstall Docker
+  apt: pkg="{{ docker_package_name }}={{ docker_version }}" state=absent
+  when: "['packer'] | some_are_in(group_names)"


### PR DESCRIPTION
## Overview

Docker CE `18.06.2` is incompatible with the Linux kernel `3.13`. Since Docker is easier to down/upgrade than the kernel version, downgrade Docker to `18.06.1` during provisioning, and uninstall Docker on AMI builds once we're done provisioning.

See:
  * https://docs.docker.com/engine/release-notes/#18092
  * https://github.com/docker/for-linux/issues/591
  * https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5736

Closes #473. 

## Testing Instructions

* If you'd like to test the Docker deinstallation, adjust `deployment/ansible/roles/bee-pollinator.beekeepers/tasks/main.yml`:

```diff
--- a/deployment/ansible/roles/bee-pollinator.beekeepers/tasks/main.yml
+++ b/deployment/ansible/roles/bee-pollinator.beekeepers/tasks/main.yml
@@ -46,4 +46,4 @@

 - name: Uninstall Docker
   apt: pkg="{{ docker_package_name }}={{ docker_version }}" state=absent
-  when: "['packer'] | some_are_in(group_names)"
+  when: "['packer', 'development'] | some_are_in(group_names)"
```

* Rerun the app provisioner with `vagrant provision app`
* Confirm that the provisioner makes it past the `[bee-pollinator.beekeepers : Install NPM Dependencies]` task