### PR TITLE
Fixes survey modals closing unexpectedly

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/AprilSurveyForm.jsx
@@ -211,6 +211,7 @@ class AprilSurveyForm extends Component {
         const {
             apiary: { name },
             survey: { month_year },
+            close,
         } = this.props;
 
         const userMessage = error.length ? (
@@ -333,6 +334,9 @@ class AprilSurveyForm extends Component {
             <div className="authModal">
                 <div className="authModal__header">
                     <div>{name}</div>
+                    <button type="button" className="button" onClick={close} aria-label="Close dialog">
+                        &times;
+                    </button>
                 </div>
                 <div className="authModal__content">
                     {userMessage}

--- a/src/icp/apps/beekeepers/js/src/components/MonthlySurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/MonthlySurveyForm.jsx
@@ -360,6 +360,7 @@ class MonthlySurveyForm extends Component {
         const {
             apiary: { name },
             survey: { month_year, completed },
+            close,
         } = this.props;
 
         const userMessage = error.length ? (
@@ -460,6 +461,9 @@ class MonthlySurveyForm extends Component {
             <div className="authModal">
                 <div className="authModal__header">
                     <div>{name}</div>
+                    <button type="button" className="button" onClick={close} aria-label="Close dialog">
+                        &times;
+                    </button>
                 </div>
                 <div className="authModal__content">
                     {userMessage}

--- a/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/NovemberSurveyForm.jsx
@@ -304,6 +304,7 @@ class NovemberSurveyForm extends Component {
         const {
             apiary: { name },
             survey: { month_year },
+            close,
         } = this.props;
 
         const userMessage = error.length ? (
@@ -563,6 +564,9 @@ class NovemberSurveyForm extends Component {
             <div className="authModal">
                 <div className="authModal__header">
                     <div>{name}</div>
+                    <button type="button" className="button" onClick={close} aria-label="Close dialog">
+                        &times;
+                    </button>
                 </div>
                 <div className="authModal__content">
                     {userMessage}

--- a/src/icp/apps/beekeepers/js/src/components/SurveyCardListing.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/SurveyCardListing.jsx
@@ -65,6 +65,7 @@ const SurveyCardListing = ({
                 )}
                 className="modal surveyModal"
                 modal
+                closeOnDocumentClick={false}
             >
                 {formComponent}
             </Popup>


### PR DESCRIPTION
## Overview

Users were losing data while completing surveys, when the survey modals
would close due to the user clicking outside the modal.

The survey modals now don't close when the user clicks outside the
modal, and must instead be closed by submitting or clicking the 'x'
button.

Connects #535

### Demo

<img width="602" alt="Screen Shot 2020-02-21 at 9 47 10 AM" src="https://user-images.githubusercontent.com/21046714/75044156-27064400-548f-11ea-824a-797d992e1b3b.png">

### Notes

This change was also applied to the monthly survey form because the monthly survey is also impacted by the change to the Popup component that prevents closing by clicking outside the box; however, the monthly surveys are currently inaccessible for testing as they aren't being used. The applicable code and functionality are identical to the November and April forms, however, so there shouldn't be any future issues.

## Testing Instructions

* Check out this branch
* Run ./scripts/beekeepers.sh start
* Enter a November survey.
* Attempt to close by clicking outside the modal; it should not close.
* Attempt to close by clicking the 'x' button; it should close.
* Reopen, and attempt to close by submitting; it should close.
* Enter an April survey.
* Attempt to close by clicking outside the modal; it should not close.
* Attempt to close by clicking the 'x' button; it should close.
* Reopen, and attempt to close by submitting; it should close.