### PR TITLE
Add an 'n/a' option to a spring survey question

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { func } from 'prop-types';
 
 import { fetchUserApiaries, flashSuccessModal } from '../actions';
-import { SURVEY_TYPE_APRIL, COLONY_LOSS_REASONS } from '../constants';
+import { SURVEY_TYPE_APRIL, SPRING_COLONY_LOSS_REASONS } from '../constants';
 import {
     arrayToSemicolonDelimitedString,
     getOrCreateSurveyRequest,
@@ -232,7 +232,7 @@ class AprilSurveyForm extends Component {
                 </div>
             );
 
-        const colonyLossReasonCheckboxInputs = this.makeMultipleChoiceInputs('colony_loss_reason', COLONY_LOSS_REASONS);
+        const colonyLossReasonCheckboxInputs = this.makeMultipleChoiceInputs('colony_loss_reason', SPRING_COLONY_LOSS_REASONS);
 
         const surveyForm = (
             <>

--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -102,6 +102,11 @@ export const COLONY_LOSS_REASONS = [
     'BEAR_OR_NATURAL_DISASTER',
 ];
 
+export const SPRING_COLONY_LOSS_REASONS = [
+    'N/A_-_NO_COLONIES_LOST',
+    ...COLONY_LOSS_REASONS,
+];
+
 export const ACTIVITY_SINCE_LAST = [
     'REMOVED_HONEY',
     'REMOVED_BROOD',


### PR DESCRIPTION
## Overview

The question "What do you think was the most likely cause of colony loss?" suggests that there was colony loss. It is possible there wasn't, and so add an answer option that indicates as such.

This change was tucked away in the client's wires and got missed in #533 

Connects #542 

### Demo

<img width="583" alt="Screen Shot 2019-10-28 at 12 37 34 PM" src="https://user-images.githubusercontent.com/10568752/67698036-f0586b00-f97f-11e9-8a2c-289b1f382050.png">

<img width="669" alt="Screen Shot 2019-10-28 at 12 57 43 PM" src="https://user-images.githubusercontent.com/10568752/67699465-90af8f00-f982-11e9-8d11-b9df134e90d1.png">


## Testing Instructions

Pull down the branch. If your haven't pulled down develop in the last few days, make sure to run migrations and possibly `./scripts/beekeepers.sh install`. Though, there were no added migrations or yarn dependencies here.

`./scripts/beekeepers.sh start`