### PR TITLE
Clear old Pollination Mapper results

### DIFF
--- a/src/icp/apps/modeling/migrations/0021_clear_old_results.py
+++ b/src/icp/apps/modeling/migrations/0021_clear_old_results.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def clear_old_results(apps, schema_editor):
+    Scenario = apps.get_model('modeling', 'Scenario')
+
+    Scenario.objects.all().update(
+        results='[]',
+        modification_hash='',
+        inputmod_hash='',
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('modeling', '0020_auto_20161206_1556'),
+    ]
+
+    operations = [
+        migrations.RunPython(clear_old_results)
+    ]

--- a/src/icp/js/src/modeling/models.js
+++ b/src/icp/js/src/modeling/models.js
@@ -500,9 +500,10 @@ var ScenarioModel = Backbone.Model.extend({
             resultModel = this.get('results').first(),
             needsResults = resultModel.isEmpty() || resultModel.isStale(inputmodHash),
             isCurrentConditions = this.get('is_current_conditions'),
+            isProjectLoaded = App.currentProject.get('area_of_interest') !== null,
             fetchResultsPromise;
 
-        if (!needsResults) {
+        if (!needsResults || !isProjectLoaded) {
             // Return current promise or immediately resolve
             return self.fetchResultsPromise || $.when();
         }


### PR DESCRIPTION
## Overview

Since we upgraded to the 2017 CDL in #410 and 598ed284, the current stored results in the database are out of date. By clearing them out, we ensure they will be recalculated when those scenarios are revisited.

Also fix issue with loading projects with their results cleared. In 1ddff11, as part of #165, the result fetching was refactored to be a little more eager. This works well for most cases, but when the results are artificially cleared, it would make existing projects crash, because the results would try to fetch before the project would finish loading (triggered by the project's fetch method), causing the front-end to request the yield without specifying an area of interest.

By adding a test to not fetch results until a project has loaded, we ensure that the eager call for project's with reset results do not fire. The results are fetched again when the result view is loaded, by which time the project has loaded correctly, so the project can reinitialize correctly.

Connects #411

### Notes

Since this is a destructive operation, we should ensure we take a database backup before running this migration.

## Testing Instructions

* Checkout this branch and `bundle --debug`
* Go to [:8000/](http://localhost:8000/) and log in
* Create a project and ensure the scenario values are saved
* Run the migration

    ```
    manage migrate
    ```

* Check the values of these scenarios in the database to ensure they've been cleared:

    ```
    manage dbshell
    ```
    ```sql
    SELECT id, modification_hash, inputmod_hash, results
    FROM modeling_scenario
    WHERE project_id = 3;

     id | modification_hash | inputmod_hash | results
    ----+-------------------+---------------+---------
      6 |                   |               | []
      5 |                   |               | []
    (2 rows)
    ```

* Load the project again in the UI. Ensure it loads correctly and recalculates the results, for _all_ scenarios.
* Inspect the values in the database again and ensure they've been recalculated:

    ```
    manage dbshell
    ```
    ```sql
    SELECT id, modification_hash, inputmod_hash, results
    FROM modeling_scenario
    WHERE project_id = 3;

     id |        modification_hash         |                          inputmod_hash                           |                                                                                                                                                           results
    ----+----------------------------------+------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
      6 | d751713988987e9331980363e24189ce | 22f18ea54d980ee1b6ce6739762de08bd751713988987e9331980363e24189ce | [{"displayName": "Crop Yield", "name": "yield", "inputmod_hash": "22f18ea54d980ee1b6ce6739762de08bd751713988987e9331980363e24189ce", "result": {"51": 0, "27": 0, "20": 0, "48": 0, "17": 0, "49": 0, "18": 0, "28": 64.306640625, "29": 0, "35": 63.834635416666664, "50": 0, "52": 0}, "polling": false, "active": false}]
      5 | d751713988987e9331980363e24189ce | 22f18ea54d980ee1b6ce6739762de08bd751713988987e9331980363e24189ce | [{"displayName": "Crop Yield", "name": "yield", "inputmod_hash": "22f18ea54d980ee1b6ce6739762de08bd751713988987e9331980363e24189ce", "result": {"51": 0, "27": 0, "20": 0, "48": 0, "17": 0, "49": 0, "18": 0, "28": 64.306640625, "29": 0, "35": 63.834635416666664, "50": 0, "52": 0}, "polling": false, "active": false}]
    (2 rows)
    ```

* Create a new project and allow its scenarios to save. Refresh the page. Ensure they are loaded correctly.