### PR TITLE
Map correctly centers after zoom

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/Map.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/Map.jsx
@@ -184,6 +184,8 @@ class Map extends Component {
     onMapZoom(event) {
         const { dispatch } = this.props;
         const zoom = event.target.getZoom();
+        const center = event.target.getCenter();
+        dispatch(setMapCenter([center.lat, center.lng]));
         dispatch(setMapZoom(zoom));
     }
 


### PR DESCRIPTION
#Overview

Previously, we were not updating the map's center when zooming. This
resulted in the map panning to the previous center after trackpad
zooms, which are intended to re-center the map at the point where the
user's cursor is when beginning the zoom. We are now correctly updating
the map's center to equal the zoom location after a zoom action ends.

Connects #555 

### Demo

![mapZoom](https://user-images.githubusercontent.com/21046714/74849453-b6ccb680-5306-11ea-9809-46cd5372e027.gif)

## Testing Instructions

* Check out this branch
* Run ./scripts/beekeepers.sh start
* Zoom in and out using trackpad. Map should remain centered on the point where you zoomed in. Map should not pan after zoom.
