### PR TITLE
No spring survey without a fall survey

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
@@ -28,6 +28,7 @@ class AprilSurveyForm extends Component {
             notes: '',
             completedSurvey: '',
             error: '',
+            missingNovemberSurvey: false,
         };
         this.multipleChoiceKeys = ['colony_loss_reason'];
         this.handleChange = this.handleChange.bind(this);
@@ -37,12 +38,21 @@ class AprilSurveyForm extends Component {
 
     componentDidMount() {
         const {
+            apiary: { surveys },
             survey: {
                 apiary,
                 id,
                 completed,
+                month_year,
             },
         } = this.props;
+        const previous_year = parseInt(month_year.slice(-4), 10) - 1;
+        if (!surveys.some(pastSurvey => pastSurvey.month_year === `11${previous_year}`)) {
+            this.setState({
+                error: `Please complete the November survey for ${previous_year} first.`,
+                missingNovemberSurvey: true,
+            });
+        }
         if (completed) {
             getOrCreateSurveyRequest({
                 apiary,
@@ -182,6 +192,7 @@ class AprilSurveyForm extends Component {
             notes,
             completedSurvey,
             error,
+            missingNovemberSurvey,
         } = this.state;
 
         const {
@@ -234,7 +245,7 @@ class AprilSurveyForm extends Component {
 
         const colonyLossReasonCheckboxInputs = this.makeMultipleChoiceInputs('colony_loss_reason', SPRING_COLONY_LOSS_REASONS);
 
-        const surveyForm = (
+        const surveyForm = missingNovemberSurvey ? null : (
             <>
                 <div className="title">{title}</div>
                 <form className="form" onSubmit={this.handleSubmit}>


### PR DESCRIPTION
## Overview

Prevents users from entering a spring survey if no survey from the
previous fall exists for the apiary. If the user incorrectly begins a
a spring survey, they are prompted to complete a fall survey first,
and the survey does not render, thereby preventing them from completing
the survey.

Connects #558 

### Demo

![image](https://user-images.githubusercontent.com/21046714/74663627-20638e00-516a-11ea-9f44-8ec399325f67.png)

## Testing Instructions

- Check out this branch
- Run ./scripts/beekeepers.sh start
- Add an Apiary
- Attempt to enter the Spring 2019 survey for the apiary. You should see an error message instead of the survey.
- Complete the Fall 2018 survey.
- You should now be able to complete the Spring 2019 survey for the apiary successfully.
