### PR TITLE
Bugfix: unify on map center format

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -166,7 +166,7 @@ class ApiaryCard extends Component {
 
     zoomPanMapToLocation(lat, lng) {
         const { dispatch } = this.props;
-        dispatch(setMapCenter([lat, lng]));
+        dispatch(setMapCenter({ lat, lng }));
         dispatch(setMapZoom(MAX_MAP_ZOOM));
     }
 

--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -16,6 +16,7 @@ import {
     func,
     number,
     string,
+    shape,
 } from 'prop-types';
 
 import { Apiary } from '../propTypes';
@@ -33,7 +34,7 @@ import {
     MAP_CENTER,
     MAX_MAP_ZOOM,
 } from '../constants';
-import { getNextInSequence, isSameLocation, isSameCoordinateArray } from '../utils';
+import { getNextInSequence, isSameLocation } from '../utils';
 
 import ApiaryMarker from './ApiaryMarker';
 import CropLayerControl from './CropLayerControl';
@@ -94,7 +95,7 @@ class Map extends Component {
     componentDidUpdate({ mapCenter: prevMapCenter, mapZoom: prevMapZoom }) {
         const { mapCenter, mapZoom } = this.props;
 
-        if (!isSameCoordinateArray(prevMapCenter, mapCenter) || prevMapZoom !== mapZoom) {
+        if (!isSameLocation(prevMapCenter, mapCenter) || prevMapZoom !== mapZoom) {
             const map = this.mapRef.current.leafletElement;
             map.setView(mapCenter, mapZoom);
         }
@@ -275,7 +276,10 @@ Map.propTypes = {
     isCropLayerActive: bool.isRequired,
     cropLayerOpacity: number.isRequired,
     dispatch: func.isRequired,
-    mapCenter: arrayOf(number).isRequired,
+    mapCenter: shape({
+        lat: number.isRequired,
+        lng: number.isRequired,
+    }).isRequired,
     mapZoom: number.isRequired,
 };
 

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -14,10 +14,6 @@ export function isSameLocation(a, b) {
     return a.lat === b.lat && a.lng === b.lng;
 }
 
-export function isSameCoordinateArray(a, b) {
-    return a[0] === b[0] && a[1] === b[1];
-}
-
 function isLastInSequence(s) {
     let isLast = true;
 


### PR DESCRIPTION
## Overview

Fix geocoder searches panning & zooming the map. This bug was introduced by formatting coordinate information as an array instead of an object 😱 

Also, I removed the beekeepers prototype because we don't need that anymore and it's generating dependabot PRs.

Refs #548 

### Demo

![bees](https://user-images.githubusercontent.com/10568752/67900538-18d89480-fb3b-11e9-8500-2e062f5a188b.gif)

## Testing Instructions

Use the geocoder and see that selecting a location pans & zooms the map as many times as you select new locations.
See no weird behavior clicking apiary card markers to pan & zoom to their locations.

