### PR TITLE
Various IE11 Fixes

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
@@ -384,6 +384,7 @@ class NovemberSurveyForm extends Component {
                         value={varroa_manage_frequency}
                         onChange={this.handleChange}
                         className="form__control"
+                        disabled={!!completedSurvey}
                     >
                         <option value="NEVER">I did not</option>
                         <option value="ONCE">Once a year</option>
@@ -424,6 +425,7 @@ class NovemberSurveyForm extends Component {
                                 value={harvested_honey}
                                 onChange={this.handleChange}
                                 className="form__control"
+                                disabled={!!completedSurvey}
                             >
                                 <option value="DID_NOT_HARVEST">Did not harvest</option>
                                 <option value="LESS_THAN_10">Less than 10 lbs</option>
@@ -474,6 +476,7 @@ class NovemberSurveyForm extends Component {
                                 value={varroa_check_frequency}
                                 onChange={this.handleChange}
                                 className="form__control"
+                                disabled={!!completedSurvey}
                             >
                                 <option value="NEVER">I did not</option>
                                 <option value="ONCE">Once a year</option>

--- a/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
@@ -99,6 +99,11 @@ class NovemberSurveyForm extends Component {
                 let newState = {
                     completedSurvey: data,
                     num_colonies: data.num_colonies,
+                    harvested_honey: data.november.harvested_honey,
+                    small_hive_beetles: data.november.small_hive_beetles,
+                    varroa_check_frequency: data.november.varroa_check_frequency,
+                    varroa_manage_frequency: data.november.varroa_manage_frequency,
+                    all_colonies_treated: data.november.all_colonies_treated,
                 };
                 this.multipleChoiceKeys.forEach((key) => {
                     if (data.november[key]) {

--- a/src/icp/apps/beekeepers/js/src/components/SuccessModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SuccessModal.jsx
@@ -6,7 +6,12 @@ import { connect } from 'react-redux';
 import { closeSuccessModal } from '../actions';
 
 const SuccessModal = ({ dispatch, isSuccessModalOpen }) => (
-    <Popup open={isSuccessModalOpen} onClose={() => dispatch(closeSuccessModal())} modal>
+    <Popup
+        open={isSuccessModalOpen}
+        onClose={() => dispatch(closeSuccessModal())}
+        className="modal"
+        modal
+    >
         {close => (
             <div className="authModal">
                 <div className="authModal__header">

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCardListing.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCardListing.jsx
@@ -56,7 +56,7 @@ const SurveyCardListing = ({
                         </span>
                     </button>
                 )}
-                className="surveyModal"
+                className="modal surveyModal"
                 modal
             >
                 {formComponent}

--- a/src/icp/apps/beekeepers/sass/01_settings/_type.scss
+++ b/src/icp/apps/beekeepers/sass/01_settings/_type.scss
@@ -1,4 +1,4 @@
-$font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, Arial, sans-serif;
+$font-family: BlinkMacSystemFont, -apple-system, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Arial, sans-serif;
 
 $font-weight-light: 400;
 $font-weight-normal: 500;

--- a/src/icp/apps/beekeepers/sass/05_base/_base.scss
+++ b/src/icp/apps/beekeepers/sass/05_base/_base.scss
@@ -21,7 +21,7 @@ body {
     color: $text-dark;
     font: $font-base;
     font-weight: $font-weight-normal;
-    background-color: #ccc;
+    background-color: #f8f9fb;
 
     > .beekeepers-app {
         display: flex;

--- a/src/icp/apps/beekeepers/sass/06_components/_modal.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_modal.scss
@@ -1,10 +1,17 @@
 .popup-overlay {
     z-index: 1001 !important;
+    display: block !important;
     overflow-y: auto;
 }
 
 .popup-content {
     z-index: 1000 !important;
+}
+
+.modal {
+    width: 400px !important;
+    margin-top: 60px !important;
+    padding: 0 !important;
 }
 
 .userModal,
@@ -96,9 +103,4 @@
             width: 100%;
         }
     }
-}
-
-.modal {
-    width: 400px !important;
-    padding: 0 !important;
 }

--- a/src/icp/apps/beekeepers/sass/06_components/_survey.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_survey.scss
@@ -1,6 +1,4 @@
 .survey {
-    display: flex;
-    flex-direction: column;
     width: 100%;
     height: auto;
     min-height: max-content;
@@ -24,7 +22,7 @@
 
     &__header {
         width: 600px;
-        margin-top: 3rem;
+        margin-top: 1rem;
         font: $font-xxl;
         font-weight: $font-weight-bold;
 
@@ -34,14 +32,12 @@
     }
 
     &__body {
-        display: flex;
-        flex-direction: column;
         width: 600px;
         margin: 2rem 0;
         font: $font-med;
 
         &--section {
-            margin: 2rem 0;
+            margin: 4rem 0;
             font: $font-xl;
             font-weight: $font-weight-bold;
         }
@@ -83,9 +79,6 @@
 }
 
 .surveyCard {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
     padding: 10px 15px;
     background-color: #fff;
     border-radius: 4px;
@@ -99,12 +92,6 @@
         margin: 10px 0;
     }
 
-    &__content {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-    }
-
     &__title {
         margin: 10px 0;
         font: $font-lg;
@@ -112,8 +99,6 @@
     }
 
     &__body {
-        // display: flex;
-        flex-direction: column;
         font: $font-med;
         text-decoration: none;
     }


### PR DESCRIPTION
## Overview

Fixes the font loading issue in IE11, using ideas from [here](https://booking.design/implementing-system-fonts-on-booking-com-a-lesson-learned-bdc984df627f). We should consider flipping this sequence for all projects to ensure IE11 compatibility.

Also fixes tall modals in IE11 which were previously transparent below the window:

![image](https://user-images.githubusercontent.com/1430060/54314346-cea5a180-45b1-11e9-8704-0b3060c64e4d.png)

Also fixes the November Survey to load correctly in read-only mode. Previously some fields were not initialized correctly, and dropdowns were not disabled.

Connects #490 
Connects #465 

### Demo

Fonts rendering correctly:

![image](https://user-images.githubusercontent.com/1430060/54313748-4b378080-45b0-11e9-9fa2-da1bf5bb0257.png)

Modals scrolling correctly:

![image](https://user-images.githubusercontent.com/1430060/54313786-61ddd780-45b0-11e9-9d25-a46cc35c0555.png)

November Survey reinitializing correctly:

![image](https://user-images.githubusercontent.com/1430060/54313839-7e7a0f80-45b0-11e9-8fe6-9d059754b7ae.png)

## Testing Instructions

* Check out this branch and `beekeepers build`
* Test the site in IE11 (BrowserStack or Windows VM)
  - [x] Ensure the fonts load correctly
  - [x] Ensure that tall modals (like surveys) scroll and look correct
* Fill out a November Survey and save it. Make sure you pick non-default choices for all dropdowns.
* Load the same survey to view it in read-only mode.
  - [x] Ensure all the fields are correctly filled
  - [x] Ensure all fields are disabled