### PR TITLE
Editable Apiary Names

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -60,54 +60,54 @@ class ApiaryCard extends Component {
     }
 
     getCardNameBlock() {
-        const { isEditing, isHovering, apiaryName } = this.state;
+        const { isEditing, isHovering } = this.state;
+
+        let className = 'card__name';
+        let onKeyPress = () => {};
+        let onChange = () => {};
+        let onClick = () => {};
+        let onFocus = () => {};
+        let cardButton = null;
+        let readOnly = true;
 
         if (isEditing) {
-            return (
-                <>
-                    <input
-                        className="card__name card__name-editing"
-                        onChange={this.onApiaryNameChange}
-                        onKeyPress={this.saveApiaryNameOnEnter}
-                        value={apiaryName}
-                    />
-                    <CardButton
-                        icon="check"
-                        tooltip="Save apiary name"
-                        onClick={this.onApiaryNameSave}
-                    />
-                </>
+            className = 'card__name card__name-editing';
+            onChange = this.onApiaryNameChange;
+            onKeyPress = this.saveApiaryNameOnEnter;
+            onFocus = () => {};
+            readOnly = false;
+            cardButton = (
+                <CardButton
+                    icon="check"
+                    tooltip="Save apiary name"
+                    onClick={this.onApiaryNameSave}
+                />
             );
+        } else if (isHovering) {
+            className = 'card__name card__name-hovering';
+            onClick = this.enableEditing;
+            onKeyPress = this.enableEditingOnEnter;
+            cardButton = (
+                <CardButton
+                    icon="pencil"
+                    tooltip="Edit apiary name"
+                    onClick={this.enableEditing}
+                />
+            );
+        } else {
+            onKeyPress = this.enableEditingOnEnter;
+            onFocus = this.enableHovering;
         }
 
-        if (isHovering) {
-            return (
-                <>
-                    <input
-                        className="card__name card__name-hovering"
-                        readOnly
-                        onClick={this.enableEditing}
-                        onKeyPress={this.enableEditingOnEnter}
-                        value={apiaryName}
-                    />
-                    <CardButton
-                        icon="pencil"
-                        tooltip="Edit apiary name"
-                        onClick={this.enableEditing}
-                    />
-                </>
-            );
-        }
-
-        return (
-            <input
-                className="card__name"
-                readOnly
-                onKeyPress={this.enableEditingOnEnter}
-                onFocus={this.enableHovering}
-                value={apiaryName}
-            />
-        );
+        return {
+            className,
+            onKeyPress,
+            onChange,
+            onClick,
+            onFocus,
+            cardButton,
+            readOnly,
+        };
     }
 
     dispatchAction(action) {
@@ -148,6 +148,7 @@ class ApiaryCard extends Component {
 
     render() {
         const { apiary, forageRange, dispatch } = this.props;
+        const { apiaryName } = this.state;
 
         const {
             marker,
@@ -203,6 +204,8 @@ class ApiaryCard extends Component {
             <ScoresLabel key={i} indicator={i} scores={[values[i]]} />
         ));
 
+        const cardName = this.getCardNameBlock();
+
         return (
             <li className="card">
                 <div className="card__top">
@@ -212,7 +215,16 @@ class ApiaryCard extends Component {
                         onMouseLeave={this.disableHovering}
                     >
                         <div className={`marker ${markerClass}`}>{marker}</div>
-                        {this.getCardNameBlock()}
+                        <input
+                            className={cardName.className}
+                            onKeyPress={cardName.onKeyPress}
+                            onChange={cardName.onChange}
+                            onClick={cardName.onClick}
+                            onFocus={cardName.onFocus}
+                            readOnly={cardName.readOnly}
+                            value={apiaryName}
+                        />
+                        {cardName.cardButton}
                     </div>
                     <div className="card__buttons">
                         <CardButton

--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { func, string } from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -15,98 +15,115 @@ import { getMarkerClass } from '../utils';
 import CardButton from './CardButton';
 import ScoresLabel from './ScoresLabel';
 
-const ApiaryCard = ({ apiary, forageRange, dispatch }) => {
-    const {
-        marker,
-        name,
-        starred,
-        surveyed,
-        scores,
-    } = apiary;
+class ApiaryCard extends Component {
+    constructor(props) {
+        super(props);
 
-    const values = scores[forageRange];
-
-    const markerClass = getMarkerClass(apiary);
-
-    const onStar = () => dispatch(setApiaryStar(apiary));
-    const onSurvey = () => dispatch(setApiarySurvey(apiary));
-    const onDelete = () => dispatch(deleteApiary(apiary));
-
-    let scoreCard;
-    if (!Object.keys(apiary.scores[forageRange]).length && !apiary.fetching) {
-        scoreCard = (
-            <>
-                <div className="card__top">
-                    <div className="card__identification">
-                        <div className={`marker ${markerClass}`}>{marker}</div>
-                        <div className="card__name">Error fetching apiary data</div>
-                    </div>
-                    <div className="card__buttons">
-                        <CardButton
-                            icon="trash"
-                            filled
-                            tooltip="Delete apiary"
-                            onClick={onDelete}
-                        />
-                    </div>
-                </div>
-                <button
-                    type="button"
-                    onClick={() => dispatch(fetchApiaryScores([apiary], forageRange))}
-                >
-                    Try again?
-                </button>
-            </>
-        );
-    } else if (!Object.keys(apiary.scores[forageRange]).length) {
-        scoreCard = <div className="spinner" />;
-    } else {
-        const scoreLabels = Object.values(INDICATORS).map(i => (
-            <ScoresLabel key={i} indicator={i} scores={[values[i]]} />
-        ));
-        scoreCard = (
-            <>
-                <div className="card__top">
-                    <div className="card__identification">
-                        <div className={`marker ${markerClass}`}>{marker}</div>
-                        <div className="card__name">{name}</div>
-                    </div>
-                    <div className="card__buttons">
-                        <CardButton
-                            icon="star"
-                            filled={starred}
-                            tooltip="Mark apiary as important"
-                            onClick={onStar}
-                        />
-                        <CardButton
-                            icon="clipboard"
-                            filled={surveyed}
-                            tooltip="Include apiary in surveys"
-                            onClick={onSurvey}
-                        />
-                        <CardButton
-                            icon="trash"
-                            filled
-                            tooltip="Delete apiary"
-                            onClick={onDelete}
-                        />
-                    </div>
-                </div>
-                <div className="card__bottom">
-                    <div className="indicator-container">
-                        {scoreLabels}
-                    </div>
-                </div>
-            </>
-        );
+        this.onStar = this.dispatchAction(setApiaryStar).bind(this);
+        this.onSurvey = this.dispatchAction(setApiarySurvey).bind(this);
+        this.onDelete = this.dispatchAction(deleteApiary).bind(this);
     }
 
-    return (
-        <li className="card">
-            {scoreCard}
-        </li>
-    );
-};
+    dispatchAction(action) {
+        return () => {
+            const { apiary, dispatch } = this.props;
+
+            dispatch(action(apiary));
+        };
+    }
+
+    render() {
+        const { apiary, forageRange, dispatch } = this.props;
+
+        const {
+            marker,
+            name,
+            starred,
+            surveyed,
+            scores,
+            fetching,
+        } = apiary;
+
+        const values = scores[forageRange];
+
+        const markerClass = getMarkerClass(apiary);
+
+        let scoreCard;
+        if (!Object.keys(scores[forageRange]).length && !fetching) {
+            scoreCard = (
+                <>
+                    <div className="card__top">
+                        <div className="card__identification">
+                            <div className={`marker ${markerClass}`}>{marker}</div>
+                            <div className="card__name">Error fetching apiary data</div>
+                        </div>
+                        <div className="card__buttons">
+                            <CardButton
+                                icon="trash"
+                                filled
+                                tooltip="Delete apiary"
+                                onClick={this.onDelete}
+                            />
+                        </div>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={() => dispatch(fetchApiaryScores([apiary], forageRange))}
+                    >
+                        Try again?
+                    </button>
+                </>
+            );
+        } else if (!Object.keys(scores[forageRange]).length) {
+            scoreCard = <div className="spinner" />;
+        } else {
+            const scoreLabels = Object.values(INDICATORS).map(i => (
+                <ScoresLabel key={i} indicator={i} scores={[values[i]]} />
+            ));
+            scoreCard = (
+                <>
+                    <div className="card__top">
+                        <div className="card__identification">
+                            <div className={`marker ${markerClass}`}>{marker}</div>
+                            <div className="card__name">{name}</div>
+                        </div>
+                        <div className="card__buttons">
+                            <CardButton
+                                icon="star"
+                                filled={starred}
+                                tooltip="Mark apiary as important"
+                                onClick={this.onStar}
+                            />
+                            <CardButton
+                                icon="clipboard"
+                                filled={surveyed}
+                                tooltip="Include apiary in surveys"
+                                onClick={this.onSurvey}
+                            />
+                            <CardButton
+                                icon="trash"
+                                filled
+                                tooltip="Delete apiary"
+                                onClick={this.onDelete}
+                            />
+                        </div>
+                    </div>
+                    <div className="card__bottom">
+                        <div className="indicator-container">
+                            {scoreLabels}
+                        </div>
+                    </div>
+                </>
+            );
+        }
+
+        return (
+            <li className="card">
+                {scoreCard}
+            </li>
+        );
+    }
+}
 
 ApiaryCard.propTypes = {
     apiary: Apiary.isRequired,

--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -40,6 +40,21 @@ class ApiaryCard extends Component {
         this.saveApiaryNameOnEnter = this.saveApiaryNameOnEnter.bind(this);
     }
 
+    componentDidUpdate(prevProps) {
+        const { apiary: { name } } = this.props;
+        const { apiary: { name: prevName } } = prevProps;
+
+        if (prevName !== name) {
+            // Update internal state if the prop has changed.
+            // This is generally discouraged, see https://github.com/yannickcr/eslint-plugin-react/blob/7dce90a4f570847b33eaefddb8d9bb7d6eca9dc5/docs/rules/no-did-update-set-state.md
+            // but without this the default name isn't updated with the
+            // reverse geocoded address which kicks in a little later.
+
+            // eslint-disable-next-line react/no-did-update-set-state
+            this.setState({ apiaryName: name });
+        }
+    }
+
     onApiaryNameChange(e) {
         this.setState({ apiaryName: e.target.value });
     }

--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { func, string } from 'prop-types';
 import { connect } from 'react-redux';
+import update from 'immutability-helper';
 
 import { Apiary } from '../propTypes';
 import { INDICATORS } from '../constants';
@@ -8,6 +9,7 @@ import {
     setApiaryStar,
     setApiarySurvey,
     deleteApiary,
+    updateApiary,
     fetchApiaryScores,
 } from '../actions';
 import { getMarkerClass } from '../utils';
@@ -19,9 +21,93 @@ class ApiaryCard extends Component {
     constructor(props) {
         super(props);
 
+        this.state = {
+            isHovering: false,
+            isEditing: false,
+            apiaryName: props.apiary.name,
+        };
+
         this.onStar = this.dispatchAction(setApiaryStar).bind(this);
         this.onSurvey = this.dispatchAction(setApiarySurvey).bind(this);
         this.onDelete = this.dispatchAction(deleteApiary).bind(this);
+        this.onApiaryNameChange = this.onApiaryNameChange.bind(this);
+        this.onApiaryNameSave = this.onApiaryNameSave.bind(this);
+        this.getCardNameBlock = this.getCardNameBlock.bind(this);
+        this.enableHovering = this.enableHovering.bind(this);
+        this.disableHovering = this.disableHovering.bind(this);
+        this.enableEditing = this.enableEditing.bind(this);
+        this.enableEditingOnEnter = this.enableEditingOnEnter.bind(this);
+        this.saveApiaryNameOnEnter = this.saveApiaryNameOnEnter.bind(this);
+    }
+
+    onApiaryNameChange(e) {
+        this.setState({ apiaryName: e.target.value });
+    }
+
+    onApiaryNameSave() {
+        const { apiary, dispatch } = this.props;
+        const { apiaryName } = this.state;
+
+        if (apiary.name !== apiaryName) {
+            const apiaryWithNewName = update(apiary, {
+                name: { $set: apiaryName },
+            });
+
+            dispatch(updateApiary(apiaryWithNewName));
+        }
+
+        this.setState({ isEditing: false });
+    }
+
+    getCardNameBlock() {
+        const { isEditing, isHovering, apiaryName } = this.state;
+
+        if (isEditing) {
+            return (
+                <>
+                    <input
+                        className="card__name card__name-editing"
+                        onChange={this.onApiaryNameChange}
+                        onKeyPress={this.saveApiaryNameOnEnter}
+                        value={apiaryName}
+                    />
+                    <CardButton
+                        icon="check"
+                        tooltip="Save apiary name"
+                        onClick={this.onApiaryNameSave}
+                    />
+                </>
+            );
+        }
+
+        if (isHovering) {
+            return (
+                <>
+                    <input
+                        className="card__name card__name-hovering"
+                        readOnly
+                        onClick={this.enableEditing}
+                        onKeyPress={this.enableEditingOnEnter}
+                        value={apiaryName}
+                    />
+                    <CardButton
+                        icon="pencil"
+                        tooltip="Edit apiary name"
+                        onClick={this.enableEditing}
+                    />
+                </>
+            );
+        }
+
+        return (
+            <input
+                className="card__name"
+                readOnly
+                onKeyPress={this.enableEditingOnEnter}
+                onFocus={this.enableHovering}
+                value={apiaryName}
+            />
+        );
     }
 
     dispatchAction(action) {
@@ -32,12 +118,39 @@ class ApiaryCard extends Component {
         };
     }
 
+    enableHovering() {
+        this.setState({ isHovering: true });
+    }
+
+    disableHovering() {
+        this.setState({ isHovering: false });
+    }
+
+    enableEditing() {
+        this.setState({ isEditing: true });
+    }
+
+    enableEditingOnEnter(e) {
+        const { isEditing } = this.state;
+
+        if (!isEditing && e.key === 'Enter') {
+            this.setState({ isEditing: true });
+        }
+    }
+
+    saveApiaryNameOnEnter(e) {
+        const { isEditing } = this.state;
+
+        if (isEditing && e.key === 'Enter') {
+            this.onApiaryNameSave();
+        }
+    }
+
     render() {
         const { apiary, forageRange, dispatch } = this.props;
 
         const {
             marker,
-            name,
             starred,
             surveyed,
             scores,
@@ -48,10 +161,12 @@ class ApiaryCard extends Component {
 
         const markerClass = getMarkerClass(apiary);
 
-        let scoreCard;
-        if (!Object.keys(scores[forageRange]).length && !fetching) {
-            scoreCard = (
-                <>
+        if (!Object.keys(values).length && !fetching) {
+            // Fetch is complete and no scores retrieved
+            // Report error
+
+            return (
+                <li className="card">
                     <div className="card__top">
                         <div className="card__identification">
                             <div className={`marker ${markerClass}`}>{marker}</div>
@@ -72,54 +187,59 @@ class ApiaryCard extends Component {
                     >
                         Try again?
                     </button>
-                </>
-            );
-        } else if (!Object.keys(scores[forageRange]).length) {
-            scoreCard = <div className="spinner" />;
-        } else {
-            const scoreLabels = Object.values(INDICATORS).map(i => (
-                <ScoresLabel key={i} indicator={i} scores={[values[i]]} />
-            ));
-            scoreCard = (
-                <>
-                    <div className="card__top">
-                        <div className="card__identification">
-                            <div className={`marker ${markerClass}`}>{marker}</div>
-                            <div className="card__name">{name}</div>
-                        </div>
-                        <div className="card__buttons">
-                            <CardButton
-                                icon="star"
-                                filled={starred}
-                                tooltip="Mark apiary as important"
-                                onClick={this.onStar}
-                            />
-                            <CardButton
-                                icon="clipboard"
-                                filled={surveyed}
-                                tooltip="Include apiary in surveys"
-                                onClick={this.onSurvey}
-                            />
-                            <CardButton
-                                icon="trash"
-                                filled
-                                tooltip="Delete apiary"
-                                onClick={this.onDelete}
-                            />
-                        </div>
-                    </div>
-                    <div className="card__bottom">
-                        <div className="indicator-container">
-                            {scoreLabels}
-                        </div>
-                    </div>
-                </>
+                </li>
             );
         }
 
+        if (fetching) {
+            return (
+                <li className="card">
+                    <div className="spinner" />
+                </li>
+            );
+        }
+
+        const scoreLabels = Object.values(INDICATORS).map(i => (
+            <ScoresLabel key={i} indicator={i} scores={[values[i]]} />
+        ));
+
         return (
             <li className="card">
-                {scoreCard}
+                <div className="card__top">
+                    <div
+                        className="card__identification"
+                        onMouseEnter={this.enableHovering}
+                        onMouseLeave={this.disableHovering}
+                    >
+                        <div className={`marker ${markerClass}`}>{marker}</div>
+                        {this.getCardNameBlock()}
+                    </div>
+                    <div className="card__buttons">
+                        <CardButton
+                            icon="star"
+                            filled={starred}
+                            tooltip="Mark apiary as important"
+                            onClick={this.onStar}
+                        />
+                        <CardButton
+                            icon="clipboard"
+                            filled={surveyed}
+                            tooltip="Include apiary in surveys"
+                            onClick={this.onSurvey}
+                        />
+                        <CardButton
+                            icon="trash"
+                            filled
+                            tooltip="Delete apiary"
+                            onClick={this.onDelete}
+                        />
+                    </div>
+                </div>
+                <div className="card__bottom">
+                    <div className="indicator-container">
+                        {scoreLabels}
+                    </div>
+                </div>
             </li>
         );
     }

--- a/src/icp/apps/beekeepers/js/src/components/CardButton.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/CardButton.jsx
@@ -7,7 +7,11 @@ const CardButton = ({
     tooltip,
     onClick,
 }) => {
-    const fillOrOutline = filled ? 'fill' : 'outline';
+    const fillOrOutline = (() => {
+        if (filled === true) return '-fill';
+        if (filled === false) return '-outline';
+        return '';
+    })();
 
     return (
         <button
@@ -16,19 +20,20 @@ const CardButton = ({
             title={tooltip}
             onClick={onClick}
         >
-            <i className={`icon-${icon}-${fillOrOutline}`} />
+            <i className={`icon-${icon}${fillOrOutline}`} />
         </button>
     );
 };
 
 CardButton.propTypes = {
     icon: string.isRequired,
-    filled: bool.isRequired,
+    filled: bool,
     tooltip: string.isRequired,
     onClick: func,
 };
 
 CardButton.defaultProps = {
+    filled: null,
     onClick: () => {},
 };
 

--- a/src/icp/apps/beekeepers/js/src/components/DropdownSelector.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/DropdownSelector.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { func, string, arrayOf } from 'prop-types';
 
 const DropdownSelector = ({ title, options, onOptionClick }) => {
-    const selectOptions = Object.entries(options).map(([option, label]) => (
+    const selectOptions = options.map(([option, label]) => (
         <option value={option} key={option}>
             {label}
         </option>
@@ -26,7 +26,7 @@ const DropdownSelector = ({ title, options, onOptionClick }) => {
 
 DropdownSelector.propTypes = {
     title: string.isRequired,
-    options: arrayOf(string).isRequired,
+    options: arrayOf(arrayOf(string)).isRequired,
     onOptionClick: func.isRequired,
 };
 

--- a/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Sidebar.jsx
@@ -73,12 +73,12 @@ class Sidebar extends Component {
                     <div className="sidebar__controls">
                         <DropdownSelector
                             title="Sort by:"
-                            options={SORT_OPTIONS}
+                            options={Object.entries(SORT_OPTIONS)}
                             onOptionClick={onSelectSort}
                         />
                         <DropdownSelector
                             title="Forage range:"
-                            options={FORAGE_RANGES}
+                            options={Object.entries(FORAGE_RANGES)}
                             onOptionClick={onSelectForageRange}
                         />
                     </div>

--- a/src/icp/apps/beekeepers/sass/06_components/_card.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_card.scss
@@ -18,7 +18,7 @@
         display: flex;
         width: 100%;
         height: 3.6rem;
-        padding: 0.7rem 0.6rem;
+        padding: 0.6rem;
         border-bottom: 1px solid $color-grey-5;
     }
 
@@ -38,10 +38,22 @@
     }
 
     &__name {
+        flex: 1;
+        padding: 0.1rem 0.5rem;
         overflow: hidden;
         font-weight: $font-weight-normal;
         font-size: $font-size-med;
+        font-family: inherit;
         text-overflow: ellipsis;
+        border: 1px solid transparent;
+
+        &-editing {
+            border: 1px solid $color-grey-4;
+        }
+
+        &-hovering {
+            border: 1px solid $color-grey-5;
+        }
     }
 
     &__benchmarklocation {


### PR DESCRIPTION
## Overview

Makes apiary names editable, as shown in the mockups.

Connects #303 

### Demo

![2019-06-06 14 51 50](https://user-images.githubusercontent.com/1430060/59058514-cedcd280-886a-11e9-8bbf-5b5ad7f0529c.gif)

Tagging @jfrankl for visual review.

### Notes

Some effort was made to make the input accessible via keyboard. This works for the most part, although it's probably not perfect. Given the 🚀🐦 nature of the project, this was all that could be done.

## Testing Instructions

* Check out this branch and `update` and `server`
* Go to [:8000/?beekeepers](http://localhost:8000/?beekeepers)
* Make a few apiaries
  - [x] Ensure the reverse geocoding works as before
* Try editing their names
  - [x] Ensure you can, and the saved values are persisted in the session
* Log in to an account. Try editing the apiary names now.
  - [x] Ensure editing works the same as it did for non-logged-in users
  - [x] Ensure refreshing the page persists the edits
  - [x] Ensure the edited name is reflected in other places, such as
    - [x] The survey page
    - [x] A survey detail popup