### PR TITLE
Remove bee hotel survey link

### DIFF
--- a/src/icp/apps/beekeepers/js/src/components/GuestSurveyView.jsx
+++ b/src/icp/apps/beekeepers/js/src/components/GuestSurveyView.jsx
@@ -15,16 +15,7 @@ const GuestSurveyView = ({ dispatch }) => (
                 Our goal is to give beekeepers, gardeners, and growers detailed information about
                 the quality of their landscapes for bees, and site-specific recommendations for
                 land and bee management practices. But, to do this, we need your help, so we can
-                have data from many diverse landscapes! If you have a wild bee hotel and would like
-                to participate in our study,&nbsp;
-                <a
-                    href="http://beescape.org/wild-bees/"
-                    target="_blank"
-                    rel="noreferrer noopener"
-                >
-                    please click here
-                </a>
-                . If you are a beekeeper, please follow the link below.
+                have data from many diverse landscapes!
             </div>
             <button
                 type="button"


### PR DESCRIPTION
## Overview

Clicking the "Participate in Study" button opened a modal that included
a link to information about wild bee hotels. That study is ending.
We have removed the sentence and link "If you have a wild bee hotel and
would like to participate in our study, please click here".

Connects #580 

### Demo

<img width="571" alt="Screen Shot 2020-03-16 at 9 52 31 AM" src="https://user-images.githubusercontent.com/21046714/76764827-e509ae80-676b-11ea-82ee-7404f869158e.png">

## Testing Instructions

 * Check out this branch
* Run ./scripts/beekeepers.sh start
* Make sure you're logged out
* Navigate to 'Survey'
* You should not see the sentence "If you have a wild bee hotel and
would like to participate in our study, please click here"
