### PR TITLE
Fix Staging Issues

### DIFF
--- a/src/icp/apps/beekeepers/sass/06_components/_survey.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_survey.scss
@@ -44,6 +44,7 @@
     }
 
     &__button {
+        display: inline-block;
         max-width: max-content;
         margin: 2rem 0;
         padding: 15px;
@@ -52,6 +53,7 @@
         text-decoration: none;
         background: $color-primary;
         border: none;
+        border-radius: 5px;
     }
 
     .dropdown__button {

--- a/src/icp/apps/beekeepers/views.py
+++ b/src/icp/apps/beekeepers/views.py
@@ -185,7 +185,9 @@ class ApiaryViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
-        return Apiary.objects.filter(user=self.request.user, deleted_at=None)
+        return (Apiary.objects
+                      .filter(user=self.request.user, deleted_at=None)
+                      .order_by('id'))
 
     def destroy(self, request, pk=None):
         """Soft deletes Apiaries from user's account"""


### PR DESCRIPTION
## Overview

Fixes issues found during staging testing.

### Demo

Previously this button was overlapping content:

![image](https://user-images.githubusercontent.com/1430060/54547147-8ef90400-497b-11e9-8dec-ca309b93e2f4.png)

That is now fixed:

![image](https://user-images.githubusercontent.com/1430060/54547163-96b8a880-497b-11e9-96e0-18e123c8ee29.png)

---

Previously reloading the main app after logging in would fetch apiaries in a random order:

![image](https://user-images.githubusercontent.com/1430060/54547259-c49ded00-497b-11e9-9eb5-40196873c8df.png)

They are now always fetched in the correct order:

![image](https://user-images.githubusercontent.com/1430060/54547320-da131700-497b-11e9-8469-b8afe1f10619.png)

## Testing Instructions

* Check out this branch and log in
* Make sure you have 0 apiaries. Delete all of them if needed.
* Go to the Survey page.
  - [x] Ensure the button pointing to the Location Finder isn't overlapping content
* Go to the Location finder.
* Add some apiaries. Delete one or two from the middle (not the first or the last).
* Refresh the page.
  - [x] Ensure the apiaries show up in the correct ordering for "Default"
  - [x] Ensure you can delete existing apiaries, and the correct ones are deleted
  - [x] Ensure you can add new apiaries, and they have the correct marker assigned