### PR TITLE
Minor Changes to Surveys

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
@@ -247,6 +247,7 @@ class AprilSurveyForm extends Component {
                             value={num_colonies}
                             disabled={!!completedSurvey}
                             required
+                            min={0}
                         />
                         <label htmlFor="colony_loss_reason">
                             What do you think was the most likely cause of colony loss?

--- a/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
@@ -25,6 +25,7 @@ class AprilSurveyForm extends Component {
             colony_loss_reason_COLONY_TOO_SMALL_IN_NOVEMBER: false,
             colony_loss_reason_PESTICIDE_EXPOSURE: false,
             colony_loss_reason_BEAR_OR_NATURAL_DISASTER: false,
+            notes: '',
             completedSurvey: '',
             error: '',
         };
@@ -50,6 +51,7 @@ class AprilSurveyForm extends Component {
                 let newState = {
                     completedSurvey: data,
                     num_colonies: data.num_colonies,
+                    notes: data.april.notes,
                 };
                 this.multipleChoiceKeys.forEach((key) => {
                     if (data.april[key]) {
@@ -105,6 +107,7 @@ class AprilSurveyForm extends Component {
 
         const {
             num_colonies,
+            notes,
         } = this.state;
 
         const multipleChoiceState = {};
@@ -132,7 +135,7 @@ class AprilSurveyForm extends Component {
             apiary,
             month_year,
             survey_type: SURVEY_TYPE_APRIL,
-            april: multipleChoiceState,
+            april: { ...multipleChoiceState, notes },
         };
 
         getOrCreateSurveyRequest({ apiary, form })
@@ -176,6 +179,7 @@ class AprilSurveyForm extends Component {
         const {
             num_colonies,
             colony_loss_reason_OTHER,
+            notes,
             completedSurvey,
             error,
         } = this.state;
@@ -264,6 +268,19 @@ class AprilSurveyForm extends Component {
                             onChange={this.handleChange}
                             disabled={!!completedSurvey}
                         />
+                        <div className="form__group">
+                            <label htmlFor="notes">
+                                Notes
+                            </label>
+                            <textarea
+                                className="form__control textarea"
+                                name="notes"
+                                rows={2}
+                                value={notes || ''}
+                                onChange={this.handleChange}
+                                disabled={!!completedSurvey}
+                            />
+                        </div>
                         {confirmationButton}
                     </div>
                     {submitButton}

--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
@@ -122,11 +122,14 @@ class MonthlySurveyColonyForm extends Component {
     render() {
         const {
             data: {
+                id,
                 colony_name,
                 colony_alive,
                 varroa_count_performed,
+                notes,
             },
             idx,
+            onChange,
         } = this.props;
 
         const inputText = this.inputFactory('text');
@@ -250,6 +253,19 @@ class MonthlySurveyColonyForm extends Component {
                     ['PACKAGE', 'Package'],
                     ['FERAL', 'Feral colony or swarm'],
                 ])}
+                <div className="form__group">
+                    <label htmlFor="notes">
+                        Notes
+                    </label>
+                    <textarea
+                        className="form__control textarea"
+                        disabled={id !== null}
+                        name="notes"
+                        onChange={onChange}
+                        rows={2}
+                        value={notes || ''}
+                    />
+                </div>
             </>
         );
     }

--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyColonyForm.jsx
@@ -48,6 +48,7 @@ class MonthlySurveyColonyForm extends Component {
                         required={required}
                         placeholder={placeholder}
                         pattern={pattern}
+                        min={0}
                     />
                 </div>
             );

--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyForm.jsx
@@ -72,6 +72,7 @@ class MonthlySurveyForm extends Component {
             varroa_treatment_MECHANICAL_OTHER: '',
             varroa_treatment_OTHER: '',
             hive_scale_id: '',
+            notes: '',
         };
 
         this.state = {

--- a/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
@@ -427,6 +427,7 @@ class NovemberSurveyForm extends Component {
                             value={num_colonies}
                             disabled={!!completedSurvey}
                             required
+                            min={0}
                         />
                         <div className="form__group">
                             <label htmlFor="harvested_honey">

--- a/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
@@ -56,6 +56,7 @@ class NovemberSurveyForm extends Component {
             mite_management_DRONE_REMOVE: false,
             mite_management_QUEEN_MANIPULATION: false,
             all_colonies_treated: true,
+            notes: '',
             completedSurvey: '',
             error: '',
         };
@@ -108,6 +109,7 @@ class NovemberSurveyForm extends Component {
                     varroa_check_frequency: data.november.varroa_check_frequency,
                     varroa_manage_frequency: data.november.varroa_manage_frequency,
                     all_colonies_treated: data.november.all_colonies_treated,
+                    notes: data.november.notes,
                 };
                 this.multipleChoiceKeys.forEach((key) => {
                     if (data.november[key]) {
@@ -294,6 +296,7 @@ class NovemberSurveyForm extends Component {
             varroa_manage_frequency,
             mite_management_OTHER,
             all_colonies_treated,
+            notes,
             completedSurvey,
             error,
         } = this.state;
@@ -535,6 +538,19 @@ class NovemberSurveyForm extends Component {
                                 <option key="true" value="true">Yes</option>
                                 <option key="false" value="false">No</option>
                             </select>
+                        </div>
+                        <div className="form__group">
+                            <label htmlFor="notes">
+                                Notes
+                            </label>
+                            <textarea
+                                className="form__control textarea"
+                                name="notes"
+                                rows={2}
+                                value={notes || ''}
+                                onChange={this.handleChange}
+                                disabled={!!completedSurvey}
+                            />
                         </div>
                         {confirmationButton}
                     </div>

--- a/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
@@ -67,24 +67,24 @@ const SurveyView = ({ apiaries, isProUser }) => {
                     you initiate it - it is not possible to partially save your work.
                 </div>
                 <div className="survey__body--section">
-                    <h2 className="survey__title">Response needed</h2>
+                    <h2 className="survey__title">Apiaries with surveys that need to be completed:</h2>
                     {incompleteSurveyCards.length
                         ? incompleteSurveyCards
                         : <div className="empty-message">None. There are no remaining surveys to complete.</div>
                     }
                 </div>
                 <div className="survey__body--section">
-                    <h2 className="survey__title">Up to date</h2>
+                    <h2 className="survey__title">Apiaries with all surveys completed:</h2>
                     {completedSurveyCards.length
                         ? completedSurveyCards
-                        : <div className="empty-message">None. Please help the bees and complete any outstanding surveys.</div>
+                        : <div className="empty-message">None of your apiaries are up-to-date on their surveys. Please help the bees and complete any outstanding surveys.</div>
                     }
                 </div>
                 <div className="survey__body--section">
-                    <h2 className="survey__title">Not in the study</h2>
+                    <h2 className="survey__title">Apiaries not in the study:</h2>
                     {unsurveyedCards.length
                         ? unsurveyedCards
-                        : <div className="empty-message">None. Nice work!</div>
+                        : <div className="empty-message">None. All of your apiares are in the study!</div>
                     }
                 </div>
             </div>

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -388,7 +388,7 @@ class UserSurveyModal extends Component {
                                         onChange={this.handleChange}
                                         value="SELL_NUCS_PACKAGES"
                                     />
-                                    <label htmlFor="income_sell_nucs">Sell nucs package</label>
+                                    <label htmlFor="income_sell_nucs">Sell nucs/package</label>
                                 </div>
                                 <div className="form__checkbox">
                                     <input

--- a/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/UserSurveyModal.jsx
@@ -295,6 +295,7 @@ class UserSurveyModal extends Component {
                                     value={year_began}
                                     onChange={this.handleChange}
                                     required
+                                    min={0}
                                 />
                             </div>
                             <div className="form__group">

--- a/src/icp/apps/beekeepers/js/src/propTypes.js
+++ b/src/icp/apps/beekeepers/js/src/propTypes.js
@@ -82,4 +82,5 @@ export const MonthlySurveyColony = shape({
     varroa_count_result: number,
     varroa_treatment: string,
     hive_scale_id: string,
+    notes: string,
 });

--- a/src/icp/apps/beekeepers/migrations/0016_add_notes_to_surveys.py
+++ b/src/icp/apps/beekeepers/migrations/0016_add_notes_to_surveys.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('beekeepers', '0015_apiary_scores_nullify_data'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='aprilsurvey',
+            name='notes',
+            field=models.TextField(help_text='Miscellaneous comments', null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='monthlysurvey',
+            name='notes',
+            field=models.TextField(help_text='Miscellaneous comments', null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='novembersurvey',
+            name='notes',
+            field=models.TextField(help_text='Miscellaneous comments', null=True, blank=True),
+        ),
+    ]

--- a/src/icp/apps/beekeepers/models.py
+++ b/src/icp/apps/beekeepers/models.py
@@ -134,6 +134,10 @@ class AprilSurvey(models.Model):
     colony_loss_reason = models.TextField(
         null=False,
         help_text='The most likely causes for colony loss')
+    notes = models.TextField(
+        null=True,
+        blank=True,
+        help_text='Miscellaneous comments')
 
     def __unicode__(self):
         return unicode('{}:{}:{}'.format(
@@ -226,6 +230,10 @@ class NovemberSurvey(models.Model):
         null=False,
         default=True,
         help_text='Did you treat all of the colonies in the apiary?')
+    notes = models.TextField(
+        null=True,
+        blank=True,
+        help_text='Miscellaneous comments')
 
     def __unicode__(self):
         return unicode('{}:{}:{}'.format(
@@ -351,6 +359,10 @@ class MonthlySurvey(models.Model):
         help_text='If you have an automated scale associated with this '
                   'colony, please enter the hive scale brand and ID number '
                   'here.')
+    notes = models.TextField(
+        null=True,
+        blank=True,
+        help_text='Miscellaneous comments')
 
     class Meta:
         unique_together = ('survey', 'colony_name')

--- a/src/icp/apps/beekeepers/sass/06_components/_modal.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_modal.scss
@@ -102,6 +102,11 @@
         &[type="password"] {
             width: 100%;
         }
+
+        &.textarea {
+            width: 100%;
+            resize: none;
+        }
     }
 }
 

--- a/src/icp/apps/beekeepers/sass/06_components/_survey.scss
+++ b/src/icp/apps/beekeepers/sass/06_components/_survey.scss
@@ -8,6 +8,7 @@
     &__title {
         margin-top: 6px;
         margin-bottom: 20px;
+        text-decoration: underline;
     }
 
     &__type {


### PR DESCRIPTION
## Overview

Performs minor changes requested by the user to all surveys. These are needed primarily for the Fall survey at this point, but have been applied to all surveys for uniformity (and because the clients have confirmed that they do want these changes on all surveys).

Connects #532 

### Demo

Negative values are not allowed in numeric fields anymore:

![2019-10-18 17 31 22](https://user-images.githubusercontent.com/1430060/67129634-33228200-f1cd-11e9-8e2a-1e95ed74be94.gif)

Text changes to the Survey tab:

![image](https://user-images.githubusercontent.com/1430060/67129660-446b8e80-f1cd-11e9-9bf4-1eba9ff59330.png)

"Sell nucs/packages" in the User Survey:

![image](https://user-images.githubusercontent.com/1430060/67129948-f7d48300-f1cd-11e9-9406-dea5320f4732.png)

Notes field on Monthly surveys:

![image](https://user-images.githubusercontent.com/1430060/67129701-59e0b880-f1cd-11e9-8294-9e9b4f461875.png)

Notes field on November surveys:

![image](https://user-images.githubusercontent.com/1430060/67129730-6a912e80-f1cd-11e9-883b-ce03fff66529.png)

Notes field on April surveys:

![image](https://user-images.githubusercontent.com/1430060/67129753-754bc380-f1cd-11e9-97ab-a4548f920361.png)

## Testing Instructions

* Check out this branch
* Run all migrations `$ ./scripts/manage.sh migrate`
* Run beekeepers `$ ./scripts/beekeepers.sh start`
* Sign up as a new user to see the User Survey
  - [x] Ensure you see "Sell nucs/packages" under "Do you receive income from any of the following?"
* Go to the Surveys tab
  - [x] Ensure you see the new language
* Open different kinds of Apiary surveys to verify the Notes field
  - [x] Ensure the field is optional, and you can leave it blank
  - [x] Ensure it is saved correctly in November Surveys
  - [x] Ensure it is saved correctly in April Surveys
  - [x] Ensure it is saved to the right colony in Monthly Surveys
* On the different kinds of surveys, try entering negative values in the numeric fields
  - [x] Ensure direct input of negative values is not allowed
  - [x] Ensure negative values cannot be input using <kbd>up</kbd> and <kbd>down</kbd> keys