### PR TITLE
Downgrade to supported libpq-dev for Trusty

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -19,7 +19,7 @@ postgresql_database: icp
 postgresql_version: "9.4"
 postgresql_package_version: "9.4.*.pgdg14.04+1"
 postgresql_support_repository_channel: "9.4"
-postgresql_support_libpq_version: "9.4.*"
+postgresql_support_libpq_version: "9.3.*"
 postgresql_support_psycopg2_version: "2.6.*"
 postgis_version: "2.2"
 postgis_package_version: "2.2.*.pgdg14.04+1"


### PR DESCRIPTION
## Overview

The 9.4.* series of libpq-dev seems to have disappeared, so we
switch to 9.3. This is the only option here: https://packages.ubuntu.com/trusty/libpq-dev

![image](https://user-images.githubusercontent.com/1430060/54389728-2eb24b80-4677-11e9-8fc5-f0454ab501b7.png)

This unblocks provisioning for `app` and `worker` VMs.

## Testing Instructions

* Destroy and create `app` and `worker` and ensure they are created correctly