### PR TITLE
Text changes for forms from beekeepers feedback

### DIFF
--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -173,7 +173,7 @@ export function signUp(form) {
                     isStaff: false,
                     userId: null,
                     userSurvey: null,
-                    message: 'Please click the validation link in your email and then log in.',
+                    message: 'Please check your email for an account activation link. The email may go to your spam folder, depending on your email settings.',
                 }));
                 dispatch(openLoginModal());
             }
@@ -244,7 +244,7 @@ export function sendAuthLink(form, endpoint) {
             dispatch(setAuthState({
                 username: '',
                 userId: null,
-                message: 'Check your email to reset your password or activate your account',
+                message: 'Please check your email for a password reset or account activation link. The email may go to your spam folder, depending on your email settings.',
                 isStaff: false,
                 authError: '',
                 userSurvey: null,

--- a/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
@@ -20,6 +20,7 @@ class AprilSurveyForm extends Component {
             colony_loss_reason_POOR_WEATHER_CONDITIONS: false,
             colony_loss_reason_COLONY_TOO_SMALL_IN_NOVEMBER: false,
             colony_loss_reason_PESTICIDE_EXPOSURE: false,
+            colony_loss_reason_BEAR_OR_NATURAL_DISASTER: false,
             completedSurvey: '',
             error: '',
         };
@@ -239,7 +240,7 @@ class AprilSurveyForm extends Component {
                             required
                         />
                         <label htmlFor="colony_loss_reason">
-                            What do you think the most likely cause of colony loss was?
+                            What do you think was the most likely cause of colony loss?
                             Check all that apply. Required.
                         </label>
                         {colonyLossReasonCheckboxInputs}

--- a/src/icp/apps/beekeepers/js/src/components/GuestSurveyView.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/GuestSurveyView.jsx
@@ -16,8 +16,15 @@ const GuestSurveyView = ({ dispatch }) => (
                 the quality of their landscapes for bees, and site-specific recommendations for
                 land and bee management practices. But, to do this, we need your help, so we can
                 have data from many diverse landscapes! If you have a wild bee hotel and would like
-                to participate in our study, please click here. If you are a beekeeper, please
-                follow the link below.
+                to participate in our study,&nbsp;
+                <a
+                    href="http://beescape.org/wild-bees/"
+                    target="_blank"
+                    rel="noreferrer noopener"
+                >
+                    please click here
+                </a>
+                . If you are a beekeeper, please follow the link below.
             </div>
             <button
                 type="button"

--- a/src/icp/apps/beekeepers/js/src/components/Header.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Header.jsx
@@ -95,14 +95,10 @@ const Header = ({ dispatch, username, isStaff }) => {
                 </div>
                 <ul className="navbar__right">
                     <li className="navbar__item">
-                        <button type="button" className="navbar__button">
-                            Home
-                        </button>
+                        <a className="navbar__button" href="http://beescape.org" target="blank">Home</a>
                     </li>
                     <li className="navbar__item">
-                        <button type="button" className="navbar__button">
-                            Methodology
-                        </button>
+                        <a className="navbar__button" href="http://beescape.org/methodology" target="blank">Methodology</a>
                     </li>
                     {authButtons}
                 </ul>

--- a/src/icp/apps/beekeepers/js/src/components/Header.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Header.jsx
@@ -95,10 +95,24 @@ const Header = ({ dispatch, username, isStaff }) => {
                 </div>
                 <ul className="navbar__right">
                     <li className="navbar__item">
-                        <a className="navbar__button" href="http://beescape.org" target="blank">Home</a>
+                        <a
+                            className="navbar__button"
+                            href="http://beescape.org"
+                            target="_blank"
+                            rel="noreferrer noopener"
+                        >
+                            Home
+                        </a>
                     </li>
                     <li className="navbar__item">
-                        <a className="navbar__button" href="http://beescape.org/methodology" target="blank">Methodology</a>
+                        <a
+                            className="navbar__button"
+                            href="http://beescape.org/methodology"
+                            target="_blank"
+                            rel="noreferrer noopener"
+                        >
+                            Methodology
+                        </a>
                     </li>
                     {authButtons}
                 </ul>

--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
@@ -15,6 +15,8 @@ import {
     SHALLOW_HIVE_BODIES_DESCRIPTION,
     QUEEN_STOCK_DESCRIPTION,
     QUEENRIGHT_DESCRIPTION,
+    THYMOL_DESCRIPTION,
+    AMITRAZ_DESCRIPTION,
 } from '../constants';
 import { MonthlySurveyColony } from '../propTypes';
 
@@ -81,13 +83,16 @@ class MonthlySurveyColonyForm extends Component {
         );
     }
 
-    makeMultipleChoiceInputs(groupName, options) {
+    makeMultipleChoiceInputs(groupName, options, tooltipDescriptions) {
         const { data, onChange } = this.props;
         const disabled = data.id !== null;
 
-        return options.map((option) => {
+        return options.map((option, index) => {
             const key = `${groupName}_${option}`;
             const label = option.split('_').join(' ').toLowerCase();
+            const tooltip = tooltipDescriptions && tooltipDescriptions[index]
+                ? <Tooltip description={[tooltipDescriptions[index]]} />
+                : null;
 
             return (
                 <div
@@ -103,7 +108,10 @@ class MonthlySurveyColonyForm extends Component {
                         onChange={onChange}
                         disabled={disabled}
                     />
-                    <label htmlFor={key}>{label}</label>
+                    <label htmlFor={key}>
+                        {label}
+                        {tooltip}
+                    </label>
                 </div>
             );
         });
@@ -132,8 +140,8 @@ class MonthlySurveyColonyForm extends Component {
             <>
                 <div className="form__group">
                     <label htmlFor="colony_loss_reason">
-                        What do you think the most likely cause of colony loss was?
-                        Check all that apply.
+                        What do you think was the most likely cause of colony loss?
+                        Check all that apply. Required.
                     </label>
                     {this.makeMultipleChoiceInputs('colony_loss_reason', COLONY_LOSS_REASONS)}
                     <div className="form__secondary">
@@ -199,10 +207,8 @@ class MonthlySurveyColonyForm extends Component {
                         Do you treat for Varroa? If so, how?
                         Check all that apply.
                     </label>
-                    {this.makeMultipleChoiceInputs('varroa_treatment', MITE_MANAGEMENT_OPTIONS)}
+                    {this.makeMultipleChoiceInputs('varroa_treatment', MITE_MANAGEMENT_OPTIONS, [THYMOL_DESCRIPTION, AMITRAZ_DESCRIPTION])}
                     <div className="form__secondary">
-                        {inputText('varroa_treatment_CHEMICAL_ORGANIC_OTHER', 'Other organic chemical')}
-                        {inputText('varroa_treatment_MECHANICAL_OTHER', 'Other mechanical')}
                         {inputText('varroa_treatment_OTHER', 'Other')}
                     </div>
                 </div>

--- a/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
@@ -11,6 +11,8 @@ import {
     VARROA_ALCOHOL_WASH_DESCRIPTION,
     VARROA_STICKYBOARD_DESCRIPTION,
     VARROA_SUGAR_SHAKE_DESCRIPTION,
+    THYMOL_DESCRIPTION,
+    AMITRAZ_DESCRIPTION,
 } from '../constants';
 import { arrayToSemicolonDelimitedString, getOrCreateSurveyRequest } from '../utils';
 import { Survey } from '../propTypes';
@@ -40,19 +42,15 @@ class NovemberSurveyForm extends Component {
             varroa_check_method_STICKY_BOARDS: false,
             varroa_manage_frequency: 'NEVER',
             mite_management_OTHER: '',
-            mite_management_CHEMICAL_ORGANIC_OTHER: '',
-            mite_management_MECHANICAL_OTHER: '',
-            mite_management_CHEMICAL_FORMIC_ACID_MAQS: false,
-            mite_management_CHEMICAL_FORMIC_ACID_FORMIC_PRO: false,
-            mite_management_CHEMICAL_OXALIC_ACID_VAPORIZATION: false,
-            mite_management_CHEMICAL_OXALIC_ACID_DRIBBLE: false,
-            mite_management_CHEMICAL_THYMOL_MENTHOL_APILIFE: false,
-            mite_management_CHEMICAL_THYMOL_MENTHOL_APIGUARD: false,
-            mite_management_CHEMICAL_SYNTHETIC_APIVAR: false,
-            mite_management_CHEMICAL_SYNTHETIC_APISTAN: false,
-            mite_management_CHEMICAL_SYNTHETIC_CHECKMITE_PLUS: false,
-            mite_management_MECHANICAL_DRONE_BROOD_REMOVAL: false,
-            mite_management_MECHANICAL_QUEEN_MANIPULATION: false,
+            mite_management_FORMIC_ACID: false,
+            mite_management_OXALIC_ACID: false,
+            mite_management_THYMOL: false,
+            mite_management_NONE: false,
+            mite_management_AMITRAZ: false,
+            mite_management_APISTAN: false,
+            mite_management_CHECKMITE: false,
+            mite_management_DRONE_REMOVE: false,
+            mite_management_QUEEN_MANIPULATION: false,
             completedSurvey: '',
             error: '',
         };
@@ -223,7 +221,7 @@ class NovemberSurveyForm extends Component {
         return options.map((option, index) => {
             const key = `${groupName}_${option}`;
             const label = option.split('_').join(' ').toLowerCase();
-            const tooltip = tooltipDescriptions
+            const tooltip = tooltipDescriptions && tooltipDescriptions[index]
                 ? <Tooltip description={[tooltipDescriptions[index]]} />
                 : null;
             return (
@@ -285,8 +283,6 @@ class NovemberSurveyForm extends Component {
             varroa_check_method_OTHER,
             varroa_manage_frequency,
             mite_management_OTHER,
-            mite_management_CHEMICAL_ORGANIC_OTHER,
-            mite_management_MECHANICAL_OTHER,
             completedSurvey,
             error,
         } = this.state;
@@ -334,7 +330,11 @@ class NovemberSurveyForm extends Component {
                 </div>
             );
 
-        const miteManagementCheckboxInputs = this.makeMultipleChoiceInputs('mite_management', MITE_MANAGEMENT_OPTIONS);
+        const miteManagementCheckboxInputs = this.makeMultipleChoiceInputs(
+            'mite_management',
+            MITE_MANAGEMENT_OPTIONS,
+            [THYMOL_DESCRIPTION, AMITRAZ_DESCRIPTION],
+        );
 
         const supplementalSugarInputs = this.makeSeasonalInputs('supplemental_sugar');
 
@@ -413,7 +413,8 @@ class NovemberSurveyForm extends Component {
                         />
                         <div className="form__group">
                             <label htmlFor="harvested_honey">
-                                How much honey did you collect on average for each colony?
+                                Approximately how much honey did you collect for each colony
+                                this year?
                             </label>
                             <select
                                 id="harvested_honey"
@@ -487,28 +488,6 @@ class NovemberSurveyForm extends Component {
                             </label>
                             {miteManagementCheckboxInputs}
                             <div className="form__secondary">
-                                <label htmlFor="mite_management_CHEMICAL_ORGANIC_OTHER">
-                                    Other organic chemical
-                                </label>
-                                <input
-                                    type="text"
-                                    className="form__control"
-                                    id="mite_management_CHEMICAL_ORGANIC_OTHER"
-                                    name="mite_management_CHEMICAL_ORGANIC_OTHER"
-                                    value={mite_management_CHEMICAL_ORGANIC_OTHER}
-                                    onChange={this.handleChange}
-                                    disabled={!!completedSurvey}
-                                />
-                                <label htmlFor="mite_management_MECHANICAL_OTHER">Other mechanical</label>
-                                <input
-                                    type="text"
-                                    className="form__control"
-                                    id="mite_management_MECHANICAL_OTHER"
-                                    name="mite_management_MECHANICAL_OTHER"
-                                    value={mite_management_MECHANICAL_OTHER}
-                                    onChange={this.handleChange}
-                                    disabled={!!completedSurvey}
-                                />
                                 <label htmlFor="mite_management_OTHER">Other</label>
                                 <input
                                     type="text"

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -44,6 +44,7 @@ class UserSurveyModal extends Component {
             equipment_8_frame: '',
             equipment_10_frame: '',
             equipment_top_bar: '',
+            equipment_warre_hive: '',
             equipment_other: '',
         };
         // If a `field` has the `value`, then all the fields in `reset` are set
@@ -128,6 +129,7 @@ class UserSurveyModal extends Component {
             equipment_8_frame,
             equipment_10_frame,
             equipment_top_bar,
+            equipment_warre_hive,
             equipment_other,
         } = this.state;
 
@@ -136,7 +138,13 @@ class UserSurveyModal extends Component {
         );
         const prepended_equipment_other = equipment_other.length ? `OTHER-${equipment_other}` : '';
         const equipment = arrayToSemicolonDelimitedString(
-            [equipment_8_frame, equipment_10_frame, equipment_top_bar, prepended_equipment_other],
+            [
+                equipment_8_frame,
+                equipment_10_frame,
+                equipment_top_bar,
+                equipment_warre_hive,
+                prepended_equipment_other,
+            ],
         );
         const form = Object.assign({}, this.state, {
             income,
@@ -177,6 +185,7 @@ class UserSurveyModal extends Component {
             equipment_8_frame,
             equipment_10_frame,
             equipment_top_bar,
+            equipment_warre_hive,
             equipment_other,
         } = this.state;
 
@@ -315,8 +324,7 @@ class UserSurveyModal extends Component {
                             </div>
                             <div className="form__group">
                                 <label htmlFor="income">
-                                    Do you obtain income from your bees?
-                                    What do you receive income from?
+                                    Do you receive income from any of the following?
                                     Check all that apply.
                                 </label>
                                 <div className="form__checkbox">
@@ -429,7 +437,7 @@ class UserSurveyModal extends Component {
                             )}
                             <div className="form__group">
                                 <label htmlFor="purchased_queens">
-                                    Do you buy queens, nucs or packages?
+                                    Do you regularly buy queens, nucs or packages?
                                 </label>
                                 <select
                                     className="form__control"
@@ -522,7 +530,7 @@ class UserSurveyModal extends Component {
                                     <input
                                         type="checkbox"
                                         className="form__control"
-                                        id="equipment"
+                                        id="equipment_10_frame"
                                         name="equipment_10_frame"
                                         checked={equipment_10_frame}
                                         onChange={this.handleChange}
@@ -541,6 +549,18 @@ class UserSurveyModal extends Component {
                                         value="TOP_BAR"
                                     />
                                     <label htmlFor="equipment_top_bar">Top bar</label>
+                                </div>
+                                <div className="form__checkbox">
+                                    <input
+                                        type="checkbox"
+                                        className="form__control"
+                                        id="equipment_warre_hive"
+                                        name="equipment_warre_hive"
+                                        checked={equipment_warre_hive}
+                                        onChange={this.handleChange}
+                                        value="WARRE_HIVE"
+                                    />
+                                    <label htmlFor="equipment_warre_hive">Warre hive</label>
                                 </div>
                                 <label htmlFor="equipment_other">Other</label>
                                 <input

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -31,7 +31,6 @@ class UserSurveyModal extends Component {
             income_sell_honey: '',
             income_sell_nucs: '',
             income_sell_queens: '',
-            income_none: '',
             practice: 'CONVENTIONAL',
             varroa_management: false,
             varroa_management_trigger: '',
@@ -125,7 +124,6 @@ class UserSurveyModal extends Component {
             income_sell_honey,
             income_sell_nucs,
             income_sell_queens,
-            income_none,
             equipment_8_frame,
             equipment_10_frame,
             equipment_top_bar,
@@ -134,7 +132,7 @@ class UserSurveyModal extends Component {
         } = this.state;
 
         const income = arrayToSemicolonDelimitedString(
-            [income_none, income_rent, income_sell_honey, income_sell_nucs, income_sell_queens],
+            [income_rent, income_sell_honey, income_sell_nucs, income_sell_queens],
         );
         const prepended_equipment_other = equipment_other.length ? `OTHER-${equipment_other}` : '';
         const equipment = arrayToSemicolonDelimitedString(
@@ -173,7 +171,6 @@ class UserSurveyModal extends Component {
             income_sell_honey,
             income_sell_nucs,
             income_sell_queens,
-            income_none,
             practice,
             varroa_management,
             varroa_management_trigger,
@@ -374,18 +371,6 @@ class UserSurveyModal extends Component {
                                         value="SELL_QUEENS"
                                     />
                                     <label htmlFor="income_sell_queens">Sell queens</label>
-                                </div>
-                                <div className="form__checkbox">
-                                    <input
-                                        type="checkbox"
-                                        className="form__control"
-                                        id="income_none"
-                                        name="income_none"
-                                        checked={income_none}
-                                        onChange={this.handleChange}
-                                        value="NO_INCOME"
-                                    />
-                                    <label htmlFor="income_none">No income</label>
                                 </div>
                             </div>
                             <div className="form__group">

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -34,6 +34,10 @@ class UserSurveyModal extends Component {
             practice: 'CONVENTIONAL',
             varroa_management: false,
             varroa_management_trigger: '',
+            varroa_management_trigger_mite_counts: '',
+            varroa_management_trigger_mite_symptoms: '',
+            varroa_management_trigger_time_of_year: '',
+            varroa_management_trigger_other: '',
             purchased_queens: false,
             purchased_queens_sources: '',
             resistant_queens: false,
@@ -54,6 +58,10 @@ class UserSurveyModal extends Component {
                 value: false,
                 reset: [
                     'varroa_management_trigger',
+                    'varroa_management_trigger_mite_counts',
+                    'varroa_management_trigger_mite_symptoms',
+                    'varroa_management_trigger_time_of_year',
+                    'varroa_management_trigger_other',
                 ],
             },
             {
@@ -124,6 +132,10 @@ class UserSurveyModal extends Component {
             income_sell_honey,
             income_sell_nucs,
             income_sell_queens,
+            varroa_management_trigger_mite_counts,
+            varroa_management_trigger_mite_symptoms,
+            varroa_management_trigger_time_of_year,
+            varroa_management_trigger_other,
             equipment_8_frame,
             equipment_10_frame,
             equipment_top_bar,
@@ -134,6 +146,17 @@ class UserSurveyModal extends Component {
         const income = arrayToSemicolonDelimitedString(
             [income_rent, income_sell_honey, income_sell_nucs, income_sell_queens],
         );
+
+        const prepend_varroa_management_trigger_other = varroa_management_trigger_other.length ? `OTHER-${varroa_management_trigger_other}` : '';
+        const varroa_management_trigger = arrayToSemicolonDelimitedString(
+            [
+                varroa_management_trigger_mite_counts,
+                varroa_management_trigger_mite_symptoms,
+                varroa_management_trigger_time_of_year,
+                prepend_varroa_management_trigger_other,
+            ],
+        );
+
         const prepended_equipment_other = equipment_other.length ? `OTHER-${equipment_other}` : '';
         const equipment = arrayToSemicolonDelimitedString(
             [
@@ -146,6 +169,7 @@ class UserSurveyModal extends Component {
         );
         const form = Object.assign({}, this.state, {
             income,
+            varroa_management_trigger,
             equipment,
         });
         dispatch(createUserSurvey(form));
@@ -173,7 +197,10 @@ class UserSurveyModal extends Component {
             income_sell_queens,
             practice,
             varroa_management,
-            varroa_management_trigger,
+            varroa_management_trigger_mite_counts,
+            varroa_management_trigger_mite_symptoms,
+            varroa_management_trigger_time_of_year,
+            varroa_management_trigger_other,
             purchased_queens,
             purchased_queens_sources,
             resistant_queens,
@@ -410,12 +437,49 @@ class UserSurveyModal extends Component {
                                     <label htmlFor="varroa_management_trigger">
                                         How do you decide when to manage for Varroa?
                                     </label>
+                                    <div className="form__checkbox">
+                                        <input
+                                            type="checkbox"
+                                            className="form__control"
+                                            id="varroa_management_trigger_mite_counts"
+                                            name="varroa_management_trigger_mite_counts"
+                                            checked={varroa_management_trigger_mite_counts}
+                                            onChange={this.handleChange}
+                                            value="MITE_COUNTS"
+                                        />
+                                        <label htmlFor="varroa_management_trigger_mite_counts">Mite Counts</label>
+                                    </div>
+                                    <div className="form__checkbox">
+                                        <input
+                                            type="checkbox"
+                                            className="form__control"
+                                            id="varroa_management_trigger_mite_symptoms"
+                                            name="varroa_management_trigger_mite_symptoms"
+                                            checked={varroa_management_trigger_mite_symptoms}
+                                            onChange={this.handleChange}
+                                            value="MITE_SYMPTOMS"
+                                        />
+                                        <label htmlFor="varroa_management_trigger_mite_symptoms">Mite Symptoms</label>
+                                    </div>
+                                    <div className="form__checkbox">
+                                        <input
+                                            type="checkbox"
+                                            className="form__control"
+                                            id="varroa_management_trigger_time_of_year"
+                                            name="varroa_management_trigger_time_of_year"
+                                            checked={varroa_management_trigger_time_of_year}
+                                            onChange={this.handleChange}
+                                            value="TIME_OF_YEAR"
+                                        />
+                                        <label htmlFor="varroa_management_trigger_time_of_year">Time of Year</label>
+                                    </div>
+                                    <label htmlFor="varroa_management_trigger_other">Other</label>
                                     <input
                                         type="text"
                                         className="form__control"
-                                        id="varroa_management_trigger"
-                                        name="varroa_management_trigger"
-                                        value={varroa_management_trigger}
+                                        id="varroa_management_trigger_other"
+                                        name="varroa_management_trigger_other"
+                                        value={varroa_management_trigger_other}
                                         onChange={this.handleChange}
                                     />
                                 </div>

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -468,7 +468,7 @@ class UserSurveyModal extends Component {
                             {resistant_queens && (
                                 <div className="form__group">
                                     <label htmlFor="resistant_queens_genetics">
-                                        Describe their genetics.
+                                        What is the stock or genetic background of your queens?
                                     </label>
                                     <input
                                         type="text"

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -260,12 +260,14 @@ class UserSurveyModal extends Component {
                             <div className="form__group">
                                 <label htmlFor="phone">Phone number</label>
                                 <input
-                                    type="text"
+                                    type="tel"
                                     className="form__control"
                                     id="phone"
                                     name="phone"
                                     value={phone}
+                                    placeholder="123-456-7890"
                                     onChange={this.handleChange}
+                                    required
                                 />
                             </div>
                             <div className="form__group">

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -59,17 +59,15 @@ export const SURVEY_TYPE_MONTHLY = 'MONTHLY';
 
 
 export const MITE_MANAGEMENT_OPTIONS = [
-    'CHEMICAL_FORMIC_ACID_MAQS',
-    'CHEMICAL_FORMIC_ACID_FORMIC_PRO',
-    'CHEMICAL_OXALIC_ACID_VAPORIZATION',
-    'CHEMICAL_OXALIC_ACID_DRIBBLE',
-    'CHEMICAL_THYMOL_MENTHOL_APILIFE',
-    'CHEMICAL_THYMOL_MENTHOL_APIGUARD',
-    'CHEMICAL_SYNTHETIC_APIVAR',
-    'CHEMICAL_SYNTHETIC_APISTAN',
-    'CHEMICAL_SYNTHETIC_CHECKMITE_PLUS',
-    'MECHANICAL_DRONE_BROOD_REMOVAL',
-    'MECHANICAL_QUEEN_MANIPULATION',
+    'THYMOL',
+    'AMITRAZ',
+    'FORMIC_ACID',
+    'OXALIC_ACID',
+    'APISTAN',
+    'CHECKMITE',
+    'QUEEN_MANIPULATION',
+    'DRONE_REMOVE',
+    'NONE',
 ];
 
 export const SEASONS = [
@@ -92,6 +90,7 @@ export const COLONY_LOSS_REASONS = [
     'POOR_WEATHER_CONDITIONS',
     'COLONY_TOO_SMALL_IN_NOVEMBER',
     'PESTICIDE_EXPOSURE',
+    'BEAR_OR_NATURAL_DISASTER',
 ];
 
 export const ACTIVITY_SINCE_LAST = [
@@ -159,4 +158,14 @@ export const QUEEN_STOCK_DESCRIPTION = {
 export const QUEENRIGHT_DESCRIPTION = {
     title: '',
     body: 'You can determine if a queen is present by locating her physically or checking for eggs. However, by late fall the queen stops laying eggs. We ask that beekeepers use their best judgement when making the assessments during these times.',
+};
+
+export const THYMOL_DESCRIPTION = {
+    title: '',
+    body: 'The active ingredient in Apilife Var is thymol.',
+};
+
+export const AMITRAZ_DESCRIPTION = {
+    title: '',
+    body: 'The active ingredient in Apivar is amitraz.',
 };

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -162,7 +162,7 @@ export const QUEENRIGHT_DESCRIPTION = {
 
 export const THYMOL_DESCRIPTION = {
     title: '',
-    body: 'The active ingredient in Apilife Var is thymol.',
+    body: 'The active ingredient in Apilife and Apiguard is thymol.',
 };
 
 export const AMITRAZ_DESCRIPTION = {

--- a/src/icp/apps/beekeepers/models.py
+++ b/src/icp/apps/beekeepers/models.py
@@ -118,6 +118,7 @@ class AprilSurvey(models.Model):
       - poor weather conditions
       - colony too small in November
       - pesticide exposure
+      - bear or natural disaster
       - other (fillable field)
 
     Multiple selections are possible, and will be separated by a semicolon.
@@ -148,8 +149,7 @@ class NovemberSurvey(models.Model):
     - varroa_check_method and varroa_manage_frequency need only be filled if
       varroa_check_frequency has been filled out
     - mite_management can take a large list of predefined inputs, but also
-      free-form text prefixed by CHEMICAL_OTHER_ORGANIC-, MECHANICAL_OTHER-,
-      or OTHER-
+      free-form text prefixed by OTHER-
     """
     HARVEST_CHOICES = (
         ('DID_NOT_HARVEST', 'Did not harvest'),
@@ -210,13 +210,14 @@ class NovemberSurvey(models.Model):
         default='NEVER',
         help_text='Do you manage for Varroa? If so, how often?')
     mite_management = models.TextField(
-        # CHEMICAL_FORMIC_ACID_MAQS;CHEMICAL_FORMIC_ACID_FORMIC_PRO;
-        # CHEMICAL_OXALIC_ACID_VAPORIZATION;CHEMICAL_OXALIC_ACID_DRIBBLE;
-        # CHEMICAL_THYMOL_MENTHOL_APILIFE;CHEMICAL_THYMOL_MENTHOL_APIGUARD;
-        # CHEMICAL_SYNTHETIC_APIVAR;CHEMICAL_SYNTHETIC_APISTAN;
-        # CHEMICAL_SYNTHETIC_CHECKMITE_PLUS;CHEMICAL_ORGANIC_OTHER-
-        # MECHANICAL_DRONE_BROOD_REMOVAL;MECHANICAL_QUEEN_MANIPULATION;
-        # MECHANICAL_OTHER-
+        # THYMOL
+        # AMITRAZ
+        # FORMIC_ACID
+        # OXALIC_ACID
+        # APISTAN
+        # CHECKMITE
+        # DRONE_REMOVAL
+        # QUEEN_MANIPULATION
         # OTHER-
         null=True,
         help_text='What methods of mite management do you use? '
@@ -325,13 +326,14 @@ class MonthlySurvey(models.Model):
         blank=True,
         help_text='Number of mites per 300 bees (1/2 cup)')
     varroa_treatment = models.TextField(
-        # CHEMICAL_FORMIC_ACID_MAQS;CHEMICAL_FORMIC_ACID_FORMIC_PRO;
-        # CHEMICAL_OXALIC_ACID_VAPORIZATION;CHEMICAL_OXALIC_ACID_DRIBBLE;
-        # CHEMICAL_THYMOL_MENTHOL_APILIFE;CHEMICAL_THYMOL_MENTHOL_APIGUARD;
-        # CHEMICAL_SYNTHETIC_APIVAR;CHEMICAL_SYNTHETIC_APISTAN;
-        # CHEMICAL_SYNTHETIC_CHECKMITE_PLUS;CHEMICAL_OTHER_ORGANIC-
-        # MECHANICAL_DRONE_BROOD_REMOVAL;MECHANICAL_QUEEN_MANIPULATION;
-        # MECHANICAL_OTHER-
+        # THYMOL
+        # AMITRAZ
+        # FORMIC_ACID
+        # OXALIC_ACID
+        # APISTAN
+        # CHECKMITE
+        # DRONE_REMOVAL
+        # QUEEN_MANIPULATION
         # OTHER-
         null=True,
         blank=True,
@@ -407,7 +409,7 @@ class UserSurvey(models.Model):
         help_text='Do you relocate your colonies throughout the year?')
     income = models.CharField(
         # RENT_COLONIES_FOR_POLLINATION; SELL_HONEY; SELL_NUCS_PACKAGES;
-        # SELL_QUEENS; NO_INCOME
+        # SELL_QUEENS
         max_length=255,
         null=False,
         blank=True,
@@ -449,7 +451,7 @@ class UserSurvey(models.Model):
         null=False,
         help_text='Do you rear queens?')
     equipment = models.TextField(
-        # 8_FRAME_LANGSTROTH; 10_FRAME_LANGSTROTH; TOP_BAR; OTHER-
+        # 8_FRAME_LANGSTROTH; 10_FRAME_LANGSTROTH; TOP_BAR; WARRE_HIVE; OTHER-
         null=False,
         blank=True,
         help_text='What kind of equipment do you use?'

--- a/src/icp/apps/beekeepers/models.py
+++ b/src/icp/apps/beekeepers/models.py
@@ -429,6 +429,7 @@ class UserSurvey(models.Model):
         null=False,
         help_text='Do you manage for Varroa?')
     varroa_management_trigger = models.TextField(
+        # MITE_COUNTS; MITE_SYMPTOMS; TIME_OF_YEAR; OTHER-
         null=True,
         blank=True,
         help_text='How do you decide when to manage for Varroa?')

--- a/src/icp/apps/beekeepers/sass/06_components/_navbar.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_navbar.scss
@@ -71,6 +71,7 @@
         color: $color-grey-2;
         font-size: 14px;
         font-family: inherit;
+        text-decoration: none;
         background: none;
         border: none;
 


### PR DESCRIPTION
## Overview

The app was tested by an elite group of beekeepers and these are the lower hanging fruit text changes.

Connects #486

### Demo

<img width="586" alt="screen shot 2019-03-07 at 2 15 57 pm" src="https://user-images.githubusercontent.com/10568752/53985584-001df900-40ea-11e9-8104-51b2426dd22f.png">
<img width="619" alt="screen shot 2019-03-07 at 2 16 00 pm" src="https://user-images.githubusercontent.com/10568752/53985585-001df900-40ea-11e9-9b3f-7e027114e1b6.png">
<img width="709" alt="screen shot 2019-03-07 at 2 16 30 pm" src="https://user-images.githubusercontent.com/10568752/53985586-001df900-40ea-11e9-8d3b-cee7db0403d7.png">
<img width="428" alt="screen shot 2019-03-07 at 11 31 58 am" src="https://user-images.githubusercontent.com/10568752/53985587-00b68f80-40ea-11e9-870e-710d7a9294f1.png">
<img width="487" alt="screen shot 2019-03-07 at 11 32 20 am" src="https://user-images.githubusercontent.com/10568752/53985588-00b68f80-40ea-11e9-8ba6-d6df03bc1605.png">
<img width="427" alt="screen shot 2019-03-07 at 3 17 49 pm" src="https://user-images.githubusercontent.com/10568752/53986454-3e1c1c80-40ec-11e9-860a-191ef7729d25.png">


### Notes

I made a judgment call on the thymol and amitraz keys to turn the extra context into a tooltip, but I also want the descriptions I then wrote run by the client.

In the interest of saving time I didn't do the refactoring in forms that I would have otherwise liked 😢 

## Testing Instructions

Make sure that all the surveys open and can submit successfully.
No typos.
