### PR TITLE
Allow users to update November and April surveys

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
@@ -6,8 +6,10 @@ import { fetchUserApiaries, flashSuccessModal } from '../actions';
 import { SURVEY_TYPE_APRIL, SPRING_COLONY_LOSS_REASONS } from '../constants';
 import {
     arrayToSemicolonDelimitedString,
-    getOrCreateSurveyRequest,
+    createSurveyRequest,
+    getSurveyRequest,
     toMonthNameYear,
+    updateSurveyRequest,
 } from '../utils';
 import { Apiary, Survey } from '../propTypes';
 
@@ -59,7 +61,7 @@ class AprilSurveyForm extends Component {
             this.setState({ novemberSurvey });
         }
         if (completed) {
-            getOrCreateSurveyRequest({
+            getSurveyRequest({
                 apiary,
                 id,
             }).then(({ data }) => {
@@ -78,13 +80,14 @@ class AprilSurveyForm extends Component {
                         const keys = data.april[key].split(';')
                             .map(s => `${key}_${s}`);
                         newState = keys.reduce((acc, k) => {
-                            acc[k] = true;
                             // Other text input requires special handling
                             // to parse key name and capture value
                             if (k.includes('_OTHER-')) {
                                 const otherKey = k.split('-')[0];
                                 const otherValue = k.split('_OTHER-')[1];
                                 acc[otherKey] = otherValue;
+                            } else {
+                                acc[k] = true;
                             }
                             return acc;
                         }, newState);
@@ -120,15 +123,15 @@ class AprilSurveyForm extends Component {
             survey: {
                 apiary,
                 month_year,
+                id,
             },
-            dispatch,
-            close,
         } = this.props;
 
         const {
             num_colonies,
             num_new_colonies,
             notes,
+            completedSurvey,
         } = this.state;
 
         const multipleChoiceState = {};
@@ -159,19 +162,26 @@ class AprilSurveyForm extends Component {
             april: { ...multipleChoiceState, notes, num_new_colonies },
         };
 
-        getOrCreateSurveyRequest({ apiary, form })
-            .then(() => {
-                dispatch(fetchUserApiaries());
-                close();
-                dispatch(flashSuccessModal());
-            })
-            .catch(error => this.setState({ error: error.response.statusText }));
+        if (completedSurvey) {
+            updateSurveyRequest({ apiary, id, form })
+                .then(() => this.handleSuccess())
+                .catch(error => this.setState({ error: error.response.statusText }));
+        } else {
+            createSurveyRequest({ apiary, form })
+                .then(() => this.handleSuccess())
+                .catch(error => this.setState({ error: error.response.statusText }));
+        }
+    }
+
+    handleSuccess() {
+        const { dispatch, close } = this.props;
+        dispatch(fetchUserApiaries());
+        close();
+        dispatch(flashSuccessModal());
     }
 
     /* eslint-disable react/destructuring-assignment */
     makeMultipleChoiceInputs(groupName, options) {
-        const { completedSurvey } = this.state;
-
         return options.map((option) => {
             const key = `${groupName}_${option}`;
             const label = option.split('_').join(' ').toLowerCase();
@@ -185,9 +195,8 @@ class AprilSurveyForm extends Component {
                         className="form__control"
                         id={key}
                         name={key}
-                        checked={this.state[key]}
+                        checked={this.state[key] || false}
                         onChange={this.handleChange}
-                        disabled={!!completedSurvey}
                     />
                     <label htmlFor={key}>{label}</label>
                 </div>
@@ -219,42 +228,38 @@ class AprilSurveyForm extends Component {
             </div>
         ) : null;
 
-        const submitButton = completedSurvey ? null
-            : (
-                <button
-                    type="submit"
-                    value="Submit"
-                    className="button--long"
-                >
-                    Submit
-                </button>
-            );
+        const submitButton = (
+            <button
+                type="submit"
+                value="Submit"
+                className="button--long"
+            >
+                Submit
+            </button>
+        );
 
         const title = completedSurvey
             ? `Survey results for ${toMonthNameYear(month_year)}`
             : `Survey for ${toMonthNameYear(month_year)}`;
 
-        const confirmationButton = completedSurvey
-            ? null
-            : (
-                <div className="form__group">
-                    <label htmlFor="confirmation">
-                        Have you provided all the information available for these
-                        colonies and are ready to submit the survey? Surveys cannot
-                        be edited after submission.
-                    </label>
-                    <input
-                        type="checkbox"
-                        className="form__control"
-                        id="confirmed"
-                        name="confirmed"
-                        required
-                    />
-                    <label htmlFor="confirmation">
-                        Yes
-                    </label>
-                </div>
-            );
+        const confirmationButton = (
+            <div className="form__group">
+                <label htmlFor="confirmation">
+                    Have you provided all the information available for these
+                    colonies and are ready to submit the survey?
+                </label>
+                <input
+                    type="checkbox"
+                    className="form__control"
+                    id="confirmed"
+                    name="confirmed"
+                    required
+                />
+                <label htmlFor="confirmation">
+                    Yes
+                </label>
+            </div>
+        );
 
         const colonyLossReasonCheckboxInputs = this.makeMultipleChoiceInputs('colony_loss_reason', SPRING_COLONY_LOSS_REASONS);
 
@@ -273,7 +278,6 @@ class AprilSurveyForm extends Component {
                             name="num_colonies"
                             onChange={this.handleChange}
                             value={num_colonies}
-                            disabled={!!completedSurvey}
                             required
                             min={0}
                             max={novemberSurvey.num_colonies}
@@ -290,7 +294,6 @@ class AprilSurveyForm extends Component {
                             name="num_new_colonies"
                             onChange={this.handleChange}
                             value={num_new_colonies}
-                            disabled={!!completedSurvey}
                             required
                             min={0}
                         />
@@ -307,7 +310,6 @@ class AprilSurveyForm extends Component {
                             name="colony_loss_reason_OTHER"
                             value={colony_loss_reason_OTHER}
                             onChange={this.handleChange}
-                            disabled={!!completedSurvey}
                         />
                         <div className="form__group">
                             <label htmlFor="notes">
@@ -319,7 +321,6 @@ class AprilSurveyForm extends Component {
                                 rows={2}
                                 value={notes || ''}
                                 onChange={this.handleChange}
-                                disabled={!!completedSurvey}
                             />
                         </div>
                         {confirmationButton}

--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyForm.jsx
@@ -15,7 +15,8 @@ import { SURVEY_TYPE_MONTHLY } from '../constants';
 import { Survey, Apiary } from '../propTypes';
 import {
     arrayToSemicolonDelimitedString,
-    getOrCreateSurveyRequest,
+    getSurveyRequest,
+    createSurveyRequest,
     toMonthNameYear,
 } from '../utils';
 
@@ -133,7 +134,7 @@ class MonthlySurveyForm extends Component {
 
         // Fetch and show data from the database for a completed survey
         if (id) {
-            getOrCreateSurveyRequest({ apiary, id })
+            getSurveyRequest({ apiary, id })
                 .then(({ data }) => {
                     const monthlies = data.monthlies.map((serverData, idx) => {
                         let clientData = prevMonthlies[idx];
@@ -174,7 +175,7 @@ class MonthlySurveyForm extends Component {
         // For a new survey, autofill select fields with most recent and complete survey data
         // Else, show a blank survey
         if (lastMonthlySurvey && !id) {
-            getOrCreateSurveyRequest({
+            getSurveyRequest({
                 apiary: lastMonthlySurvey.apiary,
                 id: lastMonthlySurvey.id,
             }).then(({ data }) => {
@@ -340,7 +341,7 @@ class MonthlySurveyForm extends Component {
             monthlies,
         };
 
-        getOrCreateSurveyRequest({ apiary, form })
+        createSurveyRequest({ apiary, form })
             .then(() => {
                 dispatch(fetchUserApiaries());
                 close();

--- a/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
@@ -16,7 +16,9 @@ import {
 } from '../constants';
 import {
     arrayToSemicolonDelimitedString,
-    getOrCreateSurveyRequest,
+    getSurveyRequest,
+    createSurveyRequest,
+    updateSurveyRequest,
     toMonthNameYear,
 } from '../utils';
 import { Apiary, Survey } from '../propTypes';
@@ -97,7 +99,7 @@ class NovemberSurveyForm extends Component {
             },
         } = this.props;
         if (completed) {
-            getOrCreateSurveyRequest({
+            getSurveyRequest({
                 apiary,
                 id,
             }).then(({ data }) => {
@@ -116,13 +118,14 @@ class NovemberSurveyForm extends Component {
                         const keys = data.november[key].split(';')
                             .map(s => `${key}_${s}`);
                         newState = keys.reduce((acc, k) => {
-                            acc[k] = true;
                             // Other text input requires special handling
                             // to parse key name and capture value
                             if (k.includes('_OTHER-')) {
                                 const otherKey = k.split('-')[0];
                                 const otherValue = k.split('_OTHER-')[1];
                                 acc[otherKey] = otherValue;
+                            } else {
+                                acc[k] = true;
                             }
                             return acc;
                         }, newState);
@@ -178,13 +181,13 @@ class NovemberSurveyForm extends Component {
             survey: {
                 apiary,
                 month_year,
+                id,
             },
-            dispatch,
-            close,
         } = this.props;
 
         const {
             num_colonies,
+            completedSurvey,
         } = this.state;
 
         const multipleChoiceState = {};
@@ -217,19 +220,26 @@ class NovemberSurveyForm extends Component {
             november,
         };
 
-        getOrCreateSurveyRequest({ apiary, form })
-            .then(() => {
-                dispatch(fetchUserApiaries());
-                close();
-                dispatch(flashSuccessModal());
-            })
-            .catch(error => this.setState({ error: error.response.statusText }));
+        if (completedSurvey) {
+            updateSurveyRequest({ apiary, id, form })
+                .then(() => this.handleSuccess())
+                .catch(error => this.setState({ error: error.response.statusText }));
+        } else {
+            createSurveyRequest({ apiary, form })
+                .then(() => this.handleSuccess())
+                .catch(error => this.setState({ error: error.response.statusText }));
+        }
+    }
+
+    handleSuccess() {
+        const { dispatch, close } = this.props;
+        dispatch(fetchUserApiaries());
+        close();
+        dispatch(flashSuccessModal());
     }
 
     /* eslint-disable react/destructuring-assignment */
     makeMultipleChoiceInputs(groupName, options, tooltipDescriptions) {
-        const { completedSurvey } = this.state;
-
         return options.map((option, index) => {
             const key = `${groupName}_${option}`;
             const label = option.split('_').join(' ').toLowerCase();
@@ -248,7 +258,6 @@ class NovemberSurveyForm extends Component {
                         name={key}
                         checked={this.state[key]}
                         onChange={this.handleChange}
-                        disabled={!!completedSurvey}
                     />
                     <label htmlFor={key}>
                         {label}
@@ -260,8 +269,6 @@ class NovemberSurveyForm extends Component {
     }
 
     makeSeasonalInputs(groupName) {
-        const { completedSurvey } = this.state;
-
         return SEASONS.map((option) => {
             const key = `${groupName}_${option}`;
             const label = option.split('_').join(' ').toLowerCase();
@@ -277,7 +284,6 @@ class NovemberSurveyForm extends Component {
                         name={key}
                         checked={this.state[key]}
                         onChange={this.handleChange}
-                        disabled={!!completedSurvey}
                     />
                     <label htmlFor={key}>{label}</label>
                 </div>
@@ -312,42 +318,38 @@ class NovemberSurveyForm extends Component {
             </div>
         ) : null;
 
-        const submitButton = completedSurvey ? null
-            : (
-                <button
-                    type="submit"
-                    value="Submit"
-                    className="button--long"
-                >
-                    Submit
-                </button>
-            );
+        const submitButton = (
+            <button
+                type="submit"
+                value="Submit"
+                className="button--long"
+            >
+                Submit
+            </button>
+        );
 
         const title = completedSurvey
             ? `Survey results for ${toMonthNameYear(month_year)}`
             : `Survey for ${toMonthNameYear(month_year)}`;
 
-        const confirmationButton = completedSurvey
-            ? null
-            : (
-                <div className="form__group">
-                    <label htmlFor="confirmation">
-                        Have you provided all the information available for these
-                        colonies and are ready to submit the survey? Surveys cannot
-                        be edited after submission.
-                    </label>
-                    <input
-                        type="checkbox"
-                        className="form__control"
-                        id="confirmed"
-                        name="confirmed"
-                        required
-                    />
-                    <label htmlFor="confirmation">
-                        Yes
-                    </label>
-                </div>
-            );
+        const confirmationButton = (
+            <div className="form__group">
+                <label htmlFor="confirmation">
+                    Have you provided all the information available for these
+                    colonies and are ready to submit the survey?
+                </label>
+                <input
+                    type="checkbox"
+                    className="form__control"
+                    id="confirmed"
+                    name="confirmed"
+                    required
+                />
+                <label htmlFor="confirmation">
+                    Yes
+                </label>
+            </div>
+        );
 
         const miteManagementCheckboxInputs = this.makeMultipleChoiceInputs(
             'mite_management',
@@ -387,7 +389,6 @@ class NovemberSurveyForm extends Component {
                             name="varroa_check_method_OTHER"
                             value={varroa_check_method_OTHER}
                             onChange={this.handleChange}
-                            disabled={!!completedSurvey}
                         />
                     </div>
                 </div>
@@ -401,7 +402,6 @@ class NovemberSurveyForm extends Component {
                         value={varroa_manage_frequency}
                         onChange={this.handleChange}
                         className="form__control"
-                        disabled={!!completedSurvey}
                     >
                         <option value="NEVER">I did not</option>
                         <option value="ONCE">Once a year</option>
@@ -428,7 +428,6 @@ class NovemberSurveyForm extends Component {
                             name="num_colonies"
                             onChange={this.handleChange}
                             value={num_colonies}
-                            disabled={!!completedSurvey}
                             required
                             min={0}
                         />
@@ -443,7 +442,6 @@ class NovemberSurveyForm extends Component {
                                 value={harvested_honey}
                                 onChange={this.handleChange}
                                 className="form__control"
-                                disabled={!!completedSurvey}
                             >
                                 <option value="DID_NOT_HARVEST">Did not harvest</option>
                                 <option value="LESS_THAN_10">Less than 10 lbs</option>
@@ -478,7 +476,6 @@ class NovemberSurveyForm extends Component {
                                 name="small_hive_beetles"
                                 value={small_hive_beetles}
                                 onChange={this.handleChange}
-                                disabled={!!completedSurvey}
                             >
                                 <option key="true" value="true">Yes</option>
                                 <option key="false" value="false">No</option>
@@ -494,7 +491,6 @@ class NovemberSurveyForm extends Component {
                                 value={varroa_check_frequency}
                                 onChange={this.handleChange}
                                 className="form__control"
-                                disabled={!!completedSurvey}
                             >
                                 <option value="NEVER">I did not</option>
                                 <option value="ONCE">Once a year</option>
@@ -519,7 +515,6 @@ class NovemberSurveyForm extends Component {
                                     name="mite_management_OTHER"
                                     value={mite_management_OTHER}
                                     onChange={this.handleChange}
-                                    disabled={!!completedSurvey}
                                 />
                             </div>
                         </div>
@@ -533,7 +528,6 @@ class NovemberSurveyForm extends Component {
                                 name="all_colonies_treated"
                                 value={all_colonies_treated}
                                 onChange={this.handleChange}
-                                disabled={!!completedSurvey}
                             >
                                 <option key="true" value="true">Yes</option>
                                 <option key="false" value="false">No</option>
@@ -549,7 +543,6 @@ class NovemberSurveyForm extends Component {
                                 rows={2}
                                 value={notes || ''}
                                 onChange={this.handleChange}
-                                disabled={!!completedSurvey}
                             />
                         </div>
                         {confirmationButton}

--- a/src/icp/apps/beekeepers/js/src/utils.js
+++ b/src/icp/apps/beekeepers/js/src/utils.js
@@ -278,7 +278,31 @@ export function sortSurveysByMonthYearDescending(a, b) {
 }
 
 /**
- * Given an Apiary ID and, optionally, a Survey ID or form, returns a post or get request
+ * Given an Apiary ID a Survey ID, returns get request
+ *
+ * @param {number} apiary
+ * @param {number} id
+ */
+export function getSurveyRequest({ apiary, id }) {
+    return csrfRequest.get(`/beekeepers/apiary/${apiary}/survey/${id}/`);
+}
+
+/**
+ * Given an Apiary ID and a form, returns a post request
+ *
+ * @param {number} apiary
+ * @param {object} form
+ *      {
+ *          survey: {Survey},
+ *          ...form fields,
+ *      }
+ */
+export function createSurveyRequest({ apiary, form }) {
+    return csrfRequest.post(`/beekeepers/apiary/${apiary}/survey/`, form);
+}
+
+/**
+ * Given an Apiary ID, a Survey ID and a form, returns a put request
  *
  * @param {number} apiary
  * @param {number} id
@@ -288,12 +312,8 @@ export function sortSurveysByMonthYearDescending(a, b) {
  *          ...form fields,
  *      }
  */
-export function getOrCreateSurveyRequest({ apiary, id, form }) {
-    const request = id
-        ? csrfRequest.get(`/beekeepers/apiary/${apiary}/survey/${id}/`)
-        : csrfRequest.post(`/beekeepers/apiary/${apiary}/survey/`, form);
-
-    return request;
+export function updateSurveyRequest({ apiary, id, form }) {
+    return csrfRequest.put(`/beekeepers/apiary/${apiary}/survey/${id}/`, form);
 }
 
 /**

--- a/src/icp/apps/beekeepers/serializers.py
+++ b/src/icp/apps/beekeepers/serializers.py
@@ -86,6 +86,31 @@ class SurveyDetailSerializer(ModelSerializer):
 
         return survey
 
+    @transaction.atomic
+    def update(self, survey, validated_data):
+        survey_type = validated_data['survey_type']
+        field = Survey.SUBSURVEY_FIELDS[survey_type]
+
+        survey.num_colonies = validated_data['num_colonies']
+
+        subdata = validated_data[field]
+        if survey_type == 'APRIL':
+            april = survey.april
+            for key, value in subdata.items():
+                setattr(april, key, value)
+            april.save()
+        elif survey_type == 'NOVEMBER':
+            november = survey.november
+            for key, value in subdata.items():
+                setattr(november, key, value)
+            november.save()
+        # Monthly surveys are not handled here as they are currently disabled.
+        # If they were to be enabled again, we'll have to augment this method
+        # with the ability to update Monthly surveys.
+
+        survey.save()
+        return survey
+
     def validate(self, data):
         """Ensure subsurvey field is specified for the survey type"""
         survey_type = data['survey_type']

--- a/src/icp/apps/beekeepers/urls.py
+++ b/src/icp/apps/beekeepers/urls.py
@@ -21,6 +21,6 @@ urlpatterns = patterns(
     url(r'^apiary/(?P<apiary_id>[0-9]+)/survey/$',
         views.create_survey, name='survey-create'),
     url(r'^apiary/(?P<apiary_id>[0-9]+)/survey/(?P<survey_id>[0-9]+)/$',
-        views.get_survey, name='survey-get'),
+        views.get_or_update_survey, name='survey-get-or-update'),
     url(r'^', include(router.urls)),
 )

--- a/src/icp/apps/beekeepers/views.py
+++ b/src/icp/apps/beekeepers/views.py
@@ -160,16 +160,23 @@ def create_survey(request, apiary_id=None):
         return Response(serializer.data, status=201)
 
 
-@decorators.api_view(['GET'])
+@decorators.api_view(['GET', 'PUT'])
 @decorators.permission_classes((IsAuthenticated, ))
-def get_survey(request, apiary_id=None, survey_id=None):
-    """Retrieve a survey and its subsurvey."""
+def get_or_update_survey(request, apiary_id=None, survey_id=None):
+    """Retrieve or update a survey and its subsurvey."""
     survey = get_object_or_404(Survey,
                                apiary=apiary_id,
                                id=survey_id)
-    serializer = SurveyDetailSerializer(survey)
 
-    return Response(serializer.data)
+    if (request.method == 'GET'):
+        serializer = SurveyDetailSerializer(survey)
+    else:
+        data = request.data
+        serializer = SurveyDetailSerializer(survey, data=data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+    return Response(serializer.data, status=200)
 
 
 class UserSurveyViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Overview

Users are now able to edit their submitted November and April surveys.
The Survey Serializer and the RestAPI endpoints have been altered to
allow the update of surveys and sub-surveys.

The utility function getOrCreateSurvey has been split into multiple
functions (getSurvey, createSurvey, updateSurvey) to allow for the
addition of the new Survey Update functionality while maintaining
consistency in format.

The November and April Survey form fields are no longer disabled when
opening the forms for review, as users should now be able to update
them when reopening.

Parsing of multiple-choice keys has been changed slightly to handle a
bug that appeared while updating the 'Other' field.

The Monthly Survey has not been updated with edit functionality, as
Monthly Surveys are not currently in use.

Connects #557 

### Notes

The April and November survey forms have a great deal of repeated code which is extended by this commit, but a refactor is out of scope for this card. 

The update functionality has NOT been applied to monthly surveys on either the app or server.

Instead of adding an edit button to the Survey List items, we've made the default review page for surveys editable, because users clicking on the main list item instead of the edit button by accident might see the disabled form fields and think editing was broken; as well, it decreased code complexity slightly.

## Testing Instructions

* Check out this branch
* Run ./scripts/beekeepers.sh start
* Create an Apiary and submit a November and April survey for it
*  Open the November survey and edit all fields. Submit, then reopen the survey and confirm all data has been edited.
* Open the April survey and edit all fields. Submit, then reopen the survey and confirm all data has been edited. 
* Pay special attention to the "other" field while editing and confirm that it's updated correctly.
