### PR TITLE
Remove links to monthly surveys

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyView.jsx
@@ -1,16 +1,15 @@
 import React from 'react';
-import { arrayOf, bool } from 'prop-types';
+import { arrayOf } from 'prop-types';
 
 import { Apiary } from '../propTypes';
 import {
     getNovemberSurveys,
     getAprilSurveys,
-    getMonthlySurveys,
     sortSurveysByMonthYearDescending,
 } from '../utils';
 import SurveyCard from './SurveyCard';
 
-const SurveyView = ({ apiaries, isProUser }) => {
+const SurveyView = ({ apiaries }) => {
     const surveyedApiaries = [];
     const unsurveyedApiaries = [];
 
@@ -30,14 +29,8 @@ const SurveyView = ({ apiaries, isProUser }) => {
     const incompleteSurveyCards = [];
 
     surveyedApiaries.forEach((apiary) => {
-        const monthlySurveys = isProUser
-            ? getMonthlySurveys(apiary)
-            : [];
-        const surveys = monthlySurveys.concat(
-            getNovemberSurveys(apiary),
-            getAprilSurveys(apiary),
-        ).sort(sortSurveysByMonthYearDescending);
-
+        const surveys = [...getNovemberSurveys(apiary), ...getAprilSurveys(apiary)]
+            .sort(sortSurveysByMonthYearDescending);
         const surveyCard = (
             <SurveyCard
                 apiary={apiary}
@@ -94,7 +87,6 @@ const SurveyView = ({ apiaries, isProUser }) => {
 
 SurveyView.propTypes = {
     apiaries: arrayOf(Apiary).isRequired,
-    isProUser: bool.isRequired,
 };
 
 export default SurveyView;


### PR DESCRIPTION
#Overview

Removed links to monthly surveys from the incompleted surveys list.
The overall survey functionality is untouched to allow for the potential
of using this functionality again in the future.

Connects #561

### Demo

<img width="715" alt="Screen Shot 2020-02-14 at 11 58 09 AM" src="https://user-images.githubusercontent.com/21046714/74552255-cfae2400-4f22-11ea-8cd5-121ec8e27d07.png">

## Testing Instructions

- Check out this branch
- Run ./scripts/beekeepers.sh start
- Add some Apiaries
- Login as a pro user
- Navigate to 'survey'
- Ensure you see only November and April surveys, and no monthly surveys