### PR TITLE
Add Apiary Name to Survey Pop-ups

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/ApiarySurveyListing.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiarySurveyListing.jsx
@@ -9,6 +9,7 @@ const ApiarySurveyListing = ({ apiary, surveys }) => {
     const listings = surveys.map(survey => (
         <SurveyCardListing
             key={name + survey.month_year + survey.survey_type}
+            apiary={apiary}
             survey={survey}
         />
     ));

--- a/src/icp/apps/beekeepers/js/src/components/ApiarySurveyListing.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiarySurveyListing.jsx
@@ -15,8 +15,8 @@ const ApiarySurveyListing = ({ apiary, surveys }) => {
     ));
 
     return (
-        <div>
-            <h2>{name}</h2>
+        <div className="historyModal">
+            <h2 className="title">{name}</h2>
             {listings}
         </div>
     );

--- a/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
@@ -4,8 +4,12 @@ import { func } from 'prop-types';
 
 import { fetchUserApiaries, flashSuccessModal } from '../actions';
 import { SURVEY_TYPE_APRIL, COLONY_LOSS_REASONS } from '../constants';
-import { arrayToSemicolonDelimitedString, getOrCreateSurveyRequest } from '../utils';
-import { Survey } from '../propTypes';
+import {
+    arrayToSemicolonDelimitedString,
+    getOrCreateSurveyRequest,
+    toMonthNameYear,
+} from '../utils';
+import { Apiary, Survey } from '../propTypes';
 
 class AprilSurveyForm extends Component {
     constructor(props) {
@@ -176,6 +180,11 @@ class AprilSurveyForm extends Component {
             error,
         } = this.state;
 
+        const {
+            apiary: { name },
+            survey: { month_year },
+        } = this.props;
+
         const userMessage = error.length ? (
             <div className="form__group--error">
                 {error}
@@ -194,8 +203,8 @@ class AprilSurveyForm extends Component {
             );
 
         const title = completedSurvey
-            ? 'Survey results'
-            : 'Fill out this survey about your apiary';
+            ? `Survey results for ${toMonthNameYear(month_year)}`
+            : `Survey for ${toMonthNameYear(month_year)}`;
 
         const confirmationButton = completedSurvey
             ? null
@@ -264,7 +273,7 @@ class AprilSurveyForm extends Component {
         return (
             <div className="authModal">
                 <div className="authModal__header">
-                    <div>April survey</div>
+                    <div>{name}</div>
                 </div>
                 <div className="authModal__content">
                     {userMessage}
@@ -281,6 +290,7 @@ function mapStateToProps(state) {
 }
 
 AprilSurveyForm.propTypes = {
+    apiary: Apiary.isRequired,
     survey: Survey.isRequired,
     dispatch: func.isRequired,
     close: func.isRequired,

--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyForm.jsx
@@ -12,7 +12,7 @@ import 'react-tabs/style/react-tabs.css';
 
 import { fetchUserApiaries, flashSuccessModal } from '../actions';
 import { SURVEY_TYPE_MONTHLY } from '../constants';
-import { Survey } from '../propTypes';
+import { Survey, Apiary } from '../propTypes';
 import {
     arrayToSemicolonDelimitedString,
     getOrCreateSurveyRequest,
@@ -326,7 +326,10 @@ class MonthlySurveyForm extends Component {
             selectedTabIndex,
         } = this.state;
 
-        const { survey: { month_year, completed } } = this.props;
+        const {
+            apiary: { name },
+            survey: { month_year, completed },
+        } = this.props;
 
         const userMessage = error.length ? (
             <div className="form__group--error">
@@ -425,7 +428,7 @@ class MonthlySurveyForm extends Component {
         return (
             <div className="authModal">
                 <div className="authModal__header">
-                    <div>Monthly Survey</div>
+                    <div>{name}</div>
                 </div>
                 <div className="authModal__content">
                     {userMessage}
@@ -442,6 +445,7 @@ function mapStateToProps(state) {
 }
 
 MonthlySurveyForm.propTypes = {
+    apiary: Apiary.isRequired,
     survey: Survey.isRequired,
     dispatch: func.isRequired,
     close: func.isRequired,

--- a/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
@@ -14,8 +14,12 @@ import {
     THYMOL_DESCRIPTION,
     AMITRAZ_DESCRIPTION,
 } from '../constants';
-import { arrayToSemicolonDelimitedString, getOrCreateSurveyRequest } from '../utils';
-import { Survey } from '../propTypes';
+import {
+    arrayToSemicolonDelimitedString,
+    getOrCreateSurveyRequest,
+    toMonthNameYear,
+} from '../utils';
+import { Apiary, Survey } from '../propTypes';
 import Tooltip from './Tooltip';
 
 
@@ -294,6 +298,11 @@ class NovemberSurveyForm extends Component {
             error,
         } = this.state;
 
+        const {
+            apiary: { name },
+            survey: { month_year },
+        } = this.props;
+
         const userMessage = error.length ? (
             <div className="form__group--error">
                 {error}
@@ -312,8 +321,8 @@ class NovemberSurveyForm extends Component {
             );
 
         const title = completedSurvey
-            ? 'Survey results'
-            : 'Fill out this survey about your apiary';
+            ? `Survey results for ${toMonthNameYear(month_year)}`
+            : `Survey for ${toMonthNameYear(month_year)}`;
 
         const confirmationButton = completedSurvey
             ? null
@@ -536,7 +545,7 @@ class NovemberSurveyForm extends Component {
         return (
             <div className="authModal">
                 <div className="authModal__header">
-                    <div>November survey</div>
+                    <div>{name}</div>
                 </div>
                 <div className="authModal__content">
                     {userMessage}
@@ -553,6 +562,7 @@ function mapStateToProps(state) {
 }
 
 NovemberSurveyForm.propTypes = {
+    apiary: Apiary.isRequired,
     survey: Survey.isRequired,
     dispatch: func.isRequired,
     close: func.isRequired,

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
@@ -40,6 +40,7 @@ const SurveyCard = ({ apiary, dispatch, surveys }) => {
         cardBody = shownSurveys.map(survey => (
             <SurveyCardListing
                 key={name + survey.month_year + survey.survey_type}
+                apiary={apiary}
                 survey={survey}
             />
         ));

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCardListing.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCardListing.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Popup from 'reactjs-popup';
 
-import { Survey } from '../propTypes';
+import { Apiary, Survey } from '../propTypes';
 import { toMonthNameYear } from '../utils';
 import {
     SURVEY_TYPE_NOVEMBER,
@@ -14,6 +14,7 @@ import NovemberSurveyForm from './NovemberSurveyForm';
 import MonthlySurveyForm from './MonthlySurveyForm';
 
 const SurveyCardListing = ({
+    apiary,
     survey,
     survey: {
         month_year,
@@ -25,17 +26,17 @@ const SurveyCardListing = ({
     switch (survey_type) {
         case SURVEY_TYPE_APRIL:
             formComponent = (close => (
-                <AprilSurveyForm survey={survey} close={close} />
+                <AprilSurveyForm apiary={apiary} survey={survey} close={close} />
             ));
             break;
         case SURVEY_TYPE_NOVEMBER:
             formComponent = (close => (
-                <NovemberSurveyForm survey={survey} close={close} />
+                <NovemberSurveyForm apiary={apiary} survey={survey} close={close} />
             ));
             break;
         case SURVEY_TYPE_MONTHLY:
             formComponent = (close => (
-                <MonthlySurveyForm survey={survey} close={close} />
+                <MonthlySurveyForm apiary={apiary} survey={survey} close={close} />
             ));
             break;
         default:
@@ -66,6 +67,7 @@ const SurveyCardListing = ({
 };
 
 SurveyCardListing.propTypes = {
+    apiary: Apiary.isRequired,
     survey: Survey.isRequired,
 };
 

--- a/src/icp/apps/beekeepers/sass/06_components/_modal.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_modal.scss
@@ -104,3 +104,11 @@
         }
     }
 }
+
+.historyModal {
+    padding: 15px;
+
+    > .title {
+        padding-bottom: 10px;
+    }
+}


### PR DESCRIPTION
## Overview

This improves the user experience by reminding the user the apiary for which they are filling out the details. Also includes some styling improvements to the "Full History" pop-up.

Connects #506 

### Demo

![image](https://user-images.githubusercontent.com/1430060/57945434-e1856c80-78a7-11e9-92de-c9badf839a41.png)

![image](https://user-images.githubusercontent.com/1430060/57945443-e6e2b700-78a7-11e9-902f-f962eafbcd6b.png)

![image](https://user-images.githubusercontent.com/1430060/57945456-ed712e80-78a7-11e9-8538-b438e69cb4e2.png)

## Testing Instructions

* Check out this branch and `beekeepers start`
* Go to [:8000/?beekeepers](http://localhost:8000/?beekeepers)
* Go to the survey page and open different kinds of surveys
  - [ ] Ensure Monthly Survey shows Apiary name
  - [ ] Ensure April Survey shows Apiary name
  - [ ] Ensure November Survey shows Apiary name
* Try opening the surveys from different places
  - [ ] Ensure opening surveys from survey card works
  - [ ] Ensure opening surveys from "Full History" pop-up works