### PR TITLE
Remove Docker deinstall from app provisioning

### DIFF
--- a/deployment/ansible/roles/bee-pollinator.beekeepers/tasks/main.yml
+++ b/deployment/ansible/roles/bee-pollinator.beekeepers/tasks/main.yml
@@ -43,7 +43,3 @@
         group="icp"
         owner="icp"
   when: "['development', 'test'] | some_are_in(group_names)"
-
-- name: Uninstall Docker
-  apt: pkg="{{ docker_package_name }}={{ docker_version }}" state=absent
-  when: "['packer'] | some_are_in(group_names)"


### PR DESCRIPTION
## Overview

While we would like to be able to remove Docker from the app AMI entirely as described in e104379a91abdb438bad70662aeefde936314d0e, the Docker Ansible role raises an error at the end of the AMI build if Docker is not installed (see: http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-app-and-worker/139/). Undo the Docker deinstall step during provisioning to get AMI builds passing again.

Closes #473.

## Testing Instructions

* I'm not quite sure if there's an easy way to test an AMI build for a PR without clobbering the staging environment. If we can do that on Jenkins, I would recommend running a build to make sure this completes successfully.
