### PR TITLE
Update Form Fields

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
@@ -240,6 +240,7 @@ class MonthlySurveyColonyForm extends Component {
                 {this.inputSelect('queen_source', 'Where did the queen come from?', [
                     ['NON_LOCAL_COMMERCIAL', 'Non-local commercial breeder'],
                     ['LOCAL_COMMERCIAL', 'Local commercial breeder'],
+                    ['LOCAL_NON_COMMERCIAL', 'Local, non-commercial or reared on site'],
                     ['REQUEENED', 'Colony requeened itself'],
                     ['PACKAGE', 'Package'],
                     ['FERAL', 'Feral colony or swarm'],

--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
@@ -205,7 +205,7 @@ class MonthlySurveyColonyForm extends Component {
                 {varroaCountDetails}
                 <div className="form__group">
                     <label htmlFor="varroa_treatment">
-                        Do you treat for Varroa? If so, how?
+                        Did you manage for Varroa since the last inspection?
                         Check all that apply.
                     </label>
                     {this.makeMultipleChoiceInputs('varroa_treatment', MITE_MANAGEMENT_OPTIONS, [THYMOL_DESCRIPTION, AMITRAZ_DESCRIPTION])}

--- a/src/icp/apps/beekeepers/migrations/0013_update_queen_source_options.py
+++ b/src/icp/apps/beekeepers/migrations/0013_update_queen_source_options.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('beekeepers', '0012_add_new_survey_fields'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='monthlysurvey',
+            name='queen_source',
+            field=models.CharField(blank=True, max_length=255, null=True, help_text='Where did the queen come from?', choices=[('NON_LOCAL_COMMERCIAL', 'Non-local commercial breeder'), ('LOCAL_COMMERCIAL', 'Local commercial breeder'), ('LOCAL_NON_COMMERCIAL', 'Local, non-commercial or reared on site'), ('REQUEENED', 'Colony requeened itself'), ('PACKAGE', 'Package'), ('FERAL', 'Feral colony or swarm')]),
+        ),
+    ]

--- a/src/icp/apps/beekeepers/models.py
+++ b/src/icp/apps/beekeepers/models.py
@@ -253,6 +253,7 @@ class MonthlySurvey(models.Model):
     QUEEN_SOURCES = (
         ('NON_LOCAL_COMMERCIAL', 'Non-local commercial breeder'),
         ('LOCAL_COMMERCIAL', 'Local commercial breeder'),
+        ('LOCAL_NON_COMMERCIAL', 'Local, non-commercial or reared on site'),
         ('REQUEENED', 'Colony requeened itself'),
         ('PACKAGE', 'Package'),
         ('FERAL', 'Feral colony or swarm'),


### PR DESCRIPTION
## Overview

Updates wording on a Varroa Management question, and adds a new Local Non-Commercial option to Queen Source.

Connects #507 

### Demo

![image](https://user-images.githubusercontent.com/1430060/57948696-5492e100-78b0-11e9-9b16-b90584a8b3c8.png)

## Testing Instructions

* On `develop` fill out a Monthly Survey
* Check out this branch and run migrations `manage migrate`
* Inspect the database
  - [x] Ensure that existing monthly survey hasn't been affected
* Fill out a new Monthly Survey. Make sure to use "Local, non-commercial or reared on site" as the answer for "Where did the queen come from?"
  - [x] Ensure `queen_source` has a value of `LOCAL_NON_COMMERCIAL` in the database