### PR TITLE
Update insecticide reference ranges

### DIFF
--- a/src/icp/apps/beekeepers/js/src/constants.js
+++ b/src/icp/apps/beekeepers/js/src/constants.js
@@ -26,7 +26,7 @@ export const INDICATOR_DETAILS = {
         name: 'Insecticide load',
         scoreLabels: ['Insecticide'],
         shortLabel: 'Insecticide',
-        scoreStops: [0, 13, 26, 37, 208],
+        scoreStops: [0, 79, 159, 226, 1271],
     },
     floral_spring: {
         name: 'Spring Floral quality',


### PR DESCRIPTION
## Overview

The value ranges for insecticide were recalibrated against a national
data layer. The fence-post values (0, 1000) were chosen to present
arbitrarily low and high values. The middle values of 79 and 226
represent the thresholds for low and high values, with medium
represented between the two.

Connects #589 

### Demo

![image](https://user-images.githubusercontent.com/1014341/82245939-d9746880-9911-11ea-8cee-071ecd7f35f5.png)


### Notes

I had to interpret the values provided in the connected issue into the format required by the application, but this was confirmed with follow up to the client

## Testing Instructions

* Test 3 and 5km values across the CONUS, and verify that the insecticide values are labeled appropriately based on this new scale. High values can be found just south of Yuba City, CA