### PR TITLE
Rename Pesticide quality to Insecticide load

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/DropdownSelector.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/DropdownSelector.jsx
@@ -1,16 +1,12 @@
 import React from 'react';
 import { func, string, arrayOf } from 'prop-types';
-import { toSpacedString, toTitleCase } from '../utils';
 
 const DropdownSelector = ({ title, options, onOptionClick }) => {
-    const selectOptions = options.map((option) => {
-        const label = toTitleCase(toSpacedString(option));
-        return (
-            <option value={option} key={option}>
-                {label}
-            </option>
-        );
-    });
+    const selectOptions = Object.entries(options).map(([option, label]) => (
+        <option value={option} key={option}>
+            {label}
+        </option>
+    ));
 
     return (
         <form className="dropdown">

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -20,9 +20,9 @@ export const INDICATOR_DETAILS = {
         scoreStops: [7, 33, 39, 46, 66],
     },
     pesticide: {
-        name: 'Pesticide quality',
-        scoreLabels: ['Pesticide'],
-        shortLabel: 'Pesticide',
+        name: 'Insecticide load',
+        scoreLabels: ['Insecticide'],
+        shortLabel: 'Insecticide',
         scoreStops: [0, 13, 26, 37, 208],
     },
     floral_spring: {

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -1,7 +1,10 @@
 export const FORAGE_RANGE_3KM = '3km';
 export const FORAGE_RANGE_5KM = '5km';
 
-export const FORAGE_RANGES = [FORAGE_RANGE_3KM, FORAGE_RANGE_5KM];
+export const FORAGE_RANGES = {
+    [FORAGE_RANGE_3KM]: FORAGE_RANGE_3KM,
+    [FORAGE_RANGE_5KM]: FORAGE_RANGE_5KM,
+};
 export const DEFAULT_SORT = 'default';
 
 export const INDICATORS = {
@@ -45,7 +48,12 @@ export const INDICATOR_DETAILS = {
     },
 };
 
-export const SORT_OPTIONS = [DEFAULT_SORT].concat(Object.values(INDICATORS));
+export const SORT_OPTIONS = Object
+    .entries(INDICATOR_DETAILS)
+    .reduce((acc, [indicator, { name }]) => {
+        acc[indicator] = name;
+        return acc;
+    }, { default: 'Default' });
 
 export const MAP_CENTER = [40.0, -76.079];
 export const MAP_ZOOM = 10;

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -10,17 +10,6 @@ export function toDashedString(value) {
     return value.toLowerCase().replace('_', '-');
 }
 
-export function toSpacedString(value) {
-    return value.replace('_', '\xa0'); // \xa0 === &nbsp;
-}
-
-export function toTitleCase(value) {
-    return value
-        .split(/(\s+)/)
-        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-        .join('');
-}
-
 export function isSameLocation(a, b) {
     return a.lat === b.lat && a.lng === b.lng;
 }


### PR DESCRIPTION
## Overview

This affects only the labels and not the inner variable definitions or S3 raster names. Thus, the upload instructions for the clients do not need to be updated.

Connects #488 

### Demo

![image](https://user-images.githubusercontent.com/1430060/54230524-f119bb00-44dc-11e9-926b-0057e6bfbd27.png)

## Testing Instructions

* Check out this branch and `beekeepers start`
* Go to [:8000/?beekeepers](http://localhost:8000/?beekeepers) and add an apiary
* Ensure the scores say "Insecticide" and "Insecticide load" instead of "Pesticide" or "Pesticide quality"