### PR TITLE
Edit colony questions in April Survey

### DIFF
--- a/src/icp/apps/beekeepers/migrations/0017_aprilsurvey_num_new_colonies.py
+++ b/src/icp/apps/beekeepers/migrations/0017_aprilsurvey_num_new_colonies.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('beekeepers', '0016_add_notes_to_surveys'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='aprilsurvey',
+            name='num_new_colonies',
+            field=models.IntegerField(default=0, help_text='Number of new colonies in this survey', null=True),
+        ),
+    ]

--- a/src/icp/apps/beekeepers/models.py
+++ b/src/icp/apps/beekeepers/models.py
@@ -108,23 +108,28 @@ class AprilSurvey(models.Model):
     """
     A short survey taken in April by all users.
 
-    Has only one question:
+    Has two questions:
       - What do you think the most likely cause of colony loss was?
 
-    The answers can be:
-      - varroa mites
-      - inadequate food stores
-      - poor queens
-      - poor weather conditions
-      - colony too small in November
-      - pesticide exposure
-      - bear or natural disaster
-      - other (fillable field)
+        The answers can be:
+          - varroa mites
+          - inadequate food stores
+          - poor queens
+          - poor weather conditions
+          - colony too small in November
+          - pesticide exposure
+          - bear or natural disaster
+          - other (fillable field)
 
-    Multiple selections are possible, and will be separated by a semicolon.
-    Answers to "other" will be prefixed with OTHER- to indicate so. E.g.
+        Multiple selections are possible, and will be separated by a semicolon.
+        Answers to "other" will be prefixed with OTHER- to indicate so. E.g.
 
-    "VARROA_MITES;INADEQUATE_FOOD_STORES;OTHER-negligence"
+        "VARROA_MITES;INADEQUATE_FOOD_STORES;OTHER-negligence"
+
+      - How many new colonies did you add over the winter, since the November
+        survey?
+
+        The answer can be any positive integer, and defaults to 0.
     """
 
     survey = models.OneToOneField(
@@ -138,6 +143,10 @@ class AprilSurvey(models.Model):
         null=True,
         blank=True,
         help_text='Miscellaneous comments')
+    num_new_colonies = models.IntegerField(
+        null=True,
+        default=0,
+        help_text='Number of new colonies in this survey')
 
     def __unicode__(self):
         return unicode('{}:{}:{}'.format(

--- a/src/icp/apps/beekeepers/views.py
+++ b/src/icp/apps/beekeepers/views.py
@@ -134,7 +134,8 @@ def create_survey(request, apiary_id=None):
             "num_colonies": 3,
             "survey_type": "APRIL", // or "NOVEMBER" or "MONTHLY"
             "april": {              // Must be specified for "APRIL" surveys
-                "colony_loss_reason": ""
+                "colony_loss_reason": "",
+                "num_new_colonies": 1
             },
             "november" : {          // Must be specified for "NOVEMBER" surveys
                 ...


### PR DESCRIPTION
## Overview

Adds a line that displays the number of colonies (`num_colonies`) the
user centered for that apiary in the November survey.

Adds a max value to the remaining colonies (`num_colonies`) field which
limits it to number of colonies entered in the November survey.

Adds the question - “How many new colonies did you add to this apiary
over the winter?” with a default answer of 0. This required the
addition of a field to the AprilSurvey model, `num_new_colonies`.
Existing April Surveys will have this new field marked `null`.

In the database, `num_colonies` represents the total number of colonies.
Therefore the data stored to this field is equal to the remaining
colonies plus the new colonies.

Connects #559 

### Demo

<img width="595" alt="Screen Shot 2020-02-18 at 1 01 25 PM" src="https://user-images.githubusercontent.com/21046714/74764072-0059ca80-524f-11ea-86f6-d3edc94afd46.png">
<img width="600" alt="Screen Shot 2020-02-18 at 1 01 35 PM" src="https://user-images.githubusercontent.com/21046714/74764094-09e33280-524f-11ea-9453-216d6f856e83.png">

## Testing Instructions

* Check out this branch
* Run migrations
* Run ./scripts/beekeepers.sh start
* Add some Apiaries
* Fill in the November 2018 survey for an apiary, then open that apiary's Spring 2019 survey. 
* You should see the number that you entered from the November survey ('You had XX colonies in November').
* Enter a number of remaining colonies higher than the November survey's num_colonies, then try to submit. You should get an error and be unable to submit.
* Enter a number of remaining colonies equal to or lower than the November survey's num_colonies.
* You should see the number 0 in the field 'How many new colonies...'. Enter a new number and submit.
* When you open the April 2019 survey after saving, you should see the numbers you entered under 'remaining colonies' and 'new colonies'.