### PR TITLE
Update survey questions to be conditional where applicable

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
@@ -20,7 +20,7 @@ import Tooltip from './Tooltip';
 class NovemberSurveyForm extends Component {
     constructor(props) {
         super(props);
-        this.state = {
+        this.initialState = {
             // each form input corresponds to a state var
             num_colonies: '',
             harvested_honey: 'DID_NOT_HARVEST',
@@ -56,11 +56,27 @@ class NovemberSurveyForm extends Component {
             completedSurvey: '',
             error: '',
         };
+        this.state = this.initialState;
         this.multipleChoiceKeys = [
             'supplemental_sugar',
             'supplemental_protein',
             'varroa_check_method',
             'mite_management',
+        ];
+        // If a `field` has the `value`, then all the fields in `reset` are set
+        // to their value from initialMonthly
+        this.resetKeys = [
+            {
+                field: 'varroa_check_frequency',
+                value: 'NEVER',
+                reset: [
+                    'varroa_check_method_ALCOHOL_WASH',
+                    'varroa_check_method_STICKY_BOARDS',
+                    'varroa_check_method_SUGAR_SHAKE',
+                    'varroa_check_method_OTHER',
+                    'varroa_manage_frequency',
+                ],
+            },
         ];
         this.handleChange = this.handleChange.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
@@ -129,7 +145,18 @@ class NovemberSurveyForm extends Component {
             finalValue = false;
         }
 
-        this.setState({ [name]: finalValue });
+        let changeset = { [name]: finalValue };
+        // Reset dependent keys if needed
+        const resetKey = this.resetKeys.find(({ field }) => field === name);
+        if (resetKey && resetKey.value === finalValue) {
+            changeset = resetKey.reset.reduce(
+                (acc, f) => Object.assign(acc, {
+                    [f]: this.initialState[f],
+                }),
+                changeset,
+            );
+        }
+        this.setState(changeset);
     }
 
 

--- a/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
@@ -64,7 +64,7 @@ class NovemberSurveyForm extends Component {
             'mite_management',
         ];
         // If a `field` has the `value`, then all the fields in `reset` are set
-        // to their value from initialMonthly
+        // to their value from initialState
         this.resetKeys = [
             {
                 field: 'varroa_check_frequency',

--- a/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
@@ -323,6 +323,49 @@ class NovemberSurveyForm extends Component {
             ],
         );
 
+        const varroaConditionalInputs = varroa_check_frequency !== 'NEVER'
+            ? (
+            <>
+                <div className="form__group">
+                    <label htmlFor="varroa_check_method">
+                        What method(s) do you use to check for Varroa?
+                        Check all that apply.
+                    </label>
+                    {varroaCheckMethodCheckboxInputs}
+                    <div className="form__secondary">
+                        <label htmlFor="varroa_check_method_OTHER">Other varroa check method</label>
+                        <input
+                            type="text"
+                            className="form__control"
+                            id="varroa_check_method_OTHER"
+                            name="varroa_check_method_OTHER"
+                            value={varroa_check_method_OTHER}
+                            onChange={this.handleChange}
+                            disabled={!!completedSurvey}
+                        />
+                    </div>
+                </div>
+                <div className="form__group">
+                    <label htmlFor="varroa_manage_frequency">
+                        How you manage for Varroa? If so, how often?
+                    </label>
+                    <select
+                        id="varroa_manage_frequency"
+                        name="varroa_manage_frequency"
+                        value={varroa_manage_frequency}
+                        onChange={this.handleChange}
+                        className="form__control"
+                    >
+                        <option value="NEVER">I did not</option>
+                        <option value="ONCE">Once a year</option>
+                        <option value="TWICE">Twice a year</option>
+                        <option value="THRICE">Three times a year</option>
+                        <option value="MORE_THAN_THREE">More than three times a year</option>
+                    </select>
+                </div>
+            </>
+            ) : null;
+
         const surveyForm = (
             <>
                 <div className="title">{title}</div>
@@ -409,43 +452,7 @@ class NovemberSurveyForm extends Component {
                                 <option value="MORE_THAN_THREE">More than three times a year</option>
                             </select>
                         </div>
-                        <div className="form__group">
-                            <label htmlFor="varroa_check_method">
-                                What method(s) do you use to check for Varroa?
-                                Check all that apply.
-                            </label>
-                            {varroaCheckMethodCheckboxInputs}
-                            <div className="form__secondary">
-                                <label htmlFor="varroa_check_method_OTHER">Other varroa check method</label>
-                                <input
-                                    type="text"
-                                    className="form__control"
-                                    id="varroa_check_method_OTHER"
-                                    name="varroa_check_method_OTHER"
-                                    value={varroa_check_method_OTHER}
-                                    onChange={this.handleChange}
-                                    disabled={!!completedSurvey}
-                                />
-                            </div>
-                        </div>
-                        <div className="form__group">
-                            <label htmlFor="varroa_manage_frequency">
-                                How you manage for Varroa? If so, how often?
-                            </label>
-                            <select
-                                id="varroa_manage_frequency"
-                                name="varroa_manage_frequency"
-                                value={varroa_manage_frequency}
-                                onChange={this.handleChange}
-                                className="form__control"
-                            >
-                                <option value="NEVER">I did not</option>
-                                <option value="ONCE">Once a year</option>
-                                <option value="TWICE">Twice a year</option>
-                                <option value="THRICE">Three times a year</option>
-                                <option value="MORE_THAN_THREE">More than three times a year</option>
-                            </select>
-                        </div>
+                        {varroaConditionalInputs}
                         <div className="form__group">
                             <label htmlFor="mite_management">
                                 What methods of mite management do you use?

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -46,6 +46,8 @@ class UserSurveyModal extends Component {
             equipment_top_bar: '',
             equipment_other: '',
         };
+        // If a `field` has the `value`, then all the fields in `reset` are set
+        // to their value from initialState
         this.resetKeys = [
             {
                 field: 'varroa_management',

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -376,19 +376,21 @@ class UserSurveyModal extends Component {
                                     <option key="false" value="false">No</option>
                                 </select>
                             </div>
-                            <div className="form__group">
-                                <label htmlFor="varroa_management_trigger">
-                                    How do you decide when to manage for Varroa?
-                                </label>
-                                <input
-                                    type="text"
-                                    className="form__control"
-                                    id="varroa_management_trigger"
-                                    name="varroa_management_trigger"
-                                    value={varroa_management_trigger}
-                                    onChange={this.handleChange}
-                                />
-                            </div>
+                            {varroa_management && (
+                                <div className="form__group">
+                                    <label htmlFor="varroa_management_trigger">
+                                        How do you decide when to manage for Varroa?
+                                    </label>
+                                    <input
+                                        type="text"
+                                        className="form__control"
+                                        id="varroa_management_trigger"
+                                        name="varroa_management_trigger"
+                                        value={varroa_management_trigger}
+                                        onChange={this.handleChange}
+                                    />
+                                </div>
+                            )}
                             <div className="form__group">
                                 <label htmlFor="purchased_queens">
                                     Do you buy queens, nucs or packages?
@@ -404,19 +406,21 @@ class UserSurveyModal extends Component {
                                     <option key="false" value="false">No</option>
                                 </select>
                             </div>
-                            <div className="form__group">
-                                <label htmlFor="purchased_queens_sources">
-                                    From what state(s) did your purchased bees originate?
-                                </label>
-                                <input
-                                    type="text"
-                                    className="form__control"
-                                    id="purchased_queens_sources"
-                                    name="purchased_queens_sources"
-                                    value={purchased_queens_sources}
-                                    onChange={this.handleChange}
-                                />
-                            </div>
+                            {purchased_queens && (
+                                <div className="form__group">
+                                    <label htmlFor="purchased_queens_sources">
+                                        From what state(s) did your purchased bees originate?
+                                    </label>
+                                    <input
+                                        type="text"
+                                        className="form__control"
+                                        id="purchased_queens_sources"
+                                        name="purchased_queens_sources"
+                                        value={purchased_queens_sources}
+                                        onChange={this.handleChange}
+                                    />
+                                </div>
+                            )}
                             <div className="form__group">
                                 <label htmlFor="resistant_queens">
                                     Do you use Varroa-resistant queens?
@@ -432,19 +436,21 @@ class UserSurveyModal extends Component {
                                     <option key="false" value="false">No</option>
                                 </select>
                             </div>
-                            <div className="form__group">
-                                <label htmlFor="resistant_queens_genetics">
-                                    Describe their genetics.
-                                </label>
-                                <input
-                                    type="text"
-                                    className="form__control"
-                                    id="resistant_queens_genetics"
-                                    name="resistant_queens_genetics"
-                                    value={resistant_queens_genetics}
-                                    onChange={this.handleChange}
-                                />
-                            </div>
+                            {resistant_queens && (
+                                <div className="form__group">
+                                    <label htmlFor="resistant_queens_genetics">
+                                        Describe their genetics.
+                                    </label>
+                                    <input
+                                        type="text"
+                                        className="form__control"
+                                        id="resistant_queens_genetics"
+                                        name="resistant_queens_genetics"
+                                        value={resistant_queens_genetics}
+                                        onChange={this.handleChange}
+                                    />
+                                </div>
+                            )}
                             <div className="form__group">
                                 <label htmlFor="rear_queens">
                                     Do you rear queens?

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -46,6 +46,29 @@ class UserSurveyModal extends Component {
             equipment_top_bar: '',
             equipment_other: '',
         };
+        this.resetKeys = [
+            {
+                field: 'varroa_management',
+                value: false,
+                reset: [
+                    'varroa_management_trigger',
+                ],
+            },
+            {
+                field: 'purchased_queens',
+                value: false,
+                reset: [
+                    'purchased_queens_sources',
+                ],
+            },
+            {
+                field: 'resistant_queens',
+                value: false,
+                reset: [
+                    'resistant_queens_genetics',
+                ],
+            },
+        ];
         this.state = this.initialState;
         this.handleChange = this.handleChange.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
@@ -73,7 +96,18 @@ class UserSurveyModal extends Component {
             finalValue = false;
         }
 
-        this.setState({ [name]: finalValue });
+        let changeset = { [name]: finalValue };
+        // Reset dependent keys if needed
+        const resetKey = this.resetKeys.find(({ field }) => field === name);
+        if (resetKey && resetKey.value === finalValue) {
+            changeset = resetKey.reset.reduce(
+                (acc, f) => Object.assign(acc, {
+                    [f]: this.initialState[f],
+                }),
+                changeset,
+            );
+        }
+        this.setState(changeset);
     }
 
     handleSubmit(event) {


### PR DESCRIPTION
## Overview

The survey questions spreadsheet specifies questions that should appear conditionally based on answers to preceding questions. This PR should capture the rest of the questions that should be conditional but weren't yet. Questions  a user had second thoughts on and subsequently hides have their answers erased so we avoid saving stale / irrelevant data.

Connects #477 

### Demo

**November:**
<img width="593" alt="screen shot 2019-02-15 at 8 53 12 am" src="https://user-images.githubusercontent.com/10568752/52862795-1dbbfc00-3104-11e9-9581-f45cbf82a483.png">
<img width="590" alt="screen shot 2019-02-15 at 8 53 18 am" src="https://user-images.githubusercontent.com/10568752/52862796-1dbbfc00-3104-11e9-837d-906676a1d686.png">


**User:**
<img width="442" alt="screen shot 2019-02-15 at 9 07 34 am" src="https://user-images.githubusercontent.com/10568752/52862820-2ad8eb00-3104-11e9-9620-974acc7e3260.png">

<img width="414" alt="screen shot 2019-02-15 at 9 07 54 am" src="https://user-images.githubusercontent.com/10568752/52862797-1dbbfc00-3104-11e9-9121-b4b4fddc0aaf.png">


## Testing Instructions

Pull down branch and `./scripts/beekeepers.sh start`. Check out the user survey and november surveys. Try out the conditional questions. If you input answers but then change your mind on the parent input, the conditional question answers should be erased on change.