### PR TITLE
Add data migration to nullify scores

### DIFF
--- a/src/icp/apps/beekeepers/js/src/actions.js
+++ b/src/icp/apps/beekeepers/js/src/actions.js
@@ -59,7 +59,9 @@ export function fetchApiaryScores(apiaryList, forageRange) {
         }
 
         // check if data for the apiaries already exist
-        if (apiaryList.every(apiary => apiary.scores[forageRange].data)) {
+        if (apiaryList.every(apiary => apiary.scores[forageRange]
+            && apiary.scores[forageRange].data)
+        ) {
             return true;
         }
 

--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -173,11 +173,11 @@ class ApiaryCard extends Component {
             fetching,
         } = apiary;
 
-        const values = scores[forageRange];
+        const values = scores && scores[forageRange];
 
         const markerClass = getMarkerClass(apiary);
 
-        if (!Object.keys(values).length && !fetching) {
+        if ((!values || !Object.keys(values).length) && !fetching) {
             // Fetch is complete and no scores retrieved
             // Report error
 

--- a/src/icp/apps/beekeepers/migrations/0015_apiary_scores_nullify_data.py
+++ b/src/icp/apps/beekeepers/migrations/0015_apiary_scores_nullify_data.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('beekeepers', '0014_update_hive_scale_id_help_text'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            "UPDATE beekeepers_apiary SET scores='{\"3km\": null, \"5km\": null}';"
+        ),
+    ]


### PR DESCRIPTION
## Overview

The schema of the underlying scores data changed, thus invalidating the cached apiary scores. By wiping the scores, we allow a user to pull fresh data on next login. Said data is not automatically pulled because of budget constraints.

Connects #525 

### Demo
Logged in with wiped data:
<img width="508" alt="Screen Shot 2019-08-01 at 10 27 24 AM" src="https://user-images.githubusercontent.com/10568752/62326387-f5d70f80-b47b-11e9-8045-bfa79d9ce108.png">


## Testing Instructions

Pull down branch
Try to login and see that the app breaks
Apply the migration `./scripts/manage.sh migrate`
Refresh app and see the screenshot
Pull data and see that it comes back successfully

