### PR TITLE
Replace ubuntu/trusty64 base box with Bento equivalent

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Production:
 
 ## Local Development
 
-A combination of Vagrant 2.1+ and Ansible 2.6+ is used to setup the development environment for this project. Running `vagrant box update` is recommended so you're on the latest version of the `ubuntu/trusty64` box.
+A combination of Vagrant 2.2+ and Ansible 2.8+ is used to setup the development environment for this project. Running `vagrant box update` is recommended so you're on the latest version of the `bento/ubuntu-14.04` box.
 
 The project consists of the following virtual machines:
 
@@ -109,14 +109,14 @@ envdir: fatal: unable to switch to directory /etc/icp.d/env: access denied
 
 The Vagrant configuration maps the following host ports to services running in the virtual machines.
 
-Service                | Port | URL
----------------------- | -----| ------------------------------------------------
-Django Web Application | 8000 | [http://localhost:8000](http://localhost:8000)
-Graphite Dashboard     | 8080 | [http://localhost:8080](http://localhost:8080)
-Kibana Dashboard       | 5601 | [http://localhost:5601](http://localhost:5601)
-PostgreSQL             | 5432 | `psql -h localhost`
-Redis                  | 6379 | `redis-cli -h localhost 6379`
-Testem                 | 7357 | [http://localhost:7357](http://localhost:7357)
+| Service                | Port | URL                                            |
+| ---------------------- | ---- | ---------------------------------------------- |
+| Django Web Application | 8000 | [http://localhost:8000](http://localhost:8000) |
+| Graphite Dashboard     | 8080 | [http://localhost:8080](http://localhost:8080) |
+| Kibana Dashboard       | 5601 | [http://localhost:5601](http://localhost:5601) |
+| PostgreSQL             | 5432 | `psql -h localhost`                            |
+| Redis                  | 6379 | `redis-cli -h localhost 6379`                  |
+| Testem                 | 7357 | [http://localhost:7357](http://localhost:7357) |
 
 ### Caching
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ end
 ANSIBLE_VERSION = "2.8.*"
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "bento/ubuntu-14.04"
 
   # Wire up package caching:
   if Vagrant.has_plugin?("vagrant-cachier")

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -106,6 +106,9 @@ Vagrant.configure("2") do |config|
       ansible.galaxy_command = "sudo pip install urllib3[secure]==1.22.* --ignore-installed" \
                                " && ansible-galaxy install --role-file=%{role_file} --roles-path=%{roles_path} --force"
       ansible.groups = ANSIBLE_GROUPS.merge(ANSIBLE_ENV_GROUPS)
+      ansible.extra_vars = {
+        services_ip: ENV.fetch("ICP_SERVICES_IP", "33.33.34.30")
+      }
     end
 
     worker.vm.provision "shell", inline: "service celeryd restart >> /dev/null 2>&1", run: "always"
@@ -158,6 +161,9 @@ Vagrant.configure("2") do |config|
       ansible.galaxy_command = "sudo pip install urllib3[secure]==1.22.* --ignore-installed" \
                                " && ansible-galaxy install --role-file=%{role_file} --roles-path=%{roles_path} --force"
       ansible.groups = ANSIBLE_GROUPS.merge(ANSIBLE_ENV_GROUPS)
+      ansible.extra_vars = {
+        services_ip: ENV.fetch("ICP_SERVICES_IP", "33.33.34.30")
+      }
     end
   end
 end

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,6 +1,6 @@
 - src: azavea.ntp
   version: 0.1.1
-  
+
 - src: azavea.pip
   version: 2.0.0
 
@@ -65,7 +65,7 @@
   version: 0.6.2
 
 - src: azavea.docker
-  version: 4.0.0
+  version: 5.0.0
 
 - src: azavea.python
   version: 0.1.0


### PR DESCRIPTION
## Overview

As a bit of a brute-force approach to resolving several issues with booting the virtual machines, switch to the Bento variant of a Trusty base box.

In addition:

- Upgrade the Docker Ansible role to properly set the Docker APT repository architecture
- Fix a bug with regarding some assumptions we had about access to the `ICP_SERVICES_IP` environment variable across environments

Connects https://github.com/project-icp/bee-pollinator-app/issues/563

### Demo

A failed build: http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-pull-requests/497/

Followed by two back-to-back successful builds:

- http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-pull-requests/498/
- http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-pull-requests/499/

### Notes

Individual commit messages have a lot of the associated details, but one additional thing to note is that the Jenkins jobs were modified to `halt` the virtual machines after success/failure vs. `destroy`. This was a workaround introduced before to smooth out build failures related to boot issues.

## Testing Instructions

- Destroy the local development environment virtual machines

```console
$ vagrant destroy -f
```

- Bring up and provision the local development environment

```console
$ vagrant up
```

- Halt and then boot up the local development environment virtual machines

```console
$ vagrant halt
$ vagrant up
```