### PR TITLE
Include current month for monthly surveys

### DIFF
--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -247,23 +247,16 @@ export function getMonthlySurveys({ id: apiary, created_at: createdAt, surveys }
         const endMonth = y === endYear ? currentMonth : 12;
 
         for (let m = startMonth; m <= endMonth; m += 1) {
-            // Don't list current month until the 15th
-            if (!(
-                y === endYear
-                && m === endMonth
-                && currentDate.getDate() < 15
-            )) {
-                const twoDigitMonth = `0${m}`.slice(-2);
-                const month_year = `${twoDigitMonth}${y}`;
-                const survey = matchSurvey(month_year) || {
-                    apiary,
-                    month_year,
-                    survey_type,
-                    completed: false,
-                };
+            const twoDigitMonth = `0${m}`.slice(-2);
+            const month_year = `${twoDigitMonth}${y}`;
+            const survey = matchSurvey(month_year) || {
+                apiary,
+                month_year,
+                survey_type,
+                completed: false,
+            };
 
-                mthSurveys.push(survey);
-            }
+            mthSurveys.push(survey);
         }
     }
 


### PR DESCRIPTION
## Overview

The client requests monthly surveys be avail once the month begins. Currently, we allow the current month if it is past the 15th of the month (aka more than 1/2 of the month has passed)

### Demo

<img width="686" alt="Screen Shot 2019-06-24 at 1 31 43 PM" src="https://user-images.githubusercontent.com/10568752/60039559-03cb9080-9685-11e9-8bcf-5b7e6d426bab.png">


## Testing Instructions

Pull down branch, and run the project `./scripts/beekeepers.sh start`
http://localhost:8000/survey/?beekeepers and login
See that all surveys through June are still visible and you can successfully submit a June survey.