### PR TITLE
Show Monthly Survey Colonies in Correct Order

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyForm.jsx
@@ -159,7 +159,7 @@ class MonthlySurveyForm extends Component {
                         });
 
                         return Object.assign({}, clientData, serverData);
-                    });
+                    }).sort((a, b) => a.id - b.id); // In ascending order of id
 
                     this.setState({
                         num_colonies: data.num_colonies,

--- a/src/icp/apps/beekeepers/js/src/components/ParticipateModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ParticipateModal.jsx
@@ -29,8 +29,15 @@ const ParticipateModal = ({ isParticipateModalOpen, dispatch }) => (
                     about the quality of their landscapes for bees, and site-specific
                     recommendations for land and bee management practices. But, to do this, we
                     need your help, so we can have data from many diverse landscapes! If you
-                    have a wild bee hotel and would like to participate in our study, please
-                    click here. If you are a beekeeper, please follow the link below.
+                    have a wild bee hotel and would like to participate in our study,&nbsp;
+                    <a
+                        href="http://beescape.org/wild-bees/"
+                        target="_blank"
+                        rel="noreferrer noopener"
+                    >
+                        please click here
+                    </a>
+                    . If you are a beekeeper, please follow the link below.
                 </div>
                 <div className="authModal__footer">
                     <button


### PR DESCRIPTION
## Overview

Even though the front-end sends the apiaries to the back-end in the correct order, and they are saved in the correct order, for some reason when they are queried for again, the serializer sends them back in reverse order:

https://github.com/project-icp/bee-pollinator-app/blob/3ab3582d60da4eb8e4845ab15139e98b6a01ce90/src/icp/apps/beekeepers/serializers.py#L56-L64

https://github.com/project-icp/bee-pollinator-app/blob/3ab3582d60da4eb8e4845ab15139e98b6a01ce90/src/icp/apps/beekeepers/views.py#L161-L170

It was unclear how this can be remedied on the DRF side, as the documentation did not provide any hints, nor could this question be found on Stack Overflow.

In the interest of expediency, I've decided to sort the results in the front-end when the Monthly Survey details modal is loaded. This ensures they are shown in the correct order, regardless of what order they are sent down from the API in.

Also adds a missing link.

Connects #459 
Connects #497 

### Demo

First survey is for the colony "A":

![image](https://user-images.githubusercontent.com/1430060/54460868-34746380-4741-11e9-9e56-7f3a01992b1e.png)

Participate in Study link:

![image](https://user-images.githubusercontent.com/1430060/54460884-40602580-4741-11e9-8e59-7a0c669ae546.png)

## Testing Instructions

* Check out this branch and `beekeepers start`
* Go to [:8000/?beekeepers](http://localhost:8000/?beekeepers) and make sure you're not logged in
* Click on the "Participate in Study" button in the top right
  - [x] Ensure the modal has the correct link according to #497 
* Log in as a "Pro" user.
* Create an Apiary.
* For the apiary, enter a Monthly Survey.
  - Write `2` as the number of colonies
  - Name the colony in the first tab `First`
  - Name the colony in the third tab `Third`
  - Add dates of inspection to both tabs, and submit the survey
* The modal will update to be read-only with the saved values.
  - [x] Ensure the tabs are in the correct order, with the first tab being `First` and the second tab being `Third`
    - The second empty tab will be omitted
* Close the modal. Open this (or any other) submitted Monthly Survey
  - [x] Ensure the tabs are in the correct order, with the first tab being `First` and the second tab being `Third`