### PR TITLE
Change button for editing apiary names

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/ApiaryCard.jsx
@@ -16,7 +16,7 @@ import {
 } from '../actions';
 import { getMarkerClass } from '../utils';
 
-import CardButton from './CardButton';
+import { CardButtonWithText, CardButtonWithIcon } from './CardButton';
 import ScoresLabel from './ScoresLabel';
 
 class ApiaryCard extends Component {
@@ -95,10 +95,10 @@ class ApiaryCard extends Component {
             onFocus = () => {};
             readOnly = false;
             cardButton = (
-                <CardButton
-                    icon="check"
+                <CardButtonWithText
                     tooltip="Save apiary name"
                     onClick={this.onApiaryNameSave}
+                    text="Save"
                 />
             );
         } else if (isHovering) {
@@ -106,10 +106,10 @@ class ApiaryCard extends Component {
             onClick = this.enableEditing;
             onKeyPress = this.enableEditingOnEnter;
             cardButton = (
-                <CardButton
-                    icon="pencil"
+                <CardButtonWithText
                     tooltip="Edit apiary name"
                     onClick={this.enableEditing}
+                    text="Edit"
                 />
             );
         } else {
@@ -208,7 +208,7 @@ class ApiaryCard extends Component {
                             <div className="card__name">Error fetching apiary data</div>
                         </div>
                         <div className="card__buttons">
-                            <CardButton
+                            <CardButtonWithIcon
                                 icon="trash"
                                 filled
                                 tooltip="Delete apiary"
@@ -269,19 +269,19 @@ class ApiaryCard extends Component {
                         {cardName.cardButton}
                     </div>
                     <div className="card__buttons">
-                        <CardButton
+                        <CardButtonWithIcon
                             icon="star"
                             filled={starred}
                             tooltip="Mark apiary as important"
                             onClick={this.onStar}
                         />
-                        <CardButton
+                        <CardButtonWithIcon
                             icon="clipboard"
                             filled={surveyed}
                             tooltip="Include apiary in surveys"
                             onClick={this.onSurvey}
                         />
-                        <CardButton
+                        <CardButtonWithIcon
                             icon="trash"
                             filled
                             tooltip="Delete apiary"

--- a/src/icp/apps/beekeepers/js/src/components/CardButton.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/CardButton.jsx
@@ -6,6 +6,7 @@ const CardButton = ({
     filled,
     tooltip,
     onClick,
+    text,
 }) => {
     const fillOrOutline = (() => {
         if (filled === true) return '-fill';
@@ -20,21 +21,47 @@ const CardButton = ({
             title={tooltip}
             onClick={onClick}
         >
-            <i className={`icon-${icon}${fillOrOutline}`} />
+            {text || <i className={`icon-${icon}${fillOrOutline}`} />}
         </button>
     );
 };
 
 CardButton.propTypes = {
-    icon: string.isRequired,
+    icon: string,
     filled: bool,
     tooltip: string.isRequired,
     onClick: func,
+    text: string,
 };
 
 CardButton.defaultProps = {
     filled: null,
     onClick: () => {},
+    icon: null,
+    text: null,
 };
 
-export default CardButton;
+
+const CardButtonWithIcon = props => (
+    <CardButton
+        {...props}
+    />
+);
+
+CardButtonWithIcon.propTypes = {
+    ...CardButton.propTypes,
+    icon: string.isRequired,
+};
+
+const CardButtonWithText = props => (
+    <CardButton
+        {...props}
+    />
+);
+
+CardButtonWithText.propTypes = {
+    ...CardButton.propTypes,
+    text: string.isRequired,
+};
+
+export { CardButtonWithText, CardButtonWithIcon };


### PR DESCRIPTION
## Overview

Users had trouble interpreting the image buttons for edit and save
within the card component, so we replaced the icons with text to clarify
their purpose. Refactored the CardButton component export into two
higher-order components, CardButtonWithText and CardButtonWithIcon, to
allow reusability of the CardButton code as well as differing sets of
required props for the different button types. The components are
co-located in the CardButton file as named exports.

Connects #560

### Demo

![Screen Shot 2020-02-12 at 3 07 39 PM](https://user-images.githubusercontent.com/21046714/74372896-766eb500-4da9-11ea-8d09-689f84927d7d.png)

![image](https://user-images.githubusercontent.com/21046714/74372968-900ffc80-4da9-11ea-913f-732f0e0c504d.png)

## Testing Instructions

- Check out this branch
- Run ./scripts/beekeepers.sh start
- Add some Apiaries
- Edit their names
- Ensure you see 'Edit' and 'Save' instead of pencil and checkmark icons
- Ensure that editing still works correctly
