### PR TITLE
Fix Python libc segfault tied to psycopg2 installation

### DIFF
--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -20,7 +20,7 @@ postgresql_version: "9.6"
 postgresql_package_version: "9.6.*.pgdg14.04+1"
 postgresql_support_repository_channel: "main"
 postgresql_support_libpq_version: "11.*.pgdg14.04+1"
-postgresql_support_psycopg2_version: "2.7"
+postgresql_support_psycopg2_version: "2.8.4"
 postgis_version: "2.3"
 postgis_package_version: "2.3.*.pgdg14.04+1"
 


### PR DESCRIPTION
## Overview

Something about the wheel for `psycopg2==2.7.x` loads external operating system libraries in a way that is incompatible with the versions of those libraries provided on Trusty. To avoid any issues with bundled wheel binaries, the most recent non `psycopg2-binary` package is being installed.

Seems related to https://github.com/psycopg/psycopg2-wheels/issues/2.

No reference to `psycopg2` is made in `requirements.txt` because the application expects `psycopg2` to already be there (via Ansible and the `postgresql-support` role).

### Notes

I built an AMI using this branch and deployed it to staging:

- http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-app-and-worker/179/
- http://civicci01.internal.azavea.com/view/bees/job/bee-pollinator-staging-deployment/175/

## Testing Instructions

- Ensure that the `/health-check` endpoint works on staging

```console
curl -s https://staging.app.pollinationmapper.org/health-check/ | python3 -mjson.tool
{
    "databases": [
        {
            "default": {
                "ok": true
            }
        }
    ],
    "caches": [
        {
            "default": {
                "ok": true
            }
        }
    ]
}
```

- Ensure that `migrate` completes successfully

```console
./scripts/manage.sh migrate
+ ARGS=migrate
+ [[ 1 -eq 1 ]]
+ [[ migrate == runserver ]]
+ vagrant ssh app -c 'cd /opt/app && envdir /etc/icp.d/env ./manage.py migrate'
Operations to perform:
  Synchronize unmigrated apps: gis, webpack_loader, staticfiles, geocode, messages, humanize, rest_framework
  Apply all migrations: core, sessions, admin, auth, contenttypes, user, registration, modeling, beekeepers
Synchronizing apps without migrations:
  Creating tables...
    Running deferred SQL...
  Installing custom SQL...
Running migrations:
  Rendering model states... DONE
  Applying contenttypes.0001_initial... OK
  Applying auth.0001_initial... OK

. . .
```