### PR TITLE
Autofill select fields in monthly surveys

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/ApiarySurveyListing.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiarySurveyListing.jsx
@@ -4,13 +4,14 @@ import { arrayOf } from 'prop-types';
 import { Apiary, Survey } from '../propTypes';
 import SurveyCardListing from './SurveyCardListing';
 
-const ApiarySurveyListing = ({ apiary, surveys }) => {
+const ApiarySurveyListing = ({ apiary, surveys, lastMonthlySurvey }) => {
     const { name } = apiary;
     const listings = surveys.map(survey => (
         <SurveyCardListing
             key={name + survey.month_year + survey.survey_type}
             apiary={apiary}
             survey={survey}
+            lastMonthlySurvey={lastMonthlySurvey}
         />
     ));
 
@@ -22,9 +23,14 @@ const ApiarySurveyListing = ({ apiary, surveys }) => {
     );
 };
 
+ApiarySurveyListing.defaultProps = {
+    lastMonthlySurvey: null,
+};
+
 ApiarySurveyListing.propTypes = {
     apiary: Apiary.isRequired,
     surveys: arrayOf(Survey).isRequired,
+    lastMonthlySurvey: Survey,
 };
 
 export default ApiarySurveyListing;

--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
@@ -177,7 +177,7 @@ class MonthlySurveyColonyForm extends Component {
             <>
                 {inputText('colony_name', 'Colony Name (required)', required)}
                 {inputDate('inspection_date', 'Date of Inspection', required)}
-                {inputText('hive_scale_id', 'If you have an automated scale associated with this colony, please enter the hive scale ID number here.')}
+                {inputText('hive_scale_id', 'If you have an automated scale associated with this colony, please enter the hive scale brand and ID number here.')}
                 {this.inputSelect('colony_alive', 'Is the colony alive?', [
                     ['true', 'Yes'],
                     ['false', 'No'],

--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
@@ -27,8 +27,7 @@ class MonthlySurveyColonyForm extends Component {
     inputFactory(inputType) {
         const { onChange, data } = this.props;
         const disabled = data.id !== null;
-
-        return (key, label, required, tooltipDescription) => {
+        return (key, label, required, tooltipDescription, placeholder, pattern) => {
             const tooltip = tooltipDescription
                 ? <Tooltip description={[tooltipDescription]} />
                 : null;
@@ -47,6 +46,8 @@ class MonthlySurveyColonyForm extends Component {
                         onChange={onChange}
                         disabled={disabled}
                         required={required}
+                        placeholder={placeholder}
+                        pattern={pattern}
                     />
                 </div>
             );
@@ -172,11 +173,12 @@ class MonthlySurveyColonyForm extends Component {
                 </div>
             </>
         );
-
+        /* eslint-disable-next-line no-useless-escape */
+        const dateRegex = '\\d{4}-\\d{2}-\\d{2}';
         return (
             <>
                 {inputText('colony_name', 'Colony Name (required)', required)}
-                {inputDate('inspection_date', 'Date of Inspection', required)}
+                {inputDate('inspection_date', 'Date of Inspection', required, false, 'YYYY-MM-DD', dateRegex)}
                 {inputText('hive_scale_id', 'If you have an automated scale associated with this colony, please enter the hive scale brand and ID number here.')}
                 {this.inputSelect('colony_alive', 'Is the colony alive?', [
                     ['true', 'Yes'],

--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
@@ -173,8 +173,10 @@ class MonthlySurveyColonyForm extends Component {
                 </div>
             </>
         );
+
         /* eslint-disable-next-line no-useless-escape */
         const dateRegex = '\\d{4}-\\d{2}-\\d{2}';
+
         return (
             <>
                 {inputText('colony_name', 'Colony Name (required)', required)}

--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
@@ -25,7 +25,7 @@ import Tooltip from './Tooltip';
 
 class MonthlySurveyColonyForm extends Component {
     inputFactory(inputType) {
-        const { data, onChange } = this.props;
+        const { onChange, data } = this.props;
         const disabled = data.id !== null;
 
         return (key, label, required, tooltipDescription) => {
@@ -54,7 +54,7 @@ class MonthlySurveyColonyForm extends Component {
     }
 
     inputSelect(key, label, options, tooltipDescription) {
-        const { data, onChange } = this.props;
+        const { onChange, data } = this.props;
         const value = data[key] && data[key].toString();
         const disabled = data.id !== null;
         const tooltip = tooltipDescription
@@ -84,7 +84,7 @@ class MonthlySurveyColonyForm extends Component {
     }
 
     makeMultipleChoiceInputs(groupName, options, tooltipDescriptions) {
-        const { data, onChange } = this.props;
+        const { onChange, data } = this.props;
         const disabled = data.id !== null;
 
         return options.map((option, index) => {

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCard.jsx
@@ -8,6 +8,7 @@ import { setApiarySurvey } from '../actions';
 
 import ApiarySurveyListing from './ApiarySurveyListing';
 import SurveyCardListing from './SurveyCardListing';
+import { SURVEY_TYPE_MONTHLY } from '../constants';
 
 const SurveyCard = ({ apiary, dispatch, surveys }) => {
     const {
@@ -37,11 +38,17 @@ const SurveyCard = ({ apiary, dispatch, surveys }) => {
     } else {
         const shownSurveys = surveys.slice(0, 4);
 
+        const sortedMonthlySurveys = surveys
+            .filter(survey => survey.survey_type === SURVEY_TYPE_MONTHLY && !!survey.completed);
+
+        const lastMonthlySurvey = sortedMonthlySurveys.length ? sortedMonthlySurveys[0] : null;
+
         cardBody = shownSurveys.map(survey => (
             <SurveyCardListing
                 key={name + survey.month_year + survey.survey_type}
                 apiary={apiary}
                 survey={survey}
+                lastMonthlySurvey={lastMonthlySurvey}
             />
         ));
 
@@ -59,7 +66,11 @@ const SurveyCard = ({ apiary, dispatch, surveys }) => {
                 className="modal nice"
                 trigger={cardDetailTrigger}
             >
-                <ApiarySurveyListing apiary={apiary} surveys={surveys} />
+                <ApiarySurveyListing
+                    apiary={apiary}
+                    surveys={surveys}
+                    lastMonthlySurvey={lastMonthlySurvey}
+                />
             </Popup>
         );
 

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCardListing.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCardListing.jsx
@@ -21,6 +21,7 @@ const SurveyCardListing = ({
         survey_type,
         completed,
     },
+    lastMonthlySurvey,
 }) => {
     let formComponent;
     switch (survey_type) {
@@ -36,7 +37,12 @@ const SurveyCardListing = ({
             break;
         case SURVEY_TYPE_MONTHLY:
             formComponent = (close => (
-                <MonthlySurveyForm apiary={apiary} survey={survey} close={close} />
+                <MonthlySurveyForm
+                    apiary={apiary}
+                    survey={survey}
+                    close={close}
+                    lastMonthlySurvey={lastMonthlySurvey}
+                />
             ));
             break;
         default:
@@ -66,9 +72,14 @@ const SurveyCardListing = ({
     );
 };
 
+SurveyCardListing.defaultProps = {
+    lastMonthlySurvey: null,
+};
+
 SurveyCardListing.propTypes = {
     apiary: Apiary.isRequired,
     survey: Survey.isRequired,
+    lastMonthlySurvey: Survey,
 };
 
 export default SurveyCardListing;

--- a/src/icp/apps/beekeepers/js/src/propTypes.js
+++ b/src/icp/apps/beekeepers/js/src/propTypes.js
@@ -81,4 +81,5 @@ export const MonthlySurveyColony = shape({
     varroa_count_technique: string,
     varroa_count_result: number,
     varroa_treatment: string,
+    hive_scale_id: string,
 });

--- a/src/icp/apps/beekeepers/migrations/0014_update_hive_scale_id_help_text.py
+++ b/src/icp/apps/beekeepers/migrations/0014_update_hive_scale_id_help_text.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('beekeepers', '0013_update_queen_source_options'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='monthlysurvey',
+            name='hive_scale_id',
+            field=models.CharField(help_text='If you have an automated scale associated with this colony, please enter the hive scale brand and ID number here.', max_length=255, null=True, blank=True),
+        ),
+    ]

--- a/src/icp/apps/beekeepers/models.py
+++ b/src/icp/apps/beekeepers/models.py
@@ -349,7 +349,8 @@ class MonthlySurvey(models.Model):
         null=True,
         blank=True,
         help_text='If you have an automated scale associated with this '
-                  'colony, please enter the hive scale ID number here.')
+                  'colony, please enter the hive scale brand and ID number '
+                  'here.')
 
     class Meta:
         unique_together = ('survey', 'colony_name')


### PR DESCRIPTION
## Overview

Adds autofill using info from the most recent completed monthly survey.

Connects #463 

### Demo

<img width="638" alt="Screen Shot 2019-06-10 at 5 13 51 PM" src="https://user-images.githubusercontent.com/10568752/59227349-2a78ca00-8ba3-11e9-92a8-e1c49281edd0.png">

<img width="590" alt="Screen Shot 2019-06-12 at 1 52 47 PM" src="https://user-images.githubusercontent.com/10568752/59388306-70679680-8d39-11e9-9496-c8544c22a25f.png">

Completed surveys:
![Screen Shot 2019-06-12 at 5 43 00 PM](https://user-images.githubusercontent.com/10568752/59388383-97be6380-8d39-11e9-9492-bc4487011b71.png)

Autofilled surveys in id order:
![Screen Shot 2019-06-12 at 5 42 54 PM](https://user-images.githubusercontent.com/10568752/59388388-9b51ea80-8d39-11e9-9040-d4e19a504754.png)

## Notes
There was an existing console warning about un/controlled inputs. There's a new console warning about requiring the `month_year` field on `lastMonthlySurvey` in some components that I haven't figured out how to clean up 🤔 

<img width="507" alt="Screen Shot 2019-06-10 at 5 23 44 PM" src="https://user-images.githubusercontent.com/10568752/59227951-8f80ef80-8ba4-11e9-912a-58fc08c552e0.png">

I rolled in #517

## Testing Instructions
- [ ] Run migrations
- [x] Successfully submit a monthly survey on an apiary without monthly surveys
Start w a blank form
- [x] Submit a subsequent monthly survey and see the hive and colony name info autofill, but change the autofilled info
- [x] See that subsequent monthly surveys use the more recent month data
- [ ] Check the network tab that the opening any type of survey only sends the expected requests

- [ ] Check that monthly form submissions work in Safari and IE11

Connects #463, #517 