### PR TITLE
Prepare app for 5 new states' raster data

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,17 +309,17 @@ is provided per state and the file naming scheme represents this as:
 
 `[STATE_ABBR]_[INDICATOR]_[FORAGE_RADIUS].tif`
 
-This results in files named like `PA_pesticide_3km.tif`.
+This results in files named like `PA_nesting_3km.tif`.
 
 In order to support multiple states that come as discrete files, a VRT per layer/radius pair
 has been created using the following steps:
 
 ```bash
-gdalbuildvrt pesticide_3km.vrt PA_pesticide_3km.tif IL_pesticide_3km.tif
+gdalbuildvrt nesting_3km.vrt PA_nesting_3km.tif IL_nesting_3km.tif
 ```
 
 A convenience script has been added to `scripts/make-vrts.sh` which contains the `gdalbuildvrt`
-commands used to generate the existing IN, IL & PA VRTs.  It can be modified to regenerate
+commands used to generate the existing VRTs.  It can be modified to regenerate
 with additional states in the future.
 Once a VRT has been created for each layer/radius, both VRT and tifs are uploaded
 to the data bucket under a folder indicating 3km or 5km.

--- a/scripts/make-vrts.sh
+++ b/scripts/make-vrts.sh
@@ -1,16 +1,16 @@
-# Build vrts for PA, IL & IN raster files contained in this directory
+# Build vrts for PA, IL, IN, NY, MI, OH, WI, & WV raster files contained in this directory
 
-gdalbuildvrt floral_spring_3km.vrt PA_floral_spring_3km.tif IL_floral_spring_3km.tif IN_floral_spring_3km.tif
-gdalbuildvrt floral_spring_5km.vrt PA_floral_spring_5km.tif IL_floral_spring_5km.tif IN_floral_spring_5km.tif
+gdalbuildvrt floral_spring_3km.vrt PA_floral_spring_3km.tif IL_floral_spring_3km.tif IN_floral_spring_3km.tif NY_floral_spring_3km.tif MI_floral_spring_3km.tif OH_floral_spring_3km.tif WI_floral_spring_3km.tif WV_floral_spring_3km.tif
+gdalbuildvrt floral_spring_5km.vrt PA_floral_spring_5km.tif IL_floral_spring_5km.tif IN_floral_spring_5km.tif NY_floral_spring_5km.tif MI_floral_spring_5km.tif OH_floral_spring_5km.tif WI_floral_spring_5km.tif WV_floral_spring_5km.tif
 
-gdalbuildvrt floral_summer_3km.vrt PA_floral_summer_3km.tif IL_floral_summer_3km.tif IN_floral_summer_3km.tif
-gdalbuildvrt floral_summer_5km.vrt PA_floral_summer_5km.tif IL_floral_summer_5km.tif IN_floral_summer_5km.tif
+gdalbuildvrt floral_summer_3km.vrt PA_floral_summer_3km.tif IL_floral_summer_3km.tif IN_floral_summer_3km.tif NY_floral_summer_3km.tif MI_floral_summer_3km.tif OH_floral_summer_3km.tif WI_floral_summer_3km.tif WV_floral_summer_3km.tif
+gdalbuildvrt floral_summer_5km.vrt PA_floral_summer_5km.tif IL_floral_summer_5km.tif IN_floral_summer_5km.tif NY_floral_summer_5km.tif MI_floral_summer_5km.tif OH_floral_summer_5km.tif WI_floral_summer_5km.tif WV_floral_summer_5km.tif
 
-gdalbuildvrt floral_fall_3km.vrt PA_floral_fall_3km.tif IL_floral_fall_3km.tif IN_floral_fall_3km.tif
-gdalbuildvrt floral_fall_5km.vrt PA_floral_fall_5km.tif IL_floral_fall_5km.tif IN_floral_fall_5km.tif
+gdalbuildvrt floral_fall_3km.vrt PA_floral_fall_3km.tif IL_floral_fall_3km.tif IN_floral_fall_3km.tif NY_floral_fall_3km.tif MI_floral_fall_3km.tif OH_floral_fall_3km.tif WI_floral_fall_3km.tif WV_floral_fall_3km.tif
+gdalbuildvrt floral_fall_5km.vrt PA_floral_fall_5km.tif IL_floral_fall_5km.tif IN_floral_fall_5km.tif NY_floral_fall_5km.tif MI_floral_fall_5km.tif OH_floral_fall_5km.tif WI_floral_fall_5km.tif WV_floral_fall_5km.tif
 
-gdalbuildvrt nesting_3km.vrt PA_nesting_3km.tif IL_nesting_3km.tif IN_nesting_3km.tif
-gdalbuildvrt nesting_5km.vrt PA_nesting_5km.tif IL_nesting_5km.tif IN_nesting_5km.tif
+gdalbuildvrt nesting_3km.vrt PA_nesting_3km.tif IL_nesting_3km.tif IN_nesting_3km.tif NY_nesting_3km.tif MI_nesting_3km.tif OH_nesting_3km.tif WI_nesting_3km.tif WV_nesting_3km.tif
+gdalbuildvrt nesting_5km.vrt PA_nesting_5km.tif IL_nesting_5km.tif IN_nesting_5km.tif NY_nesting_5km.tif MI_nesting_5km.tif OH_nesting_5km.tif WI_nesting_5km.tif WV_nesting_5km.tif
 
-gdalbuildvrt pesticide_3km.vrt PA_pesticide_3km.tif IL_pesticide_3km.tif IN_pesticide_3km.tif
-gdalbuildvrt pesticide_5km.vrt PA_pesticide_5km.tif IL_pesticide_5km.tif IN_pesticide_5km.tif
+gdalbuildvrt insecticide_3km.vrt PA_insecticide_3km.tif IL_insecticide_3km.tif IN_insecticide_3km.tif NY_insecticide_3km.tif MI_insecticide_3km.tif OH_insecticide_3km.tif WI_insecticide_3km.tif WV_insecticide_3km.tif
+gdalbuildvrt insecticide_5km.vrt PA_insecticide_5km.tif IL_insecticide_5km.tif IN_insecticide_5km.tif NY_insecticide_5km.tif MI_insecticide_5km.tif OH_insecticide_5km.tif WI_insecticide_5km.tif WV_insecticide_5km.tif

--- a/src/icp/apps/beekeepers/js/src/components/Splash.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Splash.jsx
@@ -11,7 +11,7 @@ export default function () {
                     Managed honey bees and wild bees travel far from their nests to find food.
                     What are your bees experiencing during their journey? This tool will help
                     you understand how the landscape surrounding your apiary, garden, or farm
-                    stacks up in terms of the floral resources bees can find, the pesticides
+                    stacks up in terms of the floral resources bees can find, the insecticides
                     they encounter, and, for wild bees, the nesting sites that are available.
                 </p>
                 <div className="infobox">

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -9,7 +9,7 @@ export const DEFAULT_SORT = 'default';
 
 export const INDICATORS = {
     NESTING_QUALITY: 'nesting',
-    PESTICIDE: 'pesticide',
+    INSECTICIDE: 'insecticide',
     FLORAL_SPRING: 'floral_spring',
     FLORAL_SUMMER: 'floral_summer',
     FLORAL_FALL: 'floral_fall',
@@ -22,7 +22,7 @@ export const INDICATOR_DETAILS = {
         shortLabel: 'Nesting',
         scoreStops: [7, 33, 39, 46, 66],
     },
-    pesticide: {
+    insecticide: {
         name: 'Insecticide load',
         scoreLabels: ['Insecticide'],
         shortLabel: 'Insecticide',


### PR DESCRIPTION
## Overview

The client provided raster data for 5 new states, and updated PA, IL, and IN data too. This PR updates the VRT generation script. Also, I unified the code around the indicator label 'insecticide' formerly 'pesticide'. We had an in-between hybrid solution before to avoid renaming & regenerating data.

Connects #522

### Demo

Data completes a full corridor between NY and MI :D
<img width="818" alt="Screen Shot 2019-07-12 at 4 01 31 PM" src="https://user-images.githubusercontent.com/10568752/61155380-c8232a00-a4be-11e9-9631-0f3faa7af61d.png">

Data coming in from all included states, screenshot from my local instance
<img width="520" alt="Screen Shot 2019-07-12 at 3 36 55 PM" src="https://user-images.githubusercontent.com/10568752/61155363-c0638580-a4be-11e9-8101-5aacc98f07b8.png">

Staging:
<img width="642" alt="Screen Shot 2019-07-12 at 4 07 21 PM" src="https://user-images.githubusercontent.com/10568752/61155532-2f40de80-a4bf-11e9-8382-2b4c840b0e8f.png">

### Notes

I updated data in the staging data bucket in s3; staging will not return insecticide data until its code is updated to accomodate `insecticide`. Production will be a bit tricky. Either we upload the new VRTs and layers before the updated code is deployed, or after -- in both cases we'll get no data for the insecticide field for a few minutes. I don't think this is ultimately a huge deal, so long as we flush saved apiary indicator data after all the updates are made to ensure fresh, complete data is shown to users.

## Testing Instructions

Pull down this branch and you should get data for all 8 included states when clicking the map.